### PR TITLE
Tech debt: Dedup glob pattern, progress logging, enum keys

### DIFF
--- a/src/resolve/dedup.py
+++ b/src/resolve/dedup.py
@@ -59,7 +59,7 @@ def _load_hadith_texts(
 
     Returns (hadith_ids, texts, corpora) with null/empty matn_en rows excluded.
     """
-    hadith_files = sorted(staging_dir.glob("**/hadith*.parquet"))
+    hadith_files = sorted(staging_dir.glob("**/hadiths_*.parquet"))
     if not hadith_files:
         logger.warning("dedup_no_hadith_files", staging_dir=str(staging_dir))
         return [], [], []
@@ -146,18 +146,24 @@ def run_dedup(
     model = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
 
     logger.info("dedup_encoding", count=len(texts), batch_size=batch_size)
-    embeddings: npt.NDArray[np.float32] = model.encode(
-        texts,
-        batch_size=batch_size,
-        show_progress_bar=False,
-        convert_to_numpy=True,
-        normalize_embeddings=True,
-    )
+
+    # Encode in chunks to log progress during embedding generation (#81)
+    all_embeddings: list[npt.NDArray[np.float32]] = []
+    for start in range(0, len(texts), batch_size):
+        end = min(start + batch_size, len(texts))
+        chunk: npt.NDArray[np.float32] = model.encode(
+            texts[start:end],
+            batch_size=batch_size,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+        )
+        all_embeddings.append(chunk)
+        logger.info("dedup_encoding_progress", processed=end, total=len(texts))
+
+    embeddings: npt.NDArray[np.float32] = np.vstack(all_embeddings)
     # Ensure float32 for FAISS
     embeddings = np.ascontiguousarray(embeddings, dtype=np.float32)
-
-    for i in range(0, len(texts), 1000):
-        logger.info("dedup_encoding_progress", processed=min(i + 1000, len(texts)))
 
     # ------------------------------------------------------------------
     # 3. Persist embeddings & ID mapping
@@ -268,7 +274,7 @@ def run_dedup(
     # 7. Summary logging
     # ------------------------------------------------------------------
     elapsed = time.monotonic() - t0
-    tier_counts = {"verbatim": 0, "close_paraphrase": 0, "thematic": 0}
+    tier_counts: dict[str, int] = {vt.value: 0 for vt in VariantType}
     cross_sect_count = 0
     for vt, cs in zip(variant_types, cross_sects):
         tier_counts[vt] = tier_counts.get(vt, 0) + 1
@@ -278,9 +284,9 @@ def run_dedup(
     logger.info(
         "dedup_complete",
         total_pairs=len(ids_a),
-        verbatim=tier_counts["verbatim"],
-        close_paraphrase=tier_counts["close_paraphrase"],
-        thematic=tier_counts["thematic"],
+        verbatim=tier_counts[VariantType.VERBATIM],
+        close_paraphrase=tier_counts[VariantType.CLOSE_PARAPHRASE],
+        thematic=tier_counts[VariantType.THEMATIC],
         cross_sect=cross_sect_count,
         elapsed_seconds=round(elapsed, 2),
     )

--- a/tests/test_resolve/test_dedup.py
+++ b/tests/test_resolve/test_dedup.py
@@ -146,7 +146,7 @@ class TestLoadHadithTexts:
             _make_hadith("h-1", "Actions are judged by intentions"),
             _make_hadith("h-2", "The best of you is the one who learns the Quran"),
         ]
-        _write_hadiths(tmp_path / "hadith_test.parquet", rows)
+        _write_hadiths(tmp_path / "hadiths_test.parquet", rows)
         ids, texts, corpora = _load_hadith_texts(tmp_path)
         assert len(ids) == 2
         assert len(texts) == 2
@@ -158,7 +158,7 @@ class TestLoadHadithTexts:
             _make_hadith("h-2", None),  # type: ignore[arg-type]
             _make_hadith("h-3", "   "),
         ]
-        _write_hadiths(tmp_path / "hadith_test.parquet", rows)
+        _write_hadiths(tmp_path / "hadiths_test.parquet", rows)
         ids, texts, corpora = _load_hadith_texts(tmp_path)
         assert len(ids) == 1
         assert ids[0] == "h-1"
@@ -222,7 +222,7 @@ class TestEmbeddingPipeline:
                 sect="shia",
             ),
         ]
-        _write_hadiths(tmp_path / "hadith_test.parquet", rows)
+        _write_hadiths(tmp_path / "hadiths_test.parquet", rows)
 
         output_path = run_dedup(tmp_path, threshold=0.70, top_k=5)
         assert output_path.exists()
@@ -237,7 +237,7 @@ class TestEmbeddingPipeline:
             _make_hadith("h-1", "Test text one"),
             _make_hadith("h-2", "Test text two"),
         ]
-        _write_hadiths(tmp_path / "hadith_test.parquet", rows)
+        _write_hadiths(tmp_path / "hadiths_test.parquet", rows)
 
         run_dedup(tmp_path, threshold=0.70)
         assert (tmp_path / "hadith_embeddings.faiss").exists()
@@ -254,7 +254,7 @@ class TestEmbeddingPipeline:
                 sect="shia",
             ),
         ]
-        _write_hadiths(tmp_path / "hadith_test.parquet", rows)
+        _write_hadiths(tmp_path / "hadiths_test.parquet", rows)
 
         output_path = run_dedup(tmp_path, threshold=0.70)
         table = pq.read_table(output_path)


### PR DESCRIPTION
## Summary
- Tighten hadith Parquet glob to `hadiths_*.parquet` (#80)
- Fix progress logging to report during encoding (#81)
- Use `VariantType` enum values as `tier_counts` keys (#82)
- Close #71 (process issue resolved by deployments workflow)

## Verification
- `ruff check` passes on both files
- `mypy` passes (strict mode)
- All 19 tests in `test_dedup.py` pass (including ML-dependent tests)

## Related Issues
Closes #71, Closes #80, Closes #81, Closes #82

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>