### PR TITLE
Tech debt: ResponseParser typing, orchestrator types, traceback logging

### DIFF
--- a/src/acquire/__init__.py
+++ b/src/acquire/__init__.py
@@ -8,38 +8,31 @@ Shared HTTP/download/clone utilities live in ``base.py``.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from types import ModuleType
 
 from src.acquire import fawaz, lk_corpus, muhaddithat, open_hadith, sunnah_api, thaqalayn
 from src.acquire.sanadset import download_sanadset
 from src.utils.logging import get_logger
 
-if TYPE_CHECKING:
-    from types import ModuleType
-
 logger = get_logger(__name__)
 
-# Each entry is (name, callable(raw_dir) -> Path | None).
-# Most modules expose ``run(raw_dir)``; sanadset uses ``download_sanadset``.
-SOURCES: list[tuple[str, ModuleType]] = [
+# Each entry is (name, module_or_none).
+# Most modules expose ``run(raw_dir)``; sanadset (None) is handled separately.
+SOURCES: list[tuple[str, ModuleType | None]] = [
     ("lk", lk_corpus),
-    ("sanadset", None),  # type: ignore[list-item]  # handled separately
+    ("sanadset", None),
     ("thaqalayn", thaqalayn),
     ("fawaz", fawaz),
     ("sunnah", sunnah_api),
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
 ]
-
-
 def _acquire_one(name: str, module: ModuleType | None, raw_dir: Path) -> Path | None:
     """Run a single downloader, returning its output path."""
     if name == "sanadset":
         return download_sanadset(raw_dir / "sanadset")
     assert module is not None
     return module.run(raw_dir)  # type: ignore[no-any-return]
-
-
 def run_all(raw_dir: Path) -> dict[str, Path | None]:
     """Run all downloaders. Continue on failure. Return dict of source -> path."""
     results: dict[str, Path | None] = {}
@@ -50,7 +43,7 @@ def run_all(raw_dir: Path) -> dict[str, Path | None]:
             results[name] = path
             logger.info("acquired", source=name, path=str(path) if path else "skipped")
         except Exception as exc:  # noqa: BLE001
-            logger.error("acquire_failed", source=name, error=str(exc))
+            logger.error("acquire_failed", source=name, error=str(exc), exc_info=True)
             results[name] = None
 
     # Summary table

--- a/src/acquire/base.py
+++ b/src/acquire/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +31,7 @@ DEFAULT_USER_AGENT = "isnad-graph/1.0 (hadith-research)"
 DEFAULT_TIMEOUT = 60.0
 
 # Type alias for paginated response parser callbacks.
-ResponseParser = Any  # Callable[[dict[str, Any]], tuple[list[dict[str, Any]], int | None]]
+ResponseParser = Callable[[dict[str, Any] | list[Any]], tuple[list[dict[str, Any]], int | None]]
 
 
 def ensure_dir(path: Path) -> Path:

--- a/src/parse/__init__.py
+++ b/src/parse/__init__.py
@@ -3,28 +3,23 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from types import ModuleType
 
 from src.parse import fawaz, lk_corpus, muhaddithat, open_hadith, sunnah_api, thaqalayn
 from src.parse.sanadset import parse_sanadset
 from src.utils.logging import get_logger
 
-if TYPE_CHECKING:
-    from types import ModuleType
-
 logger = get_logger(__name__)
 
-PARSERS: list[tuple[str, ModuleType]] = [
+PARSERS: list[tuple[str, ModuleType | None]] = [
     ("lk", lk_corpus),
-    ("sanadset", None),  # type: ignore[list-item]  # handled separately
+    ("sanadset", None),
     ("thaqalayn", thaqalayn),
     ("fawaz", fawaz),
     ("sunnah", sunnah_api),
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
 ]
-
-
 def _normalize_output(result: Path | tuple[Path, ...] | list[Path] | dict[str, Path]) -> list[Path]:
     """Normalize parser return values to a flat list of Paths."""
     if isinstance(result, dict):
@@ -34,8 +29,6 @@ def _normalize_output(result: Path | tuple[Path, ...] | list[Path] | dict[str, P
     if isinstance(result, list):
         return result
     return [result]
-
-
 def _parse_one(
     name: str, module: ModuleType | None, raw_dir: Path, staging_dir: Path
 ) -> list[Path]:
@@ -44,8 +37,6 @@ def _parse_one(
         return _normalize_output(parse_sanadset(raw_dir / "sanadset", staging_dir))
     assert module is not None
     return _normalize_output(module.run(raw_dir, staging_dir))
-
-
 def run_all(raw_dir: Path, staging_dir: Path) -> dict[str, list[Path]]:
     """Run all parsers. Continue on failure. Return dict of source -> output files."""
     results: dict[str, list[Path]] = {}
@@ -56,7 +47,7 @@ def run_all(raw_dir: Path, staging_dir: Path) -> dict[str, list[Path]]:
             results[name] = output_files
             logger.info("parsed", source=name, files=len(output_files))
         except Exception as exc:  # noqa: BLE001
-            logger.error("parse_failed", source=name, error=str(exc))
+            logger.error("parse_failed", source=name, error=str(exc), exc_info=True)
             results[name] = []
 
     # Summary with row counts


### PR DESCRIPTION
## Summary
- Replace ResponseParser = Any with proper Callable type (#36)
- Add proper typing to orchestrator SOURCES/PARSERS lists (#53)
- Log full tracebacks in orchestrator error handlers (#54)

## Related Issues
Closes #36
Closes #53
Closes #54

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Kwame Asante <parametrization+Kwame.Asante@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>