### PR TITLE
Tech debt: NER cleanup, disambig fixes, geographic filter

### DIFF
--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -87,10 +87,12 @@ class ChainContext:
 # ---------------------------------------------------------------------------
 # Stage 1: Exact match
 # ---------------------------------------------------------------------------
-def _exact_match(mention: str, candidates: list[Candidate]) -> list[Match]:
-    """Full normalized-name match."""
+def _exact_match(mention_norm: str, candidates: list[Candidate]) -> list[Match]:
+    """Full normalized-name match.
+
+    ``mention_norm`` must already be Arabic-normalized by the caller.
+    """
     results: list[Match] = []
-    mention_norm = normalize_arabic(mention) if mention else ""
     if not mention_norm:
         return results
     for c in candidates:
@@ -104,10 +106,12 @@ def _exact_match(mention: str, candidates: list[Candidate]) -> list[Match]:
 # ---------------------------------------------------------------------------
 # Stage 2: Fuzzy match
 # ---------------------------------------------------------------------------
-def _fuzzy_match(mention: str, candidates: list[Candidate]) -> list[Match]:
-    """rapidfuzz ratio >= threshold AND Levenshtein distance <= max."""
+def _fuzzy_match(mention_norm: str, candidates: list[Candidate]) -> list[Match]:
+    """rapidfuzz ratio >= threshold AND Levenshtein distance <= max.
+
+    ``mention_norm`` must already be Arabic-normalized by the caller.
+    """
     results: list[Match] = []
-    mention_norm = normalize_arabic(mention) if mention else ""
     if not mention_norm:
         return results
     for c in candidates:
