### PR TITLE
Tech debt: Fawaz idempotency, Thaqalayn cleanup, validate.py typing

### DIFF
--- a/src/acquire/fawaz.py
+++ b/src/acquire/fawaz.py
@@ -49,7 +49,14 @@ def run(raw_dir: Path) -> Path:
     """
     dest = ensure_dir(raw_dir / "fawaz")
 
-    # 1. Download editions.json (small catalog file)
+    # 1. Idempotency check — skip network requests if edition files already present
+    existing_editions = list(dest.glob("eng-*.json"))
+    if len(existing_editions) >= MIN_EXPECTED_EDITIONS:
+        logger.info("fawaz_already_acquired", edition_count=len(existing_editions))
+        write_manifest(dest, existing_editions)
+        return dest
+
+    # 2. Download editions.json (small catalog file)
     editions_path = dest / "editions.json"
     editions_data = fetch_json(EDITIONS_URL)
     if not editions_path.exists() or editions_path.stat().st_size == 0:
@@ -57,11 +64,11 @@ def run(raw_dir: Path) -> Path:
             json.dump(editions_data, f, indent=2)
         logger.info("editions_catalog_saved", path=str(editions_path))
 
-    # 2. Download info.json (grading metadata)
+    # 3. Download info.json (grading metadata)
     info_path = dest / "info.json"
     download_file(INFO_URL, info_path)
 
-    # 3. Filter English editions and download each
+    # 4. Filter English editions and download each
     keys = _english_edition_keys(editions_data)
     logger.info("english_editions_found", count=len(keys))
 
@@ -78,7 +85,7 @@ def run(raw_dir: Path) -> Path:
             download_file(url, edition_path, client=client, timeout=120.0)
             downloaded.append(edition_path)
 
-    # 4. Validate minimum edition count
+    # 5. Validate minimum edition count
     edition_files = [p for p in dest.glob("eng-*.json")]
     if len(edition_files) < MIN_EXPECTED_EDITIONS:
         msg = (

--- a/src/parse/thaqalayn.py
+++ b/src/parse/thaqalayn.py
@@ -41,21 +41,35 @@ def _extract_hadiths_api(data: dict[str, Any]) -> list[dict[str, Any]]:
     return result
 
 
+# Fields that indicate a dict is a hadith record rather than arbitrary metadata
+_HADITH_FIELD_INDICATORS = frozenset({
+    "hadithNumber", "hadith_number", "number",
+    "textAr", "text_ar", "arabicText", "arabic",
+    "textEn", "text_en", "englishText", "english", "translation",
+    "isnad", "matn", "grade", "grading",
+})
+
+
+def _looks_like_hadith(obj: object) -> bool:
+    """Return True if a dict has at least one hadith-indicative field."""
+    return isinstance(obj, dict) and bool(obj.keys() & _HADITH_FIELD_INDICATORS)
+
+
 def _extract_hadiths_github(data: Any) -> list[dict[str, Any]]:
     """Extract hadith list from GitHub-format JSON."""
     if isinstance(data, list):
-        return list(data)
+        return [item for item in data if _looks_like_hadith(item)]
     if isinstance(data, dict):
         # Try common wrapper keys
         for key in ("hadiths", "data", "chapters"):
             val = data.get(key)
             if isinstance(val, list):
-                return list(val)
-        # Might be nested chapters with hadiths
+                return [item for item in val if _looks_like_hadith(item)]
+        # Might be nested chapters with hadiths — require hadith-indicative fields
         result: list[dict[str, Any]] = []
-        for key, val in data.items():
+        for val in data.values():
             if isinstance(val, list):
-                result.extend(v for v in val if isinstance(v, dict))
+                result.extend(v for v in val if _looks_like_hadith(v))
         return result
     return []
 
@@ -152,8 +166,11 @@ def _infer_book_number(file_path: Path) -> int | None:
     return None
 
 
-def discover(raw_dir: Path) -> None:
-    """Load first JSON and log keys/structure for field mapping discovery."""
+def _discover(raw_dir: Path) -> None:
+    """Load first JSON and log keys/structure for field mapping discovery.
+
+    Development utility — only callable via ``python -m src.parse.thaqalayn``.
+    """
     thaq_dir = raw_dir / "thaqalayn"
     json_files = sorted(thaq_dir.glob("book_*.json"))
     if not json_files:
@@ -282,3 +299,13 @@ def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
         collections=len(coll_rows),
     )
     return hadiths_path, collections_path
+
+
+if __name__ == "__main__":
+    import sys
+
+    from src.config import get_settings
+
+    settings = get_settings()
+    if "--discover" in sys.argv:
+        _discover(settings.data_raw_dir)

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 
 from src.parse.schemas import (
@@ -19,7 +21,7 @@ from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-EXPECTED_SCHEMAS: dict[str, Any] = {
+EXPECTED_SCHEMAS: dict[str, pa.Schema] = {
     "hadiths_": HADITH_SCHEMA,
     "narrator_mentions_": NARRATOR_MENTION_SCHEMA,
     "narrators_bio_": NARRATOR_BIO_SCHEMA,
@@ -35,7 +37,7 @@ def _has_arabic(text: str) -> bool:
     return bool(_ARABIC_RE.search(text))
 
 
-def _null_percentages(table: pq.ParquetFile | Any) -> dict[str, float]:
+def _null_percentages(table: pa.Table) -> dict[str, float]:
     """Compute null percentage per column for a PyArrow table."""
     result: dict[str, float] = {}
     num_rows = len(table)
@@ -48,7 +50,7 @@ def _null_percentages(table: pq.ParquetFile | Any) -> dict[str, float]:
     return result
 
 
-def _match_schema(filename: str) -> tuple[str, Any] | None:
+def _match_schema(filename: str) -> tuple[str, pa.Schema] | None:
     """Match a filename against expected schema prefixes."""
     for prefix, schema in EXPECTED_SCHEMAS.items():
         if filename.startswith(prefix):
@@ -57,7 +59,7 @@ def _match_schema(filename: str) -> tuple[str, Any] | None:
 
 
 def _check_schema_conformance(
-    table_schema: Any, expected_schema: Any
+    table_schema: pa.Schema, expected_schema: pa.Schema
 ) -> list[str]:
     """Compare table schema against expected. Return list of issues."""
     issues: list[str] = []
@@ -133,27 +135,29 @@ def validate_staging(staging_dir: Path) -> dict[str, Any]:
 
             # Duplicate source_ids
             if "source_id" in table.column_names:
-                source_ids = table.column("source_id").to_pylist()
-                total = len(source_ids)
-                unique = len(set(source_ids))
+                source_col = table.column("source_id")
+                total = len(source_col)
+                unique = pc.count(pc.unique(source_col)).as_py()
                 dupes = total - unique
                 hadith_checks["duplicate_source_ids"] = dupes
             else:
                 hadith_checks["duplicate_source_ids"] = None
 
-            # Empty matn fields
+            # Empty matn fields — count nulls + empty/whitespace-only strings
             empty_matn_ar = 0
             empty_matn_en = 0
             if "matn_ar" in table.column_names:
-                matn_ar = table.column("matn_ar")
-                for val in matn_ar.to_pylist():
-                    if val is None or val.strip() == "":
-                        empty_matn_ar += 1
+                col = table.column("matn_ar")
+                null_count = col.null_count
+                stripped = pc.utf8_trim(col.drop_null(), " \t\n\r")
+                blank_count = pc.sum(pc.equal(stripped, "")).as_py()
+                empty_matn_ar = null_count + blank_count
             if "matn_en" in table.column_names:
-                matn_en = table.column("matn_en")
-                for val in matn_en.to_pylist():
-                    if val is None or val.strip() == "":
-                        empty_matn_en += 1
+                col = table.column("matn_en")
+                null_count = col.null_count
+                stripped = pc.utf8_trim(col.drop_null(), " \t\n\r")
+                blank_count = pc.sum(pc.equal(stripped, "")).as_py()
+                empty_matn_en = null_count + blank_count
             hadith_checks["empty_matn_ar"] = empty_matn_ar
             hadith_checks["empty_matn_en"] = empty_matn_en
 
@@ -161,13 +165,16 @@ def validate_staging(staging_dir: Path) -> dict[str, Any]:
             ar_count = 0
             en_count = 0
             if "matn_ar" in table.column_names:
-                for val in table.column("matn_ar").to_pylist():
-                    if val is not None and _has_arabic(val):
-                        ar_count += 1
+                col = table.column("matn_ar")
+                non_null = col.drop_null()
+                ar_count = pc.sum(
+                    pc.match_substring_regex(non_null, r"[\u0600-\u06FF]")
+                ).as_py()
             if "matn_en" in table.column_names:
-                for val in table.column("matn_en").to_pylist():
-                    if val is not None and val.strip() != "":
-                        en_count += 1
+                col = table.column("matn_en")
+                non_null = col.drop_null()
+                stripped = pc.utf8_trim(non_null, " \t\n\r")
+                en_count = pc.sum(pc.not_equal(stripped, "")).as_py()
             if num_rows > 0:
                 hadith_checks["arabic_coverage_pct"] = round(100.0 * ar_count / num_rows, 2)
                 hadith_checks["english_coverage_pct"] = round(100.0 * en_count / num_rows, 2)


### PR DESCRIPTION
## Summary
- Fawaz: idempotency check before editions.json fetch (#42)
- Thaqalayn: gate discover() utility, tighten GitHub format fallback (#45, #46)
- validate.py: replace .to_pylist() with pyarrow.compute, proper type annotations (#51, #52)

## Related Issues
Closes #42
Closes #45
Closes #46
Closes #51
Closes #52

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>