### PR TITLE
Phase 0: Data models & enum types

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,1 +1,67 @@
-"""Frozen Pydantic v2 models for all graph nodes and edges."""
+"""Frozen Pydantic v2 models for all graph nodes and edges.
+
+All models use ConfigDict(frozen=True) for immutability and
+all enums inherit from (str, Enum) for clean serialization.
+"""
+
+from src.models.chain import Chain
+from src.models.collection import Collection
+from src.models.edges import (
+    ActiveDuring,
+    AppearsIn,
+    BasedIn,
+    ParallelOf,
+    StudiedUnder,
+    TransmittedTo,
+)
+from src.models.enums import (
+    ChainClassification,
+    ChainPosition,
+    Gender,
+    HadithGrade,
+    HistoricalEventType,
+    NarratorGeneration,
+    NarratorRole,
+    Sect,
+    SectAffiliation,
+    SourceCorpus,
+    TransmissionMethod,
+    TrustworthinessGrade,
+    VariantType,
+)
+from src.models.grading import Grading
+from src.models.hadith import Hadith
+from src.models.historical import HistoricalEvent, Location
+from src.models.narrator import Narrator
+
+__all__ = [
+    # Enums
+    "ChainClassification",
+    "ChainPosition",
+    "Gender",
+    "HadithGrade",
+    "HistoricalEventType",
+    "NarratorGeneration",
+    "NarratorRole",
+    "Sect",
+    "SectAffiliation",
+    "SourceCorpus",
+    "TransmissionMethod",
+    "TrustworthinessGrade",
+    "VariantType",
+    # Node models
+    "Chain",
+    "Collection",
+    "Grading",
+    "Hadith",
+    "HistoricalEvent",
+    "Location",
+    "Narrator",
+    # Edge models
+    "ActiveDuring",
+    "AppearsIn",
+    "BasedIn",
+    "ParallelOf",
+    "StudiedUnder",
+    "TransmittedTo",
+]

--- a/src/models/chain.py
+++ b/src/models/chain.py
@@ -1,0 +1,48 @@
+"""Chain node model for the isnad graph."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from src.models.enums import ChainClassification
+
+__all__ = ["Chain"]
+
+
+class Chain(BaseModel):
+    """A single chain of transmission (isnad) for a hadith.
+
+    A hadith may have multiple chains; each chain is an ordered sequence
+    of narrators connecting the source (Prophet/Imam) to the compiler.
+    """
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    id: str
+    """Canonical ID with 'chn:' prefix, e.g. 'chn:bukhari-001-001-0'."""
+    hadith_id: str
+    """FK to Hadith.id."""
+    chain_index: int
+    """0-based index for multi-chain hadiths."""
+    full_chain_text_ar: str | None = None
+    """Full Arabic text of the chain."""
+    full_chain_text_en: str | None = None
+    """Full English text of the chain."""
+    chain_length: int
+    """Number of narrators in the chain."""
+    is_complete: bool
+    """Whether the chain has no missing links."""
+    is_elevated: bool = False
+    """Whether this is an ali isnad (short chain)."""
+    classification: ChainClassification
+    """Classification of the chain's continuity."""
+    narrator_ids: list[str] = Field(default_factory=list)
+    """Ordered list of Narrator IDs in this chain."""
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id_prefix(cls, v: str) -> str:
+        if not v.startswith("chn:"):
+            msg = f"Chain id must start with 'chn:', got '{v}'"
+            raise ValueError(msg)
+        return v

