### PR TITLE
Phase 2: Resolve module setup + ML deps + schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ acquire: ## Phase 1: Download all data sources
 parse: ## Phase 1: Parse raw data into staging Parquet files
 	uv run isnad parse
 
-resolve: ## Phase 2: Entity resolution
-	@echo "Phase 2 not yet implemented"
+resolve: ## Phase 2: Entity resolution (NER + disambiguation + dedup)
+	uv run isnad resolve
 
 load: ## Phase 3: Load graph database
 	@echo "Phase 3 not yet implemented"

--- a/src/cli.py
+++ b/src/cli.py
@@ -83,6 +83,23 @@ def _cmd_parse() -> None:
     print(f"Parsing complete. {total_files} staging files produced.")
 
 
+def _cmd_resolve() -> None:
+    """Run the Phase 2 entity resolution pipeline."""
+    from pathlib import Path
+
+    from src.config import get_settings
+    from src.resolve import run_all as resolve_all
+
+    settings = get_settings()
+    results = resolve_all(
+        Path(settings.data_raw_dir),
+        Path(settings.data_staging_dir),
+        Path(settings.data_curated_dir),
+    )
+    total = sum(len(v) for v in results.values())
+    print(f"Resolution complete. {total} output files.")
+
+
 def _cmd_stub(name: str) -> None:
     """Print a not-yet-implemented message for a pipeline stage."""
     print(f"Command '{name}' not yet implemented. See Makefile targets.")
@@ -122,6 +139,8 @@ def main() -> None:
 
         settings = get_settings()
         validate_staging(Path(settings.data_staging_dir))
+    elif args.command == "resolve":
+        _cmd_resolve()
     else:
         _cmd_stub(args.command)
 

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -1,1 +1,37 @@
-"""Phase 2: Narrator NER/disambiguation and hadith deduplication."""
+"""Phase 2: Entity Resolution pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["run_all"]
+
+
+def run_all(
+    raw_dir: Path, staging_dir: Path, output_dir: Path
+) -> dict[str, list[Path]]:
+    """Run full entity resolution pipeline: NER -> disambiguate -> dedup."""
+    logger.info("resolve_pipeline_start")
+
+    from src.resolve import dedup, disambiguate, ner
+
+    results: dict[str, list[Path]] = {}
+
+    # Step 1: NER
+    logger.info("resolve_step", step="ner", status="not_yet_implemented")
+    results["ner"] = ner.run(staging_dir, output_dir)
+
+    # Step 2: Disambiguation
+    logger.info("resolve_step", step="disambiguate", status="not_yet_implemented")
+    results["disambiguate"] = disambiguate.run(staging_dir, output_dir)
+
+    # Step 3: Deduplication
+    logger.info("resolve_step", step="dedup", status="not_yet_implemented")
+    results["dedup"] = dedup.run(staging_dir, output_dir)
+
+    logger.info("resolve_pipeline_complete")
+    return results

--- a/src/resolve/dedup.py
+++ b/src/resolve/dedup.py
@@ -1,0 +1,20 @@
+"""Hadith deduplication and parallel detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["run"]
+
+
+def run(staging_dir: Path, output_dir: Path) -> list[Path]:
+    """Detect duplicate and parallel hadith texts across collections.
+
+    Uses text similarity to identify verbatim, close paraphrase, and thematic parallels.
+    """
+    logger.info("dedup_run", status="not_yet_implemented")
+    return []

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -1,0 +1,20 @@
+"""Narrator disambiguation via multi-stage matching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["run"]
+
+
+def run(staging_dir: Path, output_dir: Path) -> list[Path]:
+    """Disambiguate narrator mentions to canonical narrator records.
+
+    Multi-stage pipeline: exact match, fuzzy match, embedding similarity.
+    """
+    logger.info("disambiguate_run", status="not_yet_implemented")
+    return []

--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -1,0 +1,20 @@
+"""Narrator Named Entity Recognition from isnad chains."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["run"]
+
+
+def run(staging_dir: Path, output_dir: Path) -> list[Path]:
+    """Extract narrator mentions from parsed isnad chains.
+
+    Reads staging Parquet files and produces resolved narrator mention tables.
+    """
+    logger.info("ner_run", status="not_yet_implemented")
+    return []

