### PR TITLE
Tech debt: Validation registry pattern + CLI pre-flight extraction

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -13,6 +13,27 @@ def _mask_password(value: str) -> str:
     return value[0] + "*" * (len(value) - 2) + value[-1]
 
 
+def _check_neo4j() -> None:
+    """Pre-flight Neo4j connectivity check. Exits with code 1 on failure."""
+    from neo4j import GraphDatabase
+
+    from src.config import get_settings
+
+    settings = get_settings()
+    print("Checking Neo4j connectivity...")
+    try:
+        driver = GraphDatabase.driver(
+            settings.neo4j.uri,
+            auth=(settings.neo4j.user, settings.neo4j.password),
+        )
+        driver.verify_connectivity()
+        driver.close()
+    except Exception as exc:
+        print(f"ERROR: Cannot connect to Neo4j at {settings.neo4j.uri}: {exc}")
+        sys.exit(1)
+    print("  Neo4j is reachable.")
+
+
 def _cmd_info() -> None:
     """Print configuration (masked passwords) and check DB connectivity."""
     from src.config import get_settings
@@ -104,25 +125,11 @@ def _cmd_load(*, skip_validation: bool = False, nodes_only: bool = False) -> Non
     """Run the Phase 3 graph loading pipeline."""
     from pathlib import Path
 
-    from neo4j import GraphDatabase
-
     from src.config import get_settings
 
     settings = get_settings()
 
-    # Pre-flight Neo4j connectivity check
-    print("Checking Neo4j connectivity...")
-    try:
-        driver = GraphDatabase.driver(
-            settings.neo4j.uri,
-            auth=(settings.neo4j.user, settings.neo4j.password),
-        )
-        driver.verify_connectivity()
-        driver.close()
-    except Exception as exc:
-        print(f"ERROR: Cannot connect to Neo4j at {settings.neo4j.uri}: {exc}")
-        sys.exit(1)
-    print("  Neo4j is reachable.")
+    _check_neo4j()
 
     from src.graph import load_all
     from src.utils.neo4j_client import Neo4jClient
@@ -170,24 +177,7 @@ def _cmd_validate() -> None:
     """Run graph validation queries against an existing Neo4j database."""
     from pathlib import Path
 
-    from neo4j import GraphDatabase
-
-    from src.config import get_settings
-
-    settings = get_settings()
-
-    # Pre-flight connectivity check
-    print("Checking Neo4j connectivity...")
-    try:
-        driver = GraphDatabase.driver(
-            settings.neo4j.uri,
-            auth=(settings.neo4j.user, settings.neo4j.password),
-        )
-        driver.verify_connectivity()
-        driver.close()
-    except Exception as exc:
-        print(f"ERROR: Cannot connect to Neo4j at {settings.neo4j.uri}: {exc}")
-        sys.exit(1)
+    _check_neo4j()
 
     from src.graph.validate import run_validation
     from src.utils.neo4j_client import Neo4jClient

--- a/src/graph/validate.py
+++ b/src/graph/validate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -25,6 +26,70 @@ class ValidationResult:
     row_count: int
 
 
+ClassifierFunc = Callable[
+    [str, list[dict[str, object]], float],
+    ValidationResult,
+]
+
+
+def _classify_orphan_narrators(
+    query_name: str,
+    rows: list[dict[str, object]],
+    deviation_threshold: float,
+) -> ValidationResult:
+    count = len(rows)
+    passed = count == 0
+    details = "no orphans" if passed else f"{count} orphan narrator(s) found"
+    return ValidationResult(query_name, passed, details, count)
+
+
+def _classify_chain_integrity(
+    query_name: str,
+    rows: list[dict[str, object]],
+    deviation_threshold: float,
+) -> ValidationResult:
+    count = len(rows)
+    passed = count == 0
+    details = "no cycles" if passed else f"{count} cycle(s) detected"
+    return ValidationResult(query_name, passed, details, count)
+
+
+def _classify_collection_coverage(
+    query_name: str,
+    rows: list[dict[str, object]],
+    deviation_threshold: float,
+) -> ValidationResult:
+    count = len(rows)
+    failures: list[str] = []
+    for row in rows:
+        dev = row.get("deviation_pct")
+        if dev is not None and isinstance(dev, (int, float)) and dev > deviation_threshold:
+            cid = row.get("collection_id", "?")
+            failures.append(f"{cid}: {dev:.1f}% deviation")
+    passed = len(failures) == 0
+    details = "all within threshold" if passed else "; ".join(failures)
+    return ValidationResult(query_name, passed, details, count)
+
+
+def _classify_default(
+    query_name: str,
+    rows: list[dict[str, object]],
+    deviation_threshold: float,
+) -> ValidationResult:
+    """Default classifier — pass if 0 rows (conservative)."""
+    count = len(rows)
+    passed = count == 0
+    details = f"{count} row(s) returned" if count else "empty result"
+    return ValidationResult(query_name, passed, details, count)
+
+
+_CLASSIFIER_REGISTRY: dict[str, ClassifierFunc] = {
+    "orphan_narrators": _classify_orphan_narrators,
+    "chain_integrity": _classify_chain_integrity,
+    "collection_coverage": _classify_collection_coverage,
+}
+
+
 def _classify(
     query_name: str,
     rows: list[dict[str, object]],
@@ -32,33 +97,8 @@ def _classify(
     deviation_threshold: float = _DEFAULT_DEVIATION_THRESHOLD,
 ) -> ValidationResult:
     """Classify query results as pass/fail based on query semantics."""
-    count = len(rows)
-
-    if query_name == "orphan_narrators":
-        passed = count == 0
-        details = "no orphans" if passed else f"{count} orphan narrator(s) found"
-        return ValidationResult(query_name, passed, details, count)
-
-    if query_name == "chain_integrity":
-        passed = count == 0
-        details = "no cycles" if passed else f"{count} cycle(s) detected"
-        return ValidationResult(query_name, passed, details, count)
-
-    if query_name == "collection_coverage":
-        failures: list[str] = []
-        for row in rows:
-            dev = row.get("deviation_pct")
-            if dev is not None and isinstance(dev, (int, float)) and dev > deviation_threshold:
-                cid = row.get("collection_id", "?")
-                failures.append(f"{cid}: {dev:.1f}% deviation")
-        passed = len(failures) == 0
-        details = "all within threshold" if passed else "; ".join(failures)
-        return ValidationResult(query_name, passed, details, count)
-
-    # Unknown query — pass if 0 rows (conservative default)
-    passed = count == 0
-    details = f"{count} row(s) returned" if count else "empty result"
-    return ValidationResult(query_name, passed, details, count)
+    classifier = _CLASSIFIER_REGISTRY.get(query_name, _classify_default)
+    return classifier(query_name, rows, deviation_threshold)
 
 
 def run_validation(


### PR DESCRIPTION
## Summary
- Replace hardcoded `_classify()` if/elif dispatch with dict-based `_CLASSIFIER_REGISTRY` pattern (#106)
- Extract shared `_check_neo4j()` pre-flight helper in CLI, replacing duplicated blocks in `_cmd_load()` and `_cmd_validate()` (#107)

## Related Issues
Closes #106, Closes #107

## Test plan
- [x] `uv run ruff check src/graph/validate.py src/cli.py` — all checks passed
- [x] `uv run mypy src/graph/validate.py src/cli.py` — no issues
- [x] `uv run pytest tests/test_graph/test_validate.py -v` — 15/15 passed

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>