@@ -153,9 +157,6 @@ def _temporal_filter(
                 break
         if plausible:
             filtered.append(m)
-        elif not chain_context.adjacent_death_years:
-            # Should not reach here, but keep as safety net.
-            filtered.append(m)
 
     return filtered
 
@@ -164,24 +165,34 @@ def _temporal_filter(
 # Stage 4: Geographic filter
 # ---------------------------------------------------------------------------
 def _geographic_filter(matches: list[Match]) -> list[Match]:
-    """Soft geographic constraint — skip if data is missing.
+    """Soft geographic constraint — pass-through until location ontology exists.
 
-    Currently a pass-through that only filters when both candidates
-    have location data that is clearly incompatible. Since location
-    normalization is not yet implemented, this is conservative.
+    Geographic filtering is deferred because:
+    - No normalized location ontology exists yet (birth/death locations are
+      free-text strings with inconsistent transliteration across corpora).
+    - Effective filtering requires a curated mapping of historical Islamic
+      cities/regions plus known scholarly travel routes.
+    - Incorrect filtering would silently drop valid matches, so conservative
+      pass-through is preferable until location data is reliable.
+
+    TODO(phase4): Implement geographic filtering once a location ontology
+    is built in the enrich stage. Key steps:
+      1. Normalize location strings to canonical city/region IDs.
+      2. Build a travel-plausibility graph (e.g., Basra<->Baghdad: likely).
+      3. Filter candidates whose locations are implausible given chain context.
     """
-    # With no normalized location ontology yet, pass all through.
-    # Future: filter by known travel routes and regional proximity.
     return matches
 
 
 # ---------------------------------------------------------------------------
 # Stage 5: Cross-reference match
 # ---------------------------------------------------------------------------
-def _crossref_match(mention: str, candidates: list[Candidate]) -> list[Match]:
-    """Match via external IDs (e.g., muslimscholars.info)."""
+def _crossref_match(mention_norm: str, candidates: list[Candidate]) -> list[Match]:
+    """Match via external IDs (e.g., muslimscholars.info).
+
+    ``mention_norm`` must already be Arabic-normalized by the caller.
+    """
     results: list[Match] = []
-    mention_norm = normalize_arabic(mention) if mention else ""
     if not mention_norm:
         return results
     for c in candidates:
@@ -286,7 +297,12 @@ def _disambiguate_mention(
     death_year_index: dict[str, int | None],
 ) -> tuple[Match | None, list[Match]]:
     """Run 5-stage pipeline on a single mention. Return (best_match, all_matches)."""
-    name = str(mention.get("name_normalized") or mention.get("name_raw") or "")
+    raw_name = str(mention.get("name_normalized") or mention.get("name_raw") or "")
+    if not raw_name:
+        return None, []
+
+    # Normalize Arabic once; all stages receive the pre-normalized form.
+    name = normalize_arabic(raw_name) if raw_name else ""
     if not name:
         return None, []
 

--- a/src/resolve/ner.py
+++ b/src/resolve/ner.py
@@ -157,31 +157,6 @@ def _extract_from_hadiths(
     return rows
 
 
-def _try_camelbert_fallback(
-    staging_dir: Path,
-    existing_rows: list[dict[str, str | int | None]],
-) -> list[dict[str, str | int | None]]:
-    """Attempt CAMeLBERT NER for Arabic sources if camel_tools is available.
-
-    If the library is not installed, logs a warning and returns the input unchanged.
-    """
-    try:
-        from camel_tools.ner import NERecognizer  # type: ignore[import-untyped]
-    except ImportError:
-        logger.warning(
-            "camelbert_unavailable",
-            msg="camel_tools not installed, skipping CAMeLBERT fallback",
-        )
-        return existing_rows
-
-    # Only attempt on Arabic rows that have no extraction results yet.
-    # For now, the fallback is a placeholder — full CAMeLBERT integration
-    # requires model download and configuration.
-    logger.info("camelbert_available", msg="CAMeLBERT fallback ready but not yet integrated")
-    _ = NERecognizer  # Acknowledge import to satisfy lint
-    return existing_rows
-
-
 def _write_name_audit_csv(
     rows: list[dict[str, str | int | None]],
     output_dir: Path,
@@ -195,7 +170,8 @@ def _write_name_audit_csv(
     candidates = [
         r for r in rows if r.get("name_raw") and r.get("name_normalized")
     ]
-    sample = random.sample(candidates, min(sample_size, len(candidates)))
+    rng = random.Random(42)
+    sample = rng.sample(candidates, min(sample_size, len(candidates)))
 
     with open(audit_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
@@ -239,10 +215,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
     for corpus in sorted(_SKIP_SOURCES):
         logger.info("ner_skip_source", corpus=corpus, reason="no_raw_isnads")
 
-    # Step 5: Try CAMeLBERT fallback for Arabic sources.
-    all_rows = _try_camelbert_fallback(staging_dir, all_rows)
-
-    # Step 6: Per-source metrics summary.
+    # Step 5: Per-source metrics summary.
     source_counts: dict[str, int] = {}
     for r in all_rows:
         src = str(r["source_corpus"])
@@ -251,7 +224,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
         logger.info("ner_source_summary", source_corpus=src, total_mentions=count)
     logger.info("ner_total_mentions", total=len(all_rows))
 
-    # Step 7: Build output table.
+    # Step 6: Build output table.
     output_paths: list[Path] = []
 
     if all_rows:
@@ -285,7 +258,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
     else:
         logger.warning("ner_no_mentions", msg="No narrator mentions extracted from any source")
 
-    # Step 8: Name audit CSV.
+    # Step 7: Name audit CSV.
     if all_rows:
         audit_path = _write_name_audit_csv(all_rows, output_dir)
         output_paths.append(audit_path)


### PR DESCRIPTION
## Summary
- Remove CAMeLBERT NER fallback placeholder that was a no-op (#75)
- Fixed random seed for audit CSV reproducibility (#76)
- Document geographic filter deferral with clear TODO for phase4 (#77)
- Remove unreachable dead code in `_temporal_filter` (#78)
- Normalize Arabic once at input in disambiguation pipeline, not per-stage (#79)

## Related Issues
Closes #75, Closes #76, Closes #77, Closes #78, Closes #79

## Verification
- `ruff check` -- all passed
- `mypy` -- no issues
- `pytest tests/test_resolve/` -- 59 passed

Co-Authored-By: Amara Diallo <parametrization+Amara.Diallo@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>