### PR TITLE
Phase 3: Validation queries + graph orchestrator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ parse: ## Phase 1: Parse raw data into staging Parquet files
 resolve: ## Phase 2: Entity resolution (NER + disambiguation + dedup)
 	uv run isnad resolve
 
-load: ## Phase 3: Load graph database
-	@echo "Phase 3 not yet implemented"
+load: ## Phase 3: Load graph into Neo4j
+	uv run isnad load
 
 enrich: ## Phase 4: Compute metrics
 	@echo "Phase 4 not yet implemented"

--- a/queries/validation/chain_integrity.cypher
+++ b/queries/validation/chain_integrity.cypher
@@ -1,0 +1,6 @@
+// Verify TRANSMITTED_TO paths form valid chains (no cycles, connected)
+// Bounded cycle detection — check paths up to length 20
+MATCH path = (n:Narrator)-[:TRANSMITTED_TO*1..20]->(m:Narrator)
+WHERE n = m
+RETURN n.id AS narrator_id, length(path) AS cycle_length
+LIMIT 100

--- a/queries/validation/collection_coverage.cypher
+++ b/queries/validation/collection_coverage.cypher
@@ -1,0 +1,10 @@
+// Compare expected vs actual hadith counts per collection
+MATCH (c:Collection)
+OPTIONAL MATCH (h:Hadith)-[:APPEARS_IN]->(c)
+WITH c, count(h) AS actual_count
+RETURN c.id AS collection_id, c.name_en AS name,
+       c.expected_count AS expected, actual_count AS actual,
+       CASE WHEN c.expected_count IS NOT NULL
+            THEN abs(actual_count - c.expected_count) * 100.0 / c.expected_count
+            ELSE null END AS deviation_pct
+ORDER BY c.id

--- a/queries/validation/orphan_narrators.cypher
+++ b/queries/validation/orphan_narrators.cypher
@@ -1,0 +1,6 @@
+// Find narrator nodes with no relationships
+// Expected: 0 orphans in a healthy graph
+MATCH (n:Narrator)
+WHERE NOT (n)--()
+RETURN n.id AS narrator_id, n.name_en AS name
+ORDER BY n.id

--- a/src/cli.py
+++ b/src/cli.py
@@ -100,6 +100,122 @@ def _cmd_resolve() -> None:
     print(f"\nResolution complete. {total} output files.")
 
 