--- a/src/models/collection.py
+++ b/src/models/collection.py
@@ -1,0 +1,48 @@
+"""Collection node model for the isnad graph."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from src.models.enums import Sect
+
+__all__ = ["Collection"]
+
+
+class Collection(BaseModel):
+    """A hadith collection (e.g. Sahih al-Bukhari, al-Kafi).
+
+    Represents a compiled book of hadiths with metadata about its
+    compiler, sectarian tradition, and canonical status.
+    """
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    id: str
+    """Canonical ID with 'col:' prefix, e.g. 'col:bukhari'."""
+    name_ar: str
+    """Arabic title of the collection."""
+    name_en: str
+    """English title of the collection."""
+    compiler_name: str | None = None
+    """Human-readable name of the compiler."""
+    compiler_id: str | None = None
+    """FK to Narrator.id, nullable."""
+    compilation_year_ah: int | None = None
+    """Year of compilation in Hijri calendar."""
+    sect: Sect
+    """Sectarian tradition (Sunni or Shia)."""
+    canonical_rank: int | None = None
+    """Canonical rank within its tradition (1 = highest authority)."""
+    total_hadiths: int | None = None
+    """Total number of hadiths in the collection."""
+    book_count: int | None = None
+    """Number of books/chapters in the collection."""
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id_prefix(cls, v: str) -> str:
+        if not v.startswith("col:"):
+            msg = f"Collection id must start with 'col:', got '{v}'"
+            raise ValueError(msg)
+        return v

--- a/src/models/edges.py
+++ b/src/models/edges.py
@@ -1,0 +1,120 @@
+"""Edge/relationship models for the isnad graph.
+
+These are lightweight validation models for edge data serialization,
+not Neo4j relationship objects directly.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from src.models.enums import TransmissionMethod, VariantType
+
+__all__ = [
+    "ActiveDuring",
+    "AppearsIn",
+    "BasedIn",
+    "ParallelOf",
+    "StudiedUnder",
+    "TransmittedTo",
+]
+
+
+class TransmittedTo(BaseModel):
+    """Edge: one narrator transmitted a hadith to another in a chain."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    from_narrator_id: str
+    """ID of the transmitting narrator."""
+    to_narrator_id: str
+    """ID of the receiving narrator."""
+    hadith_id: str
+    """FK to Hadith.id."""
+    chain_id: str
+    """FK to Chain.id."""
+    position_in_chain: int
+    """0-based position of this link in the chain."""
+    transmission_method: TransmissionMethod
+    """Method of transmission (haddathana, an, etc.)."""
+
+
+class AppearsIn(BaseModel):
+    """Edge: a hadith appears in a collection at a specific location."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    hadith_id: str
+    """FK to Hadith.id."""
+    collection_id: str
+    """FK to Collection.id."""
+    book_number: int | None = None
+    """Book number within the collection."""
+    chapter_number: int | None = None
+    """Chapter number within the book."""
+    hadith_number_in_book: int | None = None
+    """Hadith number within the book."""
+
+
+class ParallelOf(BaseModel):
+    """Edge: two hadiths are textual parallels (same or similar matn)."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    hadith_id_a: str
+    """First hadith ID."""
+    hadith_id_b: str
+    """Second hadith ID."""
+    similarity_score: float
+    """Textual similarity score between 0.0 and 1.0."""
+    variant_type: VariantType
+    """Type of textual relationship."""
+    cross_sect: bool
+    """Whether the parallel crosses sectarian boundaries."""
+
+
+class StudiedUnder(BaseModel):
+    """Edge: a narrator studied under (was a student of) another narrator."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    student_id: str
+    """ID of the student narrator."""
+    teacher_id: str
+    """ID of the teacher narrator."""
+    period_ah: str | None = None
+    """Period of study in Hijri years."""
+    location_id: str | None = None
+    """FK to Location.id where the study took place."""
+    source: str | None = None
+    """Bibliographic source documenting this relationship."""
+
+
+class ActiveDuring(BaseModel):
+    """Edge: a narrator was active during a historical event."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    narrator_id: str
+    """FK to Narrator.id."""
+    event_id: str
+    """FK to HistoricalEvent.id."""
+    role: str | None = None
+    """Role the narrator played during the event."""
+    affiliation: str | None = None
+    """Political or theological affiliation during the event."""
+
+
+class BasedIn(BaseModel):
+    """Edge: a narrator was based in a location during a period."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    narrator_id: str
+    """FK to Narrator.id."""
+    location_id: str
+    """FK to Location.id."""
+    period_ah: str | None = None
+    """Period of residence in Hijri years."""
+    role: str | None = None
+    """Role or activity at this location."""

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -1,0 +1,160 @@
+"""Enum types for the isnad-graph data model.
+
+All enums inherit from StrEnum for clean JSON/Parquet serialization.
+"""
+
+from enum import StrEnum
+
+__all__ = [
+    "ChainClassification",
+    "ChainPosition",
+    "Gender",
+    "HadithGrade",
+    "HistoricalEventType",
+    "NarratorGeneration",
+    "NarratorRole",
+    "Sect",
+    "SectAffiliation",
+    "SourceCorpus",
+    "TransmissionMethod",
+    "TrustworthinessGrade",
+    "VariantType",
+]
+
+
+class NarratorGeneration(StrEnum):
+    """Generation classification of a hadith narrator in the transmission chain."""
+
+    SAHABI = "sahabi"
+    TABII = "tabii"
+    TABA_TABII = "taba_tabii"
+    ATBA_TABA_TABIIN = "atba_taba_tabiin"
+    LATER = "later"
+    UNKNOWN = "unknown"
+
+
+class Gender(StrEnum):
+    """Biological gender of a narrator."""
+
+    MALE = "male"
+    FEMALE = "female"
+    UNKNOWN = "unknown"
+
+
+class SectAffiliation(StrEnum):
+    """Sectarian affiliation of a narrator as determined by biographical sources."""
+
+    SUNNI = "sunni"
+    SHIA = "shia"
+    NEUTRAL = "neutral"
+    UNKNOWN = "unknown"
+
+
+class TrustworthinessGrade(StrEnum):
+    """Narrator trustworthiness grade from classical rijal criticism."""
+
+    THIQA = "thiqa"
+    SADUQ = "saduq"
+    MAQBUL = "maqbul"
+    DAIF = "daif"
+    MATRUK = "matruk"
+    KADHDHAB = "kadhdhab"
+    UNKNOWN = "unknown"
+
+
+class HadithGrade(StrEnum):
+    """Overall authenticity grade assigned to a hadith."""
+
+    SAHIH = "sahih"
+    HASAN = "hasan"
+    DAIF = "daif"
+    MAWDU = "mawdu"
+    SAHIH_LI_GHAYRIHI = "sahih_li_ghayrihi"
+    HASAN_LI_GHAYRIHI = "hasan_li_ghayrihi"
+    UNKNOWN = "unknown"
+
+
+class TransmissionMethod(StrEnum):
+    """Method of hadith transmission between narrators."""
+
+    HADDATHANA = "haddathana"
+    AKHBARANA = "akhbarana"
+    SAMITU = "samitu"
+    AN = "an"
+    QALA = "qala"
+    ANBA_ANA = "anba_ana"
+    NAWALANI = "nawalani"
+    KATABA_ILAYYA = "kataba_ilayya"
+    WIJADA = "wijada"
+    OTHER = "other"
+    UNKNOWN = "unknown"
+
+
+class ChainClassification(StrEnum):
+    """Classification of an isnad chain's continuity and reliability."""
+
+    MUTTASIL = "muttasil"
+    MURSAL = "mursal"
+    MUALLAQ = "muallaq"
+    MUNQATI = "munqati"
+    MUDALLAS = "mudallas"
+    MUDTARIB = "mudtarib"
+    UNKNOWN = "unknown"
+
+
+class ChainPosition(StrEnum):
+    """Position of a narrator within a chain of transmission."""
+
+    ORIGINATOR = "originator"
+    FIRST = "first"
+    MIDDLE = "middle"
+    LAST = "last"
+    UNKNOWN = "unknown"
+
+
+class NarratorRole(StrEnum):
+    """Role of a narrator in the hadith transmission ecosystem."""
+
+    ORIGINATOR = "originator"
+    TRANSMITTER = "transmitter"
+    COMPILER = "compiler"
+
+
+class VariantType(StrEnum):
+    """Type of textual relationship between parallel hadiths."""
+
+    VERBATIM = "verbatim"
+    CLOSE_PARAPHRASE = "close_paraphrase"
+    THEMATIC = "thematic"
+    CONTRADICTORY = "contradictory"
+
+
+class HistoricalEventType(StrEnum):
+    """Category of historical event relevant to hadith transmission context."""
+
+    CALIPHATE = "caliphate"
+    FITNA = "fitna"
+    CONQUEST = "conquest"
+    THEOLOGICAL_CONTROVERSY = "theological_controversy"
+    COMPILATION_EFFORT = "compilation_effort"
+    PERSECUTION = "persecution"
+    DYNASTY_TRANSITION = "dynasty_transition"
+
+
+class SourceCorpus(StrEnum):
+    """Identifier for the source corpus from which data was acquired."""
+
+    LK = "lk"
+    SANADSET = "sanadset"
+    THAQALAYN = "thaqalayn"
+    SUNNAH = "sunnah"
+    FAWAZ = "fawaz"
+    OPEN_HADITH = "open_hadith"
+    MUHADDITHAT = "muhaddithat"
+
+
+class Sect(StrEnum):
+    """Islamic sectarian tradition."""
+
+    SUNNI = "sunni"
+    SHIA = "shia"