--- a/src/resolve/schemas.py
+++ b/src/resolve/schemas.py
@@ -1,0 +1,77 @@
+"""Phase 2 entity resolution output schemas."""
+
+from __future__ import annotations
+
+import pyarrow as pa
+
+__all__ = [
+    "RESOLVE_SCHEMA_VERSION",
+    "NARRATOR_MENTIONS_RESOLVED_SCHEMA",
+    "NARRATORS_CANONICAL_SCHEMA",
+    "AMBIGUOUS_NARRATORS_SCHEMA",
+    "PARALLEL_LINKS_SCHEMA",
+]
+
+RESOLVE_SCHEMA_VERSION = 1
+
+NARRATOR_MENTIONS_RESOLVED_SCHEMA = pa.schema(
+    [
+        pa.field("mention_id", pa.string(), nullable=False),
+        pa.field("hadith_id", pa.string(), nullable=False),
+        pa.field("source_corpus", pa.string(), nullable=False),
+        pa.field("position_in_chain", pa.int32(), nullable=False),
+        pa.field("name_raw", pa.string(), nullable=True),
+        pa.field("name_normalized", pa.string(), nullable=True),
+        pa.field("canonical_narrator_id", pa.string(), nullable=True),
+        pa.field("transmission_method", pa.string(), nullable=True),
+        pa.field("confidence", pa.float32(), nullable=True),
+    ]
+)
+
+NARRATORS_CANONICAL_SCHEMA = pa.schema(
+    [
+        pa.field("canonical_id", pa.string(), nullable=False),
+        pa.field("name_ar", pa.string(), nullable=True),
+        pa.field("name_en", pa.string(), nullable=True),
+        pa.field("name_ar_normalized", pa.string(), nullable=True),
+        pa.field("aliases", pa.list_(pa.string()), nullable=True),
+        pa.field("birth_year_ah", pa.int32(), nullable=True),
+        pa.field("death_year_ah", pa.int32(), nullable=True),
+        pa.field("generation", pa.string(), nullable=True),
+        pa.field("gender", pa.string(), nullable=True),
+        pa.field("trustworthiness", pa.string(), nullable=True),
+        pa.field("source_ids", pa.list_(pa.string()), nullable=True),
+        pa.field("external_id", pa.string(), nullable=True),
+        pa.field("mention_count", pa.int32(), nullable=True),
+    ]
+)
+
+AMBIGUOUS_NARRATORS_SCHEMA = pa.schema(
+    [
+        pa.field("mention_id", pa.string(), nullable=False),
+        pa.field("mention_text", pa.string(), nullable=False),
+        pa.field("source_corpus", pa.string(), nullable=False),
+        pa.field("candidate_1_id", pa.string(), nullable=True),
+        pa.field("candidate_1_name", pa.string(), nullable=True),
+        pa.field("candidate_1_score", pa.float32(), nullable=True),
+        pa.field("candidate_1_stage", pa.string(), nullable=True),
+        pa.field("candidate_2_id", pa.string(), nullable=True),
+        pa.field("candidate_2_name", pa.string(), nullable=True),
+        pa.field("candidate_2_score", pa.float32(), nullable=True),
+        pa.field("candidate_2_stage", pa.string(), nullable=True),
+        pa.field("candidate_3_id", pa.string(), nullable=True),
+        pa.field("candidate_3_name", pa.string(), nullable=True),
+        pa.field("candidate_3_score", pa.float32(), nullable=True),
+        pa.field("candidate_3_stage", pa.string(), nullable=True),
+    ]
+)
+
+PARALLEL_LINKS_SCHEMA = pa.schema(
+    [
+        pa.field("hadith_id_a", pa.string(), nullable=False),
+        pa.field("hadith_id_b", pa.string(), nullable=False),
+        pa.field("similarity_score", pa.float32(), nullable=False),
+        pa.field("variant_type", pa.string(), nullable=False),
+        pa.field("cross_sect", pa.bool_(), nullable=False),
+    ]
+)


### PR DESCRIPTION
## Summary
- Resolve module structure: schemas.py, ner.py, disambiguate.py, dedup.py (placeholders)
- Output Parquet schemas: narrator mentions resolved, narrators canonical, ambiguous, parallel links
- RESOLVE_SCHEMA_VERSION = 1 for Phase 3 contract
- Orchestrator placeholder with pipeline logging
- CLI and Makefile wired
- ML deps verified: declared in [dependency-groups] ml, resolve correctly via uv

## Verification
- `uv run ruff check src/resolve/` — all checks passed
- `uv run mypy src/resolve/` — no issues in 5 source files
- `uv run isnad resolve` — runs end-to-end, logs "not_yet_implemented" for each step

## Related Issues
Closes #58

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Kwame Asante <parametrization+Kwame.Asante@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>