### PR TITLE
Tech debt: Replace _transpose_pydict with table.to_pylist()

### DIFF
--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -44,19 +44,11 @@ def _parquet_files(directory: Path, prefix: str) -> list[Path]:
     return sorted(directory.glob(f"{prefix}*.parquet"))
 
 
-def _transpose_pydict(col_dict: dict[str, list[Any]]) -> list[dict[str, Any]]:
-    """Convert column-oriented dict ``{col: [vals]}`` to ``[{col: val}, ...]``."""
-    if not col_dict:
-        return []
-    keys = list(col_dict.keys())
-    n = len(col_dict[keys[0]])
-    return [{k: col_dict[k][i] for k in keys} for i in range(n)]
-
-
 def _read_parquet_rows(path: Path) -> list[dict[str, Any]]:
     """Read a Parquet file and return row dicts."""
     table = pq.read_table(path)
-    return _transpose_pydict(table.to_pydict())
+    rows: list[dict[str, Any]] = table.to_pylist()
+    return rows
 
 
 def _val(row: dict[str, Any], key: str, default: Any = None) -> Any:


### PR DESCRIPTION
## Summary
- Replace custom `_transpose_pydict` with PyArrow `table.to_pylist()` in `src/graph/load_nodes.py` (#100)
- Removes 8 lines of manual column-to-row transposition in favor of a single built-in call

## Related Issues
Closes #100

Co-Authored-By: Kwame Asante <parametrization+Kwame.Asante@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>