+def _cmd_load(*, skip_validation: bool = False, nodes_only: bool = False) -> None:
+    """Run the Phase 3 graph loading pipeline."""
+    from pathlib import Path
+
+    from neo4j import GraphDatabase
+
+    from src.config import get_settings
+
+    settings = get_settings()
+
+    # Pre-flight Neo4j connectivity check
+    print("Checking Neo4j connectivity...")
+    try:
+        driver = GraphDatabase.driver(
+            settings.neo4j.uri,
+            auth=(settings.neo4j.user, settings.neo4j.password),
+        )
+        driver.verify_connectivity()
+        driver.close()
+    except Exception as exc:
+        print(f"ERROR: Cannot connect to Neo4j at {settings.neo4j.uri}: {exc}")
+        sys.exit(1)
+    print("  Neo4j is reachable.")
+
+    from src.graph import load_all
+    from src.utils.neo4j_client import Neo4jClient
+
+    staging_dir = Path(settings.data_staging_dir)
+    curated_dir = Path(settings.data_curated_dir)
+    queries_dir = Path("queries")
+
+    with Neo4jClient() as client:
+        summary = load_all(
+            client,
+            staging_dir,
+            curated_dir,
+            queries_dir,
+            strict=False,
+            skip_validation=skip_validation,
+            nodes_only=nodes_only,
+        )
+
+    print("\n=== Load Summary ===")
+    print(f"  Nodes loaded : {summary.total_nodes}")
+    print(f"  Edges loaded : {summary.total_edges}")
+
+    for nr in summary.node_results:
+        print(f"    {nr.node_type}: created={nr.created} merged={nr.merged} skipped={nr.skipped}")
+    for er in summary.edge_results:
+        print(
+            f"    {er.edge_type}: created={er.created} skipped={er.skipped}"
+            f" missing_endpoints={er.missing_endpoints}"
+        )
+
+    if summary.validation_results:
+        print("\n=== Validation ===")
+        for vr in summary.validation_results:
+            status = "PASS" if vr.passed else "FAIL"
+            print(f"  [{status}] {vr.query_name}: {vr.details}")
+        if not summary.validation_passed:
+            print("\nWARNING: Some validation checks failed.")
+            sys.exit(1)
+        else:
+            print("\nAll validation checks passed.")
+
+
+def _cmd_validate() -> None:
+    """Run graph validation queries against an existing Neo4j database."""
+    from pathlib import Path
+
+    from neo4j import GraphDatabase
+
+    from src.config import get_settings
+
+    settings = get_settings()
+
+    # Pre-flight connectivity check
+    print("Checking Neo4j connectivity...")
+    try:
+        driver = GraphDatabase.driver(
+            settings.neo4j.uri,
+            auth=(settings.neo4j.user, settings.neo4j.password),
+        )
+        driver.verify_connectivity()
+        driver.close()
+    except Exception as exc:
+        print(f"ERROR: Cannot connect to Neo4j at {settings.neo4j.uri}: {exc}")
+        sys.exit(1)
+
+    from src.graph.validate import run_validation
+    from src.utils.neo4j_client import Neo4jClient
+
+    queries_dir = Path("queries")
+
+    with Neo4jClient() as client:
+        results = run_validation(client, queries_dir)
+
+    if not results:
+        print("No validation queries found.")
+        sys.exit(0)
+
+    print("=== Validation Results ===")
+    all_passed = True
+    for vr in results:
+        status = "PASS" if vr.passed else "FAIL"
+        print(f"  [{status}] {vr.query_name}: {vr.details}")
+        if not vr.passed:
+            all_passed = False
+
+    if not all_passed:
+        print("\nWARNING: Some validation checks failed.")
+        sys.exit(1)
+    else:
+        print("\nAll validation checks passed.")
+
+
 def _cmd_stub(name: str) -> None:
     """Print a not-yet-implemented message for a pipeline stage."""
     print(f"Command '{name}' not yet implemented. See Makefile targets.")
@@ -114,7 +230,13 @@ def main() -> None:
     subparsers.add_parser("acquire", help="Download data sources")
     subparsers.add_parser("parse", help="Parse raw data to staging")
     subparsers.add_parser("resolve", help="Entity resolution")
-    subparsers.add_parser("load", help="Load graph database")
+    load_parser = subparsers.add_parser("load", help="Load graph database")
+    load_parser.add_argument(
+        "--skip-validation", action="store_true", help="Skip validation queries after loading"
+    )
+    load_parser.add_argument(
+        "--nodes-only", action="store_true", help="Load only nodes (skip edges and validation)"
+    )
     subparsers.add_parser("enrich", help="Compute metrics and enrichment")
     subparsers.add_parser("validate", help="Run graph validation queries")
     subparsers.add_parser("validate-staging", help="Validate staging Parquet files")
@@ -141,6 +263,13 @@ def main() -> None:
         validate_staging(Path(settings.data_staging_dir))
     elif args.command == "resolve":
         _cmd_resolve()
+    elif args.command == "load":
+        _cmd_load(
+            skip_validation=args.skip_validation,
+            nodes_only=args.nodes_only,
+        )
+    elif args.command == "validate":
+        _cmd_validate()
     else:
         _cmd_stub(args.command)
 