--- a/src/models/grading.py
+++ b/src/models/grading.py
@@ -1,0 +1,32 @@
+"""Grading node model for the isnad graph."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from src.models.enums import HadithGrade
+
+__all__ = ["Grading"]
+
+
+class Grading(BaseModel):
+    """A scholar's grading of a specific hadith.
+
+    Multiple scholars may grade the same hadith differently based on
+    their methodology school and era.
+    """
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    id: str
+    """Unique identifier for this grading record."""
+    hadith_id: str
+    """FK to Hadith.id."""
+    scholar_name: str
+    """Name of the scholar who issued the grading."""
+    grade: HadithGrade
+    """Authenticity grade assigned by the scholar."""
+    methodology_school: str | None = None
+    """Methodology school, e.g. 'Hanbali', 'Imami'."""
+    era: str | None = None
+    """Era of the grading, e.g. 'classical', 'modern'."""

--- a/src/models/hadith.py
+++ b/src/models/hadith.py
@@ -1,0 +1,48 @@
+"""Hadith node model for the isnad graph."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from src.models.enums import SourceCorpus
+
+__all__ = ["Hadith"]
+
+
+class Hadith(BaseModel):
+    """A single hadith (prophetic tradition) with its matn and metadata.
+
+    The hadith is the atomic unit of the graph: chains, gradings, and
+    collection appearances all reference a specific hadith node.
+    """
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    id: str
+    """Canonical ID with 'hdt:' prefix, e.g. 'hdt:bukhari-001-001'."""
+    matn_ar: str
+    """Arabic body text of the hadith."""
+    matn_en: str | None = None
+    """English translation of the body text."""
+    isnad_raw_ar: str | None = None
+    """Raw Arabic isnad string."""
+    isnad_raw_en: str | None = None
+    """Raw English isnad string."""
+    grade_composite: str | None = None
+    """Consensus or primary grade string."""
+    topic_tags: list[str] = Field(default_factory=list)
+    """Topic tags populated in Phase 4."""
+    source_corpus: SourceCorpus
+    """Source corpus from which this hadith was acquired."""
+    has_shia_parallel: bool = False
+    """Whether a parallel exists in Shia collections."""
+    has_sunni_parallel: bool = False
+    """Whether a parallel exists in Sunni collections."""
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id_prefix(cls, v: str) -> str:
+        if not v.startswith("hdt:"):
+            msg = f"Hadith id must start with 'hdt:', got '{v}'"
+            raise ValueError(msg)
+        return v

