### PR TITLE
Tech debt: PEP 8 blanks, PyArrow compute, CSV→Parquet metrics

### DIFF
--- a/src/acquire/__init__.py
+++ b/src/acquire/__init__.py
@@ -27,12 +27,16 @@ SOURCES: list[tuple[str, ModuleType | None]] = [
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
 ]
+
+
 def _acquire_one(name: str, module: ModuleType | None, raw_dir: Path) -> Path | None:
     """Run a single downloader, returning its output path."""
     if name == "sanadset":
         return download_sanadset(raw_dir / "sanadset")
     assert module is not None
     return module.run(raw_dir)  # type: ignore[no-any-return]
+
+
 def run_all(raw_dir: Path) -> dict[str, Path | None]:
     """Run all downloaders. Continue on failure. Return dict of source -> path."""
     results: dict[str, Path | None] = {}

--- a/src/parse/__init__.py
+++ b/src/parse/__init__.py
@@ -20,6 +20,8 @@ PARSERS: list[tuple[str, ModuleType | None]] = [
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
 ]
+
+
 def _normalize_output(result: Path | tuple[Path, ...] | list[Path] | dict[str, Path]) -> list[Path]:
     """Normalize parser return values to a flat list of Paths."""
     if isinstance(result, dict):
@@ -29,6 +31,8 @@ def _normalize_output(result: Path | tuple[Path, ...] | list[Path] | dict[str, P
     if isinstance(result, list):
         return result
     return [result]
+
+
 def _parse_one(
     name: str, module: ModuleType | None, raw_dir: Path, staging_dir: Path
 ) -> list[Path]:
@@ -37,6 +41,8 @@ def _parse_one(
         return _normalize_output(parse_sanadset(raw_dir / "sanadset", staging_dir))
     assert module is not None
     return _normalize_output(module.run(raw_dir, staging_dir))
+
+
 def run_all(raw_dir: Path, staging_dir: Path) -> dict[str, list[Path]]:
     """Run all parsers. Continue on failure. Return dict of source -> output files."""
     results: dict[str, list[Path]] = {}

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -71,6 +71,7 @@ def _collect_dedup_metrics(metrics: ResolveMetrics, staging_dir: Path) -> None:
     if not path.exists():
         return
     try:
+        import pyarrow.compute as pc
         import pyarrow.parquet as pq
 
         table = pq.read_table(path)
@@ -78,16 +79,12 @@ def _collect_dedup_metrics(metrics: ResolveMetrics, staging_dir: Path) -> None:
         if table.num_rows > 0:
             vt_col = table.column("variant_type")
             cs_col = table.column("cross_sect")
-            for i in range(table.num_rows):
-                vt = vt_col[i].as_py()
-                if vt == "verbatim":
-                    metrics.parallel_verbatim += 1
-                elif vt == "close_paraphrase":
-                    metrics.parallel_close_paraphrase += 1
-                elif vt == "thematic":
-                    metrics.parallel_thematic += 1
-                if cs_col[i].as_py():
-                    metrics.parallel_cross_sect += 1
+            metrics.parallel_verbatim = pc.sum(pc.equal(vt_col, "verbatim")).as_py()
+            metrics.parallel_close_paraphrase = pc.sum(
+                pc.equal(vt_col, "close_paraphrase")
+            ).as_py()
+            metrics.parallel_thematic = pc.sum(pc.equal(vt_col, "thematic")).as_py()
+            metrics.parallel_cross_sect = pc.sum(cs_col).as_py()
     except Exception:  # noqa: BLE001
         logger.warning("dedup_metrics_read_failed", path=str(path))
 
@@ -95,7 +92,7 @@ def _collect_dedup_metrics(metrics: ResolveMetrics, staging_dir: Path) -> None:
 def _collect_disambig_metrics(metrics: ResolveMetrics, output_dir: Path) -> None:
     """Read disambiguation outputs to populate narrator metrics."""
     canonical_path = output_dir / "narrators_canonical.parquet"
-    ambiguous_path = output_dir / "ambiguous_narrators.csv"
+    ambiguous_path = output_dir / "ambiguous_narrators.parquet"
 
     try:
         if canonical_path.exists():
@@ -108,12 +105,10 @@ def _collect_disambig_metrics(metrics: ResolveMetrics, output_dir: Path) -> None
 
     try:
         if ambiguous_path.exists():
-            import csv
+            import pyarrow.parquet as pq
 
-            with open(ambiguous_path, encoding="utf-8") as f:
-                reader = csv.reader(f)
-                next(reader, None)  # skip header
-                metrics.ambiguous_count = sum(1 for _ in reader)
+            meta = pq.read_metadata(ambiguous_path)
+            metrics.ambiguous_count = meta.num_rows
     except Exception:  # noqa: BLE001
         logger.warning("ambiguous_metrics_read_failed", path=str(ambiguous_path))
 


### PR DESCRIPTION
## Summary
- Fix PEP 8 blank lines in orchestrators (#70)
- Use PyArrow compute for dedup metrics (#85)
- Update disambig metrics from CSV to Parquet (#86)

## Related Issues
Closes #70, Closes #85, Closes #86

Co-Authored-By: Kwame Asante <parametrization+Kwame.Asante@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>