--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -1,1 +1,109 @@
 """Phase 3: Neo4j node/edge loaders and validation queries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.graph.load_edges import EdgeLoadResult, load_all_edges
+from src.graph.load_nodes import LoadResult, load_all_nodes
+from src.graph.validate import ValidationResult, run_validation
+from src.utils.logging import get_logger
+from src.utils.neo4j_client import Neo4jClient
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "EdgeLoadResult",
+    "LoadResult",
+    "LoadSummary",
+    "ValidationResult",
+    "load_all",
+    "load_all_edges",
+    "load_all_nodes",
+    "run_validation",
+]
+
+
+@dataclass(frozen=True)
+class LoadSummary:
+    """Full pipeline outcome: nodes + edges + validation."""
+
+    node_results: list[LoadResult]
+    edge_results: list[EdgeLoadResult]
+    validation_results: list[ValidationResult] = field(default_factory=list)
+    total_nodes: int = 0
+    total_edges: int = 0
+    validation_passed: bool = True
+
+
+def load_all(
+    client: Neo4jClient,
+    staging_dir: Path,
+    curated_dir: Path,
+    queries_dir: Path,
+    *,
+    strict: bool = True,
+    skip_validation: bool = False,
+    nodes_only: bool = False,
+) -> LoadSummary:
+    """Full graph loading pipeline: nodes -> edges -> validate.
+
+    Parameters
+    ----------
+    client:
+        Connected Neo4j client.
+    staging_dir:
+        Directory containing staging Parquet files.
+    curated_dir:
+        Directory containing curated reference data (YAML).
+    queries_dir:
+        Root queries directory (contains ``validation/`` subdirectory).
+    strict:
+        If ``True``, raise on missing required data files.
+    skip_validation:
+        If ``True``, skip validation queries after loading.
+    nodes_only:
+        If ``True``, load only nodes (skip edges and validation).
+    """
+    logger.info(
+        "load_all_start", strict=strict, skip_validation=skip_validation, nodes_only=nodes_only
+    )
+
+    # 1. Load nodes
+    node_results = load_all_nodes(client, staging_dir, curated_dir, strict=strict)
+    total_nodes = sum(r.created + r.merged for r in node_results)
+    logger.info("load_all_nodes_done", total_nodes=total_nodes)
+
+    # 2. Load edges (unless nodes_only)
+    edge_results: list[EdgeLoadResult] = []
+    total_edges = 0
+    if not nodes_only:
+        edge_results = load_all_edges(client, staging_dir, curated_dir, strict=strict)
+        total_edges = sum(r.created for r in edge_results)
+        logger.info("load_all_edges_done", total_edges=total_edges)
+
+    # 3. Validate (unless skipped or nodes_only)
+    validation_results: list[ValidationResult] = []
+    validation_passed = True
+    if not skip_validation and not nodes_only:
+        validation_results = run_validation(client, queries_dir)
+        validation_passed = all(v.passed for v in validation_results)
+        status = "PASS" if validation_passed else "FAIL"
+        logger.info("load_all_validation_done", status=status, checks=len(validation_results))
+
+    summary = LoadSummary(
+        node_results=node_results,
+        edge_results=edge_results,
+        validation_results=validation_results,
+        total_nodes=total_nodes,
+        total_edges=total_edges,
+        validation_passed=validation_passed,
+    )
+    logger.info(
+        "load_all_complete",
+        total_nodes=total_nodes,
+        total_edges=total_edges,
+        validation_passed=validation_passed,
+    )
+    return summary

--- a/src/graph/validate.py
+++ b/src/graph/validate.py
@@ -1,0 +1,127 @@
+"""Graph validation query runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.utils.logging import get_logger
+from src.utils.neo4j_client import Neo4jClient
+
+logger = get_logger(__name__)
+
+__all__ = ["run_validation", "ValidationResult"]
+
+_DEFAULT_DEVIATION_THRESHOLD = 10.0
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of a single validation query."""
+
+    query_name: str
+    passed: bool
+    details: str
+    row_count: int
+
+
+def _classify(
+    query_name: str,
+    rows: list[dict[str, object]],
+    *,
+    deviation_threshold: float = _DEFAULT_DEVIATION_THRESHOLD,
+) -> ValidationResult:
+    """Classify query results as pass/fail based on query semantics."""
+    count = len(rows)
+
+    if query_name == "orphan_narrators":
+        passed = count == 0
+        details = "no orphans" if passed else f"{count} orphan narrator(s) found"
+        return ValidationResult(query_name, passed, details, count)
+
+    if query_name == "chain_integrity":
+        passed = count == 0
+        details = "no cycles" if passed else f"{count} cycle(s) detected"
+        return ValidationResult(query_name, passed, details, count)
+
+    if query_name == "collection_coverage":
+        failures: list[str] = []
+        for row in rows:
+            dev = row.get("deviation_pct")
+            if dev is not None and isinstance(dev, (int, float)) and dev > deviation_threshold:
+                cid = row.get("collection_id", "?")
+                failures.append(f"{cid}: {dev:.1f}% deviation")
+        passed = len(failures) == 0
+        details = "all within threshold" if passed else "; ".join(failures)
+        return ValidationResult(query_name, passed, details, count)
+
+    # Unknown query — pass if 0 rows (conservative default)
+    passed = count == 0
+    details = f"{count} row(s) returned" if count else "empty result"
+    return ValidationResult(query_name, passed, details, count)
+
+
+def run_validation(
+    client: Neo4jClient,
+    queries_dir: Path,
+    *,
+    deviation_threshold: float = _DEFAULT_DEVIATION_THRESHOLD,
+) -> list[ValidationResult]:
+    """Run all ``.cypher`` files in ``queries_dir/validation/``.
+
+    Parameters
+    ----------
+    client:
+        Connected Neo4j client.
+    queries_dir:
+        Root queries directory (must contain a ``validation/`` subdirectory).
+    deviation_threshold:
+        Maximum acceptable deviation percentage for collection coverage.
+
+    Returns
+    -------
+    list[ValidationResult]
+        One result per query file executed.
+    """
+    validation_dir = queries_dir / "validation"
+    if not validation_dir.is_dir():
+        logger.warning("validation_dir_missing", path=str(validation_dir))
+        return []
+
+    cypher_files = sorted(validation_dir.glob("*.cypher"))
+    if not cypher_files:
+        logger.warning("no_validation_queries", path=str(validation_dir))
+        return []
+
+    results: list[ValidationResult] = []
+    for fp in cypher_files:
+        query_name = fp.stem
+        cypher_text = fp.read_text(encoding="utf-8").strip()
+        if not cypher_text:
+            logger.warning("empty_cypher_file", file=fp.name)
+            continue
+
+        logger.info("validation_running", query=query_name)
+        try:
+            rows = client.execute_read(cypher_text)
+        except Exception:
+            logger.exception("validation_query_failed", query=query_name)
+            results.append(
+                ValidationResult(
+                    query_name, passed=False, details="query execution failed", row_count=0
+                )
+            )
+            continue
+
+        result = _classify(query_name, rows, deviation_threshold=deviation_threshold)
+        status = "PASS" if result.passed else "FAIL"
+        logger.info(
+            "validation_complete",
+            query=query_name,
+            status=status,
+            rows=result.row_count,
+            details=result.details,
+        )
+        results.append(result)
+
+    return results


### PR DESCRIPTION
## Summary
- 3 Cypher validation queries: orphan narrators, chain integrity, collection coverage
- Graph validation runner (`src/graph/validate.py`) with pass/fail classification
- `LoadSummary` orchestrator in `src/graph/__init__.py`: nodes -> edges -> validate
- CLI flags: `--skip-validation`, `--nodes-only` on `isnad load`
- `isnad validate` command for standalone validation
- Makefile `load` target wired to `uv run isnad load`

## Related Issues
Closes #92

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>