### PR TITLE
Fix: Docker healthchecks, Dockerfile CMD, CORS, .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+data/
+__pycache__
+.mypy_cache
+.ruff_cache
+.pytest_cache
+*.egg-info
+node_modules
+frontend/node_modules
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN pip install uv && uv sync --frozen
 COPY . .
-CMD ["uvicorn", "src.api.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "src.api.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       NEO4J_server_memory_pagecache_size: 1G
     volumes:
       - neo4j_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - isnad-net
     restart: unless-stopped
@@ -50,12 +55,17 @@ services:
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=isnad_graph_dev
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
       neo4j:
-        condition: service_started
+        condition: service_healthy
     networks:
       - isnad-net
-    command: uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000
+    command: uv run uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000
     restart: unless-stopped
 
   frontend:

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -35,9 +35,9 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # tighten in production
+        allow_origins=["http://localhost:3000"],  # frontend dev server only
         allow_credentials=True,
-        allow_methods=["*"],
+        allow_methods=["GET", "POST"],
         allow_headers=["*"],
     )
     from src.api.routes import (


### PR DESCRIPTION
## Summary
- Fix API Dockerfile to use `uv run uvicorn` (#182)
- Add healthchecks to Neo4j and API services (#183)
- Tighten CORS to localhost:3000 only (#149)
- Add .dockerignore to reduce image size

## Related Issues
Closes #182, Closes #183, Closes #149

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>