--- a/src/models/historical.py
+++ b/src/models/historical.py
@@ -1,0 +1,67 @@
+"""Historical event and location node models for the isnad graph."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.models.enums import HistoricalEventType
+
+__all__ = ["HistoricalEvent", "Location"]
+
+
+class HistoricalEvent(BaseModel):
+    """A historical event relevant to the context of hadith transmission.
+
+    Events provide temporal anchoring for narrator activity and help
+    contextualize the political environment of hadith compilation.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+    id: str
+    """Unique identifier for the event."""
+    name_en: str
+    """English name of the event."""
+    name_ar: str | None = None
+    """Arabic name of the event."""
+    year_start_ah: int
+    """Start year in Hijri calendar."""
+    year_end_ah: int | None = None
+    """End year in Hijri calendar."""
+    year_start_ce: int
+    """Start year in Common Era calendar."""
+    year_end_ce: int | None = None
+    """End year in Common Era calendar."""
+    event_type: HistoricalEventType = Field(alias="type")
+    """Category of the event (serializes as 'type')."""
+    caliphate: str | None = None
+    """Caliphate during which the event occurred."""
+    region: str | None = None
+    """Geographic region of the event."""
+    description: str | None = None
+    """Narrative description of the event."""
+
+
+class Location(BaseModel):
+    """A geographic location relevant to narrator biography or hadith transmission."""
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    id: str
+    """Canonical ID with 'loc:' prefix, e.g. 'loc:medina'."""
+    name_en: str
+    """English name of the location."""
+    name_ar: str | None = None
+    """Arabic name of the location."""
+    region: str | None = None
+    """Broader geographic region."""
+    lat: float | None = None
+    """Latitude coordinate."""
+    lon: float | None = None
+    """Longitude coordinate."""
+    political_entity_period: dict[str, str] | None = None
+    """Mapping of date ranges to political entities, e.g. {'622-661': 'Rashidun'}."""

