### PR TITLE
Phase 5: Timeline, Comparative, Graph Explorer pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,12 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
-    "@tanstack/react-query": "^5.0.0"
+    "@tanstack/react-query": "^5.0.0",
+    "d3": "^7.0.0",
+    "react-force-graph-2d": "^1.0.0"
   },
   "devDependencies": {
+    "@types/d3": "^7.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,9 @@ import HadithsPage from './pages/HadithsPage'
 import CollectionsPage from './pages/CollectionsPage'
 import SearchPage from './pages/SearchPage'
 import TimelinePage from './pages/TimelinePage'
+import ComparativePage from './pages/ComparativePage'
+import GraphExplorerPage from './pages/GraphExplorerPage'
+import NarratorDetailPage from './pages/NarratorDetailPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -24,10 +27,13 @@ export default function App() {
           <Route element={<Layout />}>
             <Route index element={<Navigate to="/narrators" replace />} />
             <Route path="narrators" element={<NarratorsPage />} />
+            <Route path="narrators/:id" element={<NarratorDetailPage />} />
             <Route path="hadiths" element={<HadithsPage />} />
             <Route path="collections" element={<CollectionsPage />} />
             <Route path="search" element={<SearchPage />} />
             <Route path="timeline" element={<TimelinePage />} />
+            <Route path="compare" element={<ComparativePage />} />
+            <Route path="graph" element={<GraphExplorerPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,14 @@
-import type { PaginatedResponse, Narrator, Hadith, Collection, SearchResult } from '../types/api'
+import type {
+  PaginatedResponse,
+  Narrator,
+  Hadith,
+  Collection,
+  Chain,
+  SearchResult,
+  TimelineEvent,
+  ParallelPair,
+  GraphNetwork,
+} from '../types/api'
 
 const API_BASE = '/api/v1'
 
@@ -13,12 +23,19 @@ async function fetchJson<T>(url: string): Promise<T> {
 export async function fetchNarrators(
   page = 1,
   limit = 20,
+  search?: string,
 ): Promise<PaginatedResponse<Narrator>> {
-  return fetchJson(`${API_BASE}/narrators?page=${page}&limit=${limit}`)
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (search) params.set('q', search)
+  return fetchJson(`${API_BASE}/narrators?${params}`)
 }
 
 export async function fetchNarrator(id: string): Promise<Narrator> {
   return fetchJson(`${API_BASE}/narrators/${encodeURIComponent(id)}`)
+}
+
+export async function fetchNarratorChains(id: string): Promise<Chain[]> {
+  return fetchJson(`${API_BASE}/narrators/${encodeURIComponent(id)}/chains`)
 }
 
 export async function fetchHadiths(
@@ -32,6 +49,10 @@ export async function fetchHadith(id: string): Promise<Hadith> {
   return fetchJson(`${API_BASE}/hadiths/${encodeURIComponent(id)}`)
 }
 
+export async function fetchHadithParallels(id: string): Promise<Hadith[]> {
+  return fetchJson(`${API_BASE}/hadiths/${encodeURIComponent(id)}/parallels`)
+}
+
 export async function fetchCollections(
   page = 1,
   limit = 20,
@@ -43,11 +64,53 @@ export async function fetchCollection(id: string): Promise<Collection> {
   return fetchJson(`${API_BASE}/collections/${encodeURIComponent(id)}`)
 }
 
+export async function fetchCollectionHadiths(
+  id: string,
+  page = 1,
+  limit = 20,
+): Promise<PaginatedResponse<Hadith>> {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  return fetchJson(`${API_BASE}/collections/${encodeURIComponent(id)}/hadiths?${params}`)
+}
+
+export async function fetchTimeline(
+  yearStart?: number,
+  yearEnd?: number,
+): Promise<TimelineEvent[]> {
+  const params = new URLSearchParams()
+  if (yearStart != null) params.set('year_start', String(yearStart))
+  if (yearEnd != null) params.set('year_end', String(yearEnd))
+  const qs = params.toString()
+  return fetchJson(`${API_BASE}/timeline${qs ? `?${qs}` : ''}`)
+}
+
+export async function fetchParallels(
+  page = 1,
+  limit = 20,
+): Promise<PaginatedResponse<ParallelPair>> {
+  return fetchJson(`${API_BASE}/parallels?page=${page}&limit=${limit}`)
+}
+
+export async function fetchGraphNetwork(
+  narratorId: string,
+  depth = 1,
+): Promise<GraphNetwork> {
+  const params = new URLSearchParams({
+    narrator_id: narratorId,
+    depth: String(depth),
+  })
+  return fetchJson(`${API_BASE}/graph/network?${params}`)
+}
+
 export async function searchAll(
   query: string,
+  mode: 'fulltext' | 'semantic' = 'fulltext',
   limit = 20,
 ): Promise<SearchResult[]> {
-  return fetchJson(
-    `${API_BASE}/search?q=${encodeURIComponent(query)}&limit=${limit}`,
-  )
+  const params = new URLSearchParams({
+    q: query,
+    mode,
+    limit: String(limit),
+  })
+  return fetchJson(`${API_BASE}/search?${params}`)
 }

--- a/frontend/src/components/ForceGraph.tsx
+++ b/frontend/src/components/ForceGraph.tsx
@@ -1,0 +1,101 @@
+import { useRef, useEffect, useCallback } from 'react'
+import ForceGraph2D, { type ForceGraphMethods } from 'react-force-graph-2d'
+import type { GraphNode, GraphEdge } from '../types/api'
+
+const COMMUNITY_COLORS = [
+  '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+  '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
+  '#aec7e8', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5',
+]
+
+function communityColor(id: number | null): string {
+  if (id == null) return '#999'
+  return COMMUNITY_COLORS[id % COMMUNITY_COLORS.length] ?? '#999'
+}
+
+interface ForceGraphProps {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  onNodeClick?: (nodeId: string) => void
+  width?: number
+  height?: number
+}
+
+interface InternalNode {
+  id: string
+  label: string
+  community_id: number | null
+  type: string
+  x?: number
+  y?: number
+}
+
+export default function ForceGraph({ nodes, edges, onNodeClick, width, height }: ForceGraphProps) {
+  const fgRef = useRef<ForceGraphMethods | undefined>(undefined)
+
+  const graphData = {
+    nodes: nodes.map((n): InternalNode => ({ ...n })),
+    links: edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      relationship: e.relationship,
+    })),
+  }
+
+  useEffect(() => {
+    if (fgRef.current) {
+      fgRef.current.d3Force('charge')?.strength(-120)
+    }
+  }, [])
+
+  const handleNodeClick = useCallback(
+    (node: { id?: string | number }) => {
+      if (onNodeClick && node.id != null) {
+        onNodeClick(String(node.id))
+      }
+    },
+    [onNodeClick],
+  )
+
+  const nodeCanvasObject = useCallback(
+    (node: InternalNode, ctx: CanvasRenderingContext2D) => {
+      const x = node.x ?? 0
+      const y = node.y ?? 0
+      const radius = 6
+      const color = communityColor(node.community_id)
+
+      ctx.beginPath()
+      ctx.arc(x, y, radius, 0, 2 * Math.PI)
+      ctx.fillStyle = color
+      ctx.fill()
+      ctx.strokeStyle = '#fff'
+      ctx.lineWidth = 1.5
+      ctx.stroke()
+
+      const label = node.label ?? String(node.id)
+      if (label) {
+        ctx.font = '4px sans-serif'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'top'
+        ctx.fillStyle = '#333'
+        ctx.fillText(label, x, y + radius + 2)
+      }
+    },
+    [],
+  )
+
+  return (
+    <ForceGraph2D
+      ref={fgRef}
+      graphData={graphData}
+      width={width}
+      height={height ?? 600}
+      nodeCanvasObject={nodeCanvasObject}
+      onNodeClick={handleNodeClick}
+      linkDirectionalArrowLength={4}
+      linkDirectionalArrowRelPos={1}
+      linkColor={() => '#ccc'}
+      cooldownTicks={100}
+    />
+  )
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -6,6 +6,8 @@ const navItems = [
   { to: '/collections', label: 'Collections' },
   { to: '/search', label: 'Search' },
   { to: '/timeline', label: 'Timeline' },
+  { to: '/compare', label: 'Compare' },
+  { to: '/graph', label: 'Graph Explorer' },
 ]
 
 export default function Sidebar() {

--- a/frontend/src/pages/ComparativePage.tsx
+++ b/frontend/src/pages/ComparativePage.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchParallels } from '../api/client'
+
+export default function ComparativePage() {
+  const [page, setPage] = useState(1)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['parallels', page],
+    queryFn: () => fetchParallels(page, 10),
+  })
+
+  return (
+    <div>
+      <h2>Comparative Analysis</h2>
+      <p style={{ color: '#666', marginBottom: '1rem' }}>
+        Side-by-side comparison of parallel Sunni and Shia hadiths (PARALLEL_OF relationships).
+      </p>
+
+      {isLoading && <p>Loading parallels...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+            {data.items.map((pair, idx) => (
+              <div
+                key={`${pair.sunni_hadith.id}-${pair.shia_hadith.id}`}
+                style={{
+                  border: '1px solid #ddd',
+                  borderRadius: 8,
+                  overflow: 'hidden',
+                }}
+              >
+                <div
+                  style={{
+                    padding: '0.5rem 1rem',
+                    background: '#f5f5f5',
+                    borderBottom: '1px solid #ddd',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <span style={{ fontWeight: 600 }}>Parallel #{(page - 1) * 10 + idx + 1}</span>
+                  <SimilarityBadge score={pair.similarity_score} />
+                </div>
+
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', minHeight: 120 }}>
+                  <HadithPanel label="Sunni" hadith={pair.sunni_hadith} color="#1a73e8" />
+                  <HadithPanel label="Shia" hadith={pair.shia_hadith} color="#e8501a" />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{ marginTop: '1.5rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}
+          >
+            <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              Previous
+            </button>
+            <span>
+              Page {data.page} of {data.pages}
+            </span>
+            <button disabled={page >= data.pages} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function SimilarityBadge({ score }: { score: number }) {
+  const pct = Math.round(score * 100)
+  const bg = score >= 0.8 ? '#2ca02c' : score >= 0.5 ? '#ff7f0e' : '#d62728'
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.15rem 0.5rem',
+        borderRadius: 12,
+        background: bg,
+        color: '#fff',
+        fontSize: '0.8rem',
+        fontWeight: 600,
+      }}
+    >
+      {pct}% similar
+    </span>
+  )
+}
+
+function HadithPanel({
+  label,
+  hadith,
+  color,
+}: {
+  label: string
+  hadith: {
+    collection_name: string | null
+    hadith_number: string
+    text_arabic: string
+    text_english: string | null
+    grade: string | null
+  }
+  color: string
+}) {
+  return (
+    <div style={{ padding: '1rem', borderRight: '1px solid #eee' }}>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <span
+          style={{
+            fontWeight: 600,
+            color,
+            fontSize: '0.85rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {label}
+        </span>
+        {hadith.collection_name && (
+          <span style={{ marginLeft: '0.5rem', color: '#666', fontSize: '0.8rem' }}>
+            {hadith.collection_name} #{hadith.hadith_number}
+          </span>
+        )}
+        {hadith.grade && (
+          <span
+            style={{
+              marginLeft: '0.5rem',
+              padding: '0.1rem 0.4rem',
+              background: '#eee',
+              borderRadius: 4,
+              fontSize: '0.75rem',
+            }}
+          >
+            {hadith.grade}
+          </span>
+        )}
+      </div>
+      <p style={{ direction: 'rtl', textAlign: 'right', lineHeight: 1.8, margin: '0.5rem 0' }}>
+        {hadith.text_arabic}
+      </p>
+      {hadith.text_english && (
+        <p style={{ color: '#555', fontSize: '0.9rem', margin: '0.5rem 0' }}>
+          {hadith.text_english}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -1,0 +1,183 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchGraphNetwork, fetchNarrators } from '../api/client'
+import ForceGraph from '../components/ForceGraph'
+import type { GraphNode, GraphEdge } from '../types/api'
+
+export default function GraphExplorerPage() {
+  const [searchInput, setSearchInput] = useState('')
+  const [selectedNarratorId, setSelectedNarratorId] = useState<string | null>(null)
+  const [depth, setDepth] = useState(1)
+  const [allNodes, setAllNodes] = useState<GraphNode[]>([])
+  const [allEdges, setAllEdges] = useState<GraphEdge[]>([])
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 })
+
+  const { data: searchResults } = useQuery({
+    queryKey: ['narrator-search', searchInput],
+    queryFn: () => fetchNarrators(1, 10),
+    enabled: searchInput.length > 0,
+  })
+
+  const { data: networkData, isLoading } = useQuery({
+    queryKey: ['graph-network', selectedNarratorId, depth],
+    queryFn: () => fetchGraphNetwork(selectedNarratorId!, depth),
+    enabled: selectedNarratorId != null,
+  })
+
+  useEffect(() => {
+    if (!networkData) return
+    setAllNodes((prev) => {
+      const existing = new Set(prev.map((n) => n.id))
+      const newNodes = networkData.nodes.filter((n) => !existing.has(n.id))
+      return [...prev, ...newNodes]
+    })
+    setAllEdges((prev) => {
+      const existing = new Set(prev.map((e) => `${e.source}-${e.target}`))
+      const newEdges = networkData.edges.filter((e) => !existing.has(`${e.source}-${e.target}`))
+      return [...prev, ...newEdges]
+    })
+  }, [networkData])
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) {
+        setDimensions({
+          width: entry.contentRect.width,
+          height: Math.max(500, entry.contentRect.height),
+        })
+      }
+    })
+    observer.observe(containerRef.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const handleNodeClick = useCallback((nodeId: string) => {
+    setSelectedNarratorId(nodeId)
+  }, [])
+
+  const handleReset = useCallback(() => {
+    setAllNodes([])
+    setAllEdges([])
+    setSelectedNarratorId(null)
+    setSearchInput('')
+  }, [])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 120px)' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        <h2 style={{ margin: '0 0 0.5rem' }}>Graph Explorer</h2>
+        <p style={{ color: '#666', margin: '0 0 1rem' }}>
+          Interactive force-directed graph. Search for a narrator to start, then click nodes to
+          expand.
+        </p>
+
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          <input
+            type="text"
+            placeholder="Search for a narrator to start..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            style={{ padding: '0.5rem', width: 300 }}
+          />
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            Depth:
+            <select
+              value={depth}
+              onChange={(e) => setDepth(Number(e.target.value))}
+              style={{ padding: '0.25rem' }}
+            >
+              <option value={1}>1</option>
+              <option value={2}>2</option>
+              <option value={3}>3</option>
+            </select>
+          </label>
+          <button onClick={handleReset} style={{ padding: '0.5rem 1rem' }}>
+            Reset
+          </button>
+          {isLoading && <span style={{ color: '#666' }}>Loading...</span>}
+        </div>
+
+        {searchInput && searchResults && (
+          <div
+            style={{
+              marginTop: '0.5rem',
+              border: '1px solid #ddd',
+              borderRadius: 4,
+              maxHeight: 200,
+              overflowY: 'auto',
+              background: '#fff',
+              position: 'relative',
+              zIndex: 10,
+              maxWidth: 400,
+            }}
+          >
+            {searchResults.items.map((n) => (
+              <div
+                key={n.id}
+                onClick={() => {
+                  setSelectedNarratorId(n.id)
+                  setSearchInput('')
+                }}
+                style={{
+                  padding: '0.5rem',
+                  cursor: 'pointer',
+                  borderBottom: '1px solid #eee',
+                }}
+              >
+                <span style={{ direction: 'rtl' }}>{n.name_arabic}</span>
+                {n.name_transliterated && (
+                  <span style={{ marginLeft: '0.5rem', color: '#666' }}>
+                    ({n.name_transliterated})
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div
+        ref={containerRef}
+        style={{
+          flex: 1,
+          border: '1px solid #ddd',
+          borderRadius: 6,
+          overflow: 'hidden',
+          background: '#fafafa',
+          minHeight: 400,
+        }}
+      >
+        {allNodes.length > 0 ? (
+          <ForceGraph
+            nodes={allNodes}
+            edges={allEdges}
+            onNodeClick={handleNodeClick}
+            width={dimensions.width}
+            height={dimensions.height}
+          />
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+              color: '#999',
+            }}
+          >
+            Search for a narrator above to begin exploring the graph.
+          </div>
+        )}
+      </div>
+
+      {allNodes.length > 0 && (
+        <div style={{ marginTop: '0.5rem', color: '#666', fontSize: '0.85rem' }}>
+          {allNodes.length} nodes, {allEdges.length} edges loaded
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -1,8 +1,95 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { fetchHadiths } from '../api/client'
+
 export default function HadithsPage() {
+  const [page, setPage] = useState(1)
+  const navigate = useNavigate()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['hadiths', page],
+    queryFn: () => fetchHadiths(page, 20),
+  })
+
   return (
     <div>
       <h2>Hadiths</h2>
-      <p>Browse and search hadith texts. Coming soon.</p>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
+                <th style={{ padding: '0.5rem' }}>Collection</th>
+                <th style={{ padding: '0.5rem' }}>Number</th>
+                <th style={{ padding: '0.5rem' }}>Grade</th>
+                <th style={{ padding: '0.5rem' }}>Topics</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((h) => (
+                <tr
+                  key={h.id}
+                  onClick={() => navigate(`/hadiths/${h.id}`)}
+                  style={{ borderBottom: '1px solid #eee', cursor: 'pointer' }}
+                >
+                  <td style={{ padding: '0.5rem' }}>{h.collection_name ?? h.collection_id}</td>
+                  <td style={{ padding: '0.5rem' }}>{h.hadith_number}</td>
+                  <td style={{ padding: '0.5rem' }}>
+                    {h.grade && (
+                      <span
+                        style={{
+                          padding: '0.15rem 0.5rem',
+                          borderRadius: 4,
+                          fontSize: '0.85rem',
+                          background: h.grade.toLowerCase() === 'sahih' ? '#e6f4ea' : '#fef7e0',
+                          color: h.grade.toLowerCase() === 'sahih' ? '#137333' : '#b06000',
+                        }}
+                      >
+                        {h.grade}
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ padding: '0.5rem' }}>
+                    {h.topics?.map((t) => (
+                      <span
+                        key={t.label}
+                        style={{
+                          display: 'inline-block',
+                          marginRight: '0.25rem',
+                          padding: '0.1rem 0.4rem',
+                          borderRadius: 3,
+                          fontSize: '0.8rem',
+                          background: '#e8eaf6',
+                          color: '#283593',
+                        }}
+                      >
+                        {t.label}
+                      </span>
+                    ))}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              Previous
+            </button>
+            <span>
+              Page {data.page} of {data.pages}
+            </span>
+            <button disabled={page >= data.pages} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </button>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/NarratorDetailPage.tsx
+++ b/frontend/src/pages/NarratorDetailPage.tsx
@@ -1,0 +1,118 @@
+import { useParams, Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { fetchNarrator, fetchNarratorChains } from '../api/client'
+
+export default function NarratorDetailPage() {
+  const { id } = useParams<{ id: string }>()
+
+  const {
+    data: narrator,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['narrator', id],
+    queryFn: () => fetchNarrator(id!),
+    enabled: !!id,
+  })
+
+  const { data: chains } = useQuery({
+    queryKey: ['narrator-chains', id],
+    queryFn: () => fetchNarratorChains(id!),
+    enabled: !!id,
+  })
+
+  if (isLoading) return <p>Loading...</p>
+  if (error) return <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>
+  if (!narrator) return <p>Narrator not found.</p>
+
+  return (
+    <div>
+      <Link to="/narrators" style={{ color: '#1a73e8' }}>
+        &larr; Back to Narrators
+      </Link>
+
+      <h2 style={{ direction: 'rtl', textAlign: 'right', marginTop: '1rem' }}>
+        {narrator.name_arabic}
+      </h2>
+      {narrator.name_transliterated && (
+        <h3 style={{ color: '#555', fontWeight: 400 }}>{narrator.name_transliterated}</h3>
+      )}
+
+      <section style={{ marginTop: '1.5rem' }}>
+        <h3>Biography</h3>
+        <table style={{ borderCollapse: 'collapse' }}>
+          <tbody>
+            {[
+              ['Kunya', narrator.kunya],
+              ['Nisba', narrator.nisba],
+              ['Birth Year', narrator.birth_year != null ? `${narrator.birth_year} AH` : null],
+              ['Death Year', narrator.death_year != null ? `${narrator.death_year} AH` : null],
+              ['Generation', narrator.generation],
+              ['Reliability', narrator.reliability_grade],
+              ['Sect', narrator.sect],
+              ['Location', narrator.location],
+            ].map(
+              ([label, value]) =>
+                value && (
+                  <tr key={label as string} style={{ borderBottom: '1px solid #eee' }}>
+                    <td style={{ padding: '0.4rem 1rem 0.4rem 0', fontWeight: 600 }}>
+                      {label}
+                    </td>
+                    <td style={{ padding: '0.4rem 0' }}>{value}</td>
+                  </tr>
+                ),
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section style={{ marginTop: '1.5rem' }}>
+        <h3>Network Statistics</h3>
+        <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap' }}>
+          {[
+            ['In-Degree', narrator.in_degree],
+            ['Out-Degree', narrator.out_degree],
+            ['Betweenness', narrator.betweenness_centrality?.toFixed(4)],
+            ['PageRank', narrator.pagerank?.toFixed(4)],
+            ['Community', narrator.community_id != null ? `#${narrator.community_id}` : null],
+          ].map(
+            ([label, value]) =>
+              value != null && (
+                <div
+                  key={label as string}
+                  style={{
+                    padding: '0.75rem 1rem',
+                    border: '1px solid #ddd',
+                    borderRadius: 4,
+                    minWidth: 100,
+                    textAlign: 'center',
+                  }}
+                >
+                  <div style={{ fontSize: '0.75rem', color: '#666' }}>{label}</div>
+                  <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>{value}</div>
+                </div>
+              ),
+          )}
+        </div>
+      </section>
+
+      {chains && chains.length > 0 && (
+        <section style={{ marginTop: '1.5rem' }}>
+          <h3>Chains ({chains.length})</h3>
+          <ul style={{ paddingLeft: '1.25rem' }}>
+            {chains.map((chain) => (
+              <li key={chain.id} style={{ marginBottom: '0.5rem' }}>
+                <Link to={`/hadiths/${chain.hadith_id}`} style={{ color: '#1a73e8' }}>
+                  Hadith {chain.hadith_id}
+                </Link>
+                {!chain.is_complete && (
+                  <span style={{ color: '#999', marginLeft: '0.5rem' }}>(incomplete chain)</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/NarratorsPage.tsx
+++ b/frontend/src/pages/NarratorsPage.tsx
@@ -1,8 +1,89 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { fetchNarrators } from '../api/client'
+
 export default function NarratorsPage() {
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const [inputValue, setInputValue] = useState('')
+  const navigate = useNavigate()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['narrators', page, search],
+    queryFn: () => fetchNarrators(page, 20, search || undefined),
+  })
+
+  const handleSearch = () => {
+    setSearch(inputValue)
+    setPage(1)
+  }
+
   return (
     <div>
       <h2>Narrators</h2>
-      <p>Browse and search hadith narrators. Coming soon.</p>
+
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Search narrators..."
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          style={{ padding: '0.5rem', flex: 1, maxWidth: 400 }}
+        />
+        <button onClick={handleSearch} style={{ padding: '0.5rem 1rem' }}>
+          Search
+        </button>
+      </div>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
+                <th style={{ padding: '0.5rem' }}>Name (Arabic)</th>
+                <th style={{ padding: '0.5rem' }}>Name (Transliterated)</th>
+                <th style={{ padding: '0.5rem' }}>Generation</th>
+                <th style={{ padding: '0.5rem' }}>Reliability</th>
+                <th style={{ padding: '0.5rem' }}>Community</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((n) => (
+                <tr
+                  key={n.id}
+                  onClick={() => navigate(`/narrators/${n.id}`)}
+                  style={{ borderBottom: '1px solid #eee', cursor: 'pointer' }}
+                >
+                  <td style={{ padding: '0.5rem', direction: 'rtl' }}>{n.name_arabic}</td>
+                  <td style={{ padding: '0.5rem' }}>{n.name_transliterated ?? '-'}</td>
+                  <td style={{ padding: '0.5rem' }}>{n.generation ?? '-'}</td>
+                  <td style={{ padding: '0.5rem' }}>{n.reliability_grade ?? '-'}</td>
+                  <td style={{ padding: '0.5rem' }}>
+                    {n.community_id != null ? `#${n.community_id}` : '-'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              Previous
+            </button>
+            <span>
+              Page {data.page} of {data.pages}
+            </span>
+            <button disabled={page >= data.pages} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </button>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,8 +1,152 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import * as d3 from 'd3'
+import { fetchTimeline } from '../api/client'
+import type { TimelineEvent } from '../types/api'
+
+const MARGIN = { top: 30, right: 30, bottom: 40, left: 60 }
+
 export default function TimelinePage() {
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const [selectedEvent, setSelectedEvent] = useState<TimelineEvent | null>(null)
+  const [yearRange, setYearRange] = useState<[number, number]>([0, 300])
+
+  const { data: events, isLoading, error } = useQuery({
+    queryKey: ['timeline', yearRange[0], yearRange[1]],
+    queryFn: () => fetchTimeline(yearRange[0], yearRange[1]),
+  })
+
+  const handleEventClick = useCallback((event: TimelineEvent) => {
+    setSelectedEvent((prev) => (prev?.id === event.id ? null : event))
+  }, [])
+
+  useEffect(() => {
+    if (!events?.length || !svgRef.current) return
+
+    const svg = d3.select(svgRef.current)
+    const width = svgRef.current.clientWidth || 800
+    const height = Math.max(400, events.length * 30 + MARGIN.top + MARGIN.bottom)
+
+    svg.attr('height', height)
+    svg.selectAll('*').remove()
+
+    const allYears = events.flatMap((e) => [e.year_start, e.year_end ?? e.year_start])
+    const xMin = d3.min(allYears) ?? 0
+    const xMax = d3.max(allYears) ?? 300
+
+    const xScale = d3
+      .scaleLinear()
+      .domain([xMin - 10, xMax + 10])
+      .range([MARGIN.left, width - MARGIN.right])
+
+    const yScale = d3
+      .scaleBand<number>()
+      .domain(events.map((_e, i) => i))
+      .range([MARGIN.top, height - MARGIN.bottom])
+      .padding(0.3)
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - MARGIN.bottom})`)
+      .call(d3.axisBottom(xScale).tickFormat((d) => `${d} AH`))
+      .selectAll('text')
+      .style('font-size', '11px')
+
+    const bars = svg
+      .selectAll('.event-bar')
+      .data(events)
+      .join('g')
+      .attr('class', 'event-bar')
+      .style('cursor', 'pointer')
+
+    bars
+      .append('rect')
+      .attr('x', (d) => xScale(d.year_start))
+      .attr('y', (_d, i) => yScale(i) ?? 0)
+      .attr('width', (d) => Math.max(4, xScale(d.year_end ?? d.year_start) - xScale(d.year_start)))
+      .attr('height', yScale.bandwidth())
+      .attr('rx', 3)
+      .attr('fill', '#1a73e8')
+      .attr('opacity', 0.75)
+
+    bars
+      .append('text')
+      .attr('x', (d) => xScale(d.year_start) - 4)
+      .attr('y', (_d, i) => (yScale(i) ?? 0) + yScale.bandwidth() / 2)
+      .attr('text-anchor', 'end')
+      .attr('dominant-baseline', 'central')
+      .style('font-size', '11px')
+      .style('fill', '#333')
+      .text((d) => d.name)
+
+    bars.on('click', (_event, d) => handleEventClick(d))
+  }, [events, handleEventClick])
+
   return (
     <div>
       <h2>Timeline</h2>
-      <p>Historical timeline of narrators and transmission networks. Coming soon.</p>
+      <p style={{ color: '#666', marginBottom: '1rem' }}>
+        Historical events and narrator activity periods (Anno Hegirae).
+      </p>
+
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem', alignItems: 'center' }}>
+        <label>
+          From (AH):{' '}
+          <input
+            type="number"
+            value={yearRange[0]}
+            onChange={(e) => setYearRange([Number(e.target.value), yearRange[1]])}
+            style={{ width: 80, padding: '0.25rem' }}
+          />
+        </label>
+        <label>
+          To (AH):{' '}
+          <input
+            type="number"
+            value={yearRange[1]}
+            onChange={(e) => setYearRange([yearRange[0], Number(e.target.value)])}
+            style={{ width: 80, padding: '0.25rem' }}
+          />
+        </label>
+      </div>
+
+      {isLoading && <p>Loading timeline...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      <div style={{ display: 'flex', gap: '1.5rem' }}>
+        <div style={{ flex: 1, overflowX: 'auto' }}>
+          <svg ref={svgRef} width="100%" height={400} />
+        </div>
+
+        {selectedEvent && (
+          <div
+            style={{
+              width: 300,
+              padding: '1rem',
+              border: '1px solid #ddd',
+              borderRadius: 6,
+              background: '#fafafa',
+            }}
+          >
+            <h3 style={{ margin: '0 0 0.5rem' }}>{selectedEvent.name}</h3>
+            <p style={{ color: '#666', fontSize: '0.875rem' }}>
+              {selectedEvent.year_start}
+              {selectedEvent.year_end ? ` - ${selectedEvent.year_end}` : ''} AH
+            </p>
+            {selectedEvent.description && <p>{selectedEvent.description}</p>}
+            {selectedEvent.narrators.length > 0 && (
+              <>
+                <h4 style={{ marginBottom: '0.25rem' }}>Active Narrators</h4>
+                <ul style={{ margin: 0, paddingLeft: '1.25rem' }}>
+                  {selectedEvent.narrators.map((n) => (
+                    <li key={n.id}>{n.name}</li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -10,23 +10,38 @@ export interface Narrator {
   id: string
   name_arabic: string
   name_transliterated: string | null
+  kunya: string | null
+  nisba: string | null
   birth_year: number | null
   death_year: number | null
   generation: string | null
   reliability_grade: string | null
   sect: string | null
   location: string | null
+  in_degree: number | null
+  out_degree: number | null
+  betweenness_centrality: number | null
+  pagerank: number | null
+  community_id: number | null
+}
+
+export interface TopicTag {
+  label: string
+  confidence: number
 }
 
 export interface Hadith {
   id: string
   collection_id: string
+  collection_name: string | null
   book_number: number | null
   hadith_number: string
   text_arabic: string
   text_english: string | null
   grade: string | null
   chapter: string | null
+  topics: TopicTag[] | null
+  parallels: Hadith[] | null
 }
 
 export interface Collection {
@@ -50,4 +65,37 @@ export interface SearchResult {
   id: string
   label: string
   snippet: string
+}
+
+export interface TimelineEvent {
+  id: string
+  name: string
+  year_start: number
+  year_end: number | null
+  description: string | null
+  narrators: { id: string; name: string }[]
+}
+
+export interface ParallelPair {
+  sunni_hadith: Hadith
+  shia_hadith: Hadith
+  similarity_score: number
+}
+
+export interface GraphNode {
+  id: string
+  label: string
+  community_id: number | null
+  type: 'narrator' | 'hadith'
+}
+
+export interface GraphEdge {
+  source: string
+  target: string
+  relationship: string
+}
+
+export interface GraphNetwork {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
 }


### PR DESCRIPTION
## Summary
- **TimelinePage**: D3.js event timeline with narrator activity overlay, year range filter, click-to-inspect
- **ComparativePage**: side-by-side Sunni/Shia parallels with similarity score badges
- **GraphExplorerPage**: WebGL force-directed graph with progressive loading, narrator search, depth control
- **ForceGraph component**: reusable canvas graph with community coloring, directional arrows
- Added d3 + react-force-graph-2d dependencies, @types/d3
- New API types (TimelineEvent, ParallelPair, GraphNode/Edge/Network) and client functions
- Updated routes (/compare, /graph, /narrators/:id) and sidebar navigation
- Includes NarratorDetailPage, enhanced NarratorsPage (search) and HadithsPage (topics/grades)

## Related Issues
Closes #140

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>