--- a/src/models/narrator.py
+++ b/src/models/narrator.py
@@ -1,0 +1,67 @@
+"""Narrator node model for the isnad graph."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from src.models.enums import Gender, NarratorGeneration, SectAffiliation, TrustworthinessGrade
+
+__all__ = ["Narrator"]
+
+
+class Narrator(BaseModel):
+    """A hadith narrator (rawi) in the isnad graph.
+
+    Represents a historical person who participated in the transmission
+    of prophetic traditions, with biographical metadata and graph metrics.
+    """
+
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True)
+
+    id: str
+    """Canonical ID with 'nar:' prefix, e.g. 'nar:abu-hurayra-001'."""
+    name_ar: str
+    """Full Arabic name."""
+    name_en: str
+    """Full English transliteration."""
+    kunya: str | None = None
+    """Patronymic, e.g. 'Abu Hurayra'."""
+    nisba: str | None = None
+    """Geographic or tribal attribution, e.g. 'al-Dawsi'."""
+    laqab: str | None = None
+    """Honorific or epithet."""
+    birth_year_ah: int | None = None
+    """Birth year in Hijri calendar."""
+    death_year_ah: int | None = None
+    """Death year in Hijri calendar."""
+    birth_location_id: str | None = None
+    """FK to Location.id."""
+    death_location_id: str | None = None
+    """FK to Location.id."""
+    generation: NarratorGeneration
+    """Generation in the transmission chain (sahabi, tabii, etc.)."""
+    gender: Gender
+    """Biological gender."""
+    sect_affiliation: SectAffiliation
+    """Sectarian affiliation per biographical sources."""
+    tabaqat_class: str | None = None
+    """Layer/class in tabaqat literature."""
+    trustworthiness_consensus: TrustworthinessGrade
+    """Consensus trustworthiness grade from rijal criticism."""
+    aliases: list[str] = Field(default_factory=list)
+    """Alternate name forms for this narrator."""
+
+    # Graph metrics (populated in Phase 4, nullable until then)
+    betweenness_centrality: float | None = None
+    in_degree: int | None = None
+    out_degree: int | None = None
+    pagerank: float | None = None
+    community_id: int | None = None
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id_prefix(cls, v: str) -> str:
+        if not v.startswith("nar:"):
+            msg = f"Narrator id must start with 'nar:', got '{v}'"
+            raise ValueError(msg)
+        return v


### PR DESCRIPTION
## Summary
- Implement 13 enum types as StrEnum for clean JSON/Parquet serialization
- Implement 6 node models (Narrator, Hadith, Collection, Chain, Grading, HistoricalEvent/Location) with `ConfigDict(frozen=True)`
- Implement 6 edge models (TransmittedTo, AppearsIn, ParallelOf, StudiedUnder, ActiveDuring, BasedIn)
- Field validators on id fields enforcing `nar:`, `hdt:`, `col:`, `chn:` prefixes
- HistoricalEvent.event_type with `Field(alias="type")` and `populate_by_name=True`
- Explicit `__all__` lists and named imports throughout (no wildcards)
- Passes `ruff check` and `mypy --strict`

## Related Issues
Closes #7

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Amara Diallo <parametrization+Amara.Diallo@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>