### PR TITLE
Phase 7: Fawaz Arabic editions + parallel text merge

### DIFF
--- a/src/acquire/fawaz.py
+++ b/src/acquire/fawaz.py
@@ -1,6 +1,6 @@
 """Acquire hadith editions from the Fawaz Ahmed Hadith API CDN.
 
-Downloads English-language edition JSON files and grading metadata (info.json)
+Downloads English and Arabic edition JSON files and grading metadata (info.json)
 from the jsdelivr CDN mirror of fawazahmed0/hadith-api.
 """
 
@@ -29,25 +29,34 @@ EDITION_URL_TEMPLATE = "https://cdn.jsdelivr.net/gh/fawazahmed0/hadith-api@1/edi
 MIN_EXPECTED_EDITIONS = 10
 
 
-def _english_edition_keys(editions: dict[str, Any] | list[Any]) -> list[str]:
-    """Return edition keys that start with ``eng-``."""
+_EDITION_PREFIXES = ("eng-", "ara-")
+
+
+def _edition_keys(editions: dict[str, Any] | list[Any]) -> list[str]:
+    """Return edition keys that start with ``eng-`` or ``ara-``."""
     if isinstance(editions, dict):
-        return sorted(k for k in editions if k.startswith("eng-"))
+        return sorted(k for k in editions if any(k.startswith(p) for p in _EDITION_PREFIXES))
     return []
 
 
 def run(raw_dir: Path) -> Path:
-    """Download Fawaz CDN editions (English) and info.json.
+    """Download Fawaz CDN editions (English + Arabic) and info.json.
 
     Idempotent — existing files are skipped.
     """
     dest = ensure_dir(raw_dir / "fawaz")
 
     # 1. Idempotency check — skip network requests if edition files already present
-    existing_editions = list(dest.glob("eng-*.json"))
-    if len(existing_editions) >= MIN_EXPECTED_EDITIONS:
-        logger.info("fawaz_already_acquired", edition_count=len(existing_editions))
-        write_manifest(dest, existing_editions)
+    existing_eng = list(dest.glob("eng-*.json"))
+    existing_ara = list(dest.glob("ara-*.json"))
+    if len(existing_eng) >= MIN_EXPECTED_EDITIONS and len(existing_ara) >= MIN_EXPECTED_EDITIONS:
+        all_existing = existing_eng + existing_ara
+        logger.info(
+            "fawaz_already_acquired",
+            eng_count=len(existing_eng),
+            ara_count=len(existing_ara),
+        )
+        write_manifest(dest, all_existing)
         return dest
 
     # 2. Download editions.json (small catalog file)
@@ -62,9 +71,9 @@ def run(raw_dir: Path) -> Path:
     info_path = dest / "info.json"
     download_file(INFO_URL, info_path)
 
-    # 4. Filter English editions and download each
-    keys = _english_edition_keys(editions_data)
-    logger.info("english_editions_found", count=len(keys))
+    # 4. Filter English + Arabic editions and download each
+    keys = _edition_keys(editions_data)
+    logger.info("editions_found", count=len(keys))
 
     downloaded: list[Path] = [editions_path, info_path]
 
@@ -79,14 +88,17 @@ def run(raw_dir: Path) -> Path:
             download_file(url, edition_path, client=client, timeout=120.0)
             downloaded.append(edition_path)
 
-    # 5. Validate minimum edition count
-    edition_files = [p for p in dest.glob("eng-*.json")]
-    if len(edition_files) < MIN_EXPECTED_EDITIONS:
-        msg = (
-            f"Expected >={MIN_EXPECTED_EDITIONS} English edition files, found {len(edition_files)}"
-        )
+    # 5. Validate minimum edition count for English
+    eng_files = list(dest.glob("eng-*.json"))
+    if len(eng_files) < MIN_EXPECTED_EDITIONS:
+        msg = f"Expected >={MIN_EXPECTED_EDITIONS} English edition files, found {len(eng_files)}"
         raise AssertionError(msg)
 
-    logger.info("fawaz_acquired", edition_count=len(edition_files))
+    ara_files = list(dest.glob("ara-*.json"))
+    logger.info(
+        "fawaz_acquired",
+        eng_count=len(eng_files),
+        ara_count=len(ara_files),
+    )
     write_manifest(dest, downloaded)
     return dest

--- a/src/parse/fawaz.py
+++ b/src/parse/fawaz.py
@@ -2,6 +2,9 @@
 
 Each edition JSON contains ``metadata`` and a ``hadiths`` array.
 Produces ``hadiths_fawaz.parquet`` and ``collections_fawaz.parquet``.
+
+English (eng-*) and Arabic (ara-*) editions are merged by hadith number
+within each collection to produce parallel text records.
 """
 
 from __future__ import annotations
@@ -51,29 +54,45 @@ def _collection_name_from_key(edition_key: str) -> str:
     return parts[1] if len(parts) > 1 else edition_key
 
 
-def _parse_edition(
-    edition_path: Path,
-    info: dict[str, Any],
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """Parse a single edition JSON, returning (hadith_rows, collection_row)."""
+def _load_edition(edition_path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Load an edition JSON, returning (metadata, hadiths)."""
     with open(edition_path) as f:
         data: dict[str, Any] = json.load(f)
+    return data.get("metadata", {}), data.get("hadiths", [])
 
-    metadata: dict[str, Any] = data.get("metadata", {})
-    hadiths: list[dict[str, Any]] = data.get("hadiths", [])
-    edition_key = edition_path.stem  # e.g. "eng-bukhari"
-    collection_name = _collection_name_from_key(edition_key)
-    sect = _detect_sect(edition_key, metadata)
 
-    hadith_rows: list[dict[str, Any]] = []
-    for h in hadiths:
+def _merge_editions(
+    eng_hadiths: list[dict[str, Any]],
+    ara_hadiths: list[dict[str, Any]],
+    collection_name: str,
+    metadata: dict[str, Any],
+    sect: str,
+) -> list[dict[str, Any]]:
+    """Merge English and Arabic hadith lists by hadith number."""
+    # Index Arabic hadiths by number
+    ara_by_number: dict[int | None, dict[str, Any]] = {}
+    for h in ara_hadiths:
+        num = safe_int(h.get("hadithnumber"))
+        ara_by_number[num] = h
+
+    # Track which Arabic hadiths were matched
+    matched_ara_numbers: set[int | None] = set()
+    rows: list[dict[str, Any]] = []
+
+    # Process English hadiths, merging Arabic where available
+    for h in eng_hadiths:
         hadith_number = safe_int(h.get("hadithnumber"))
         source_id = generate_source_id(SOURCE_CORPUS, collection_name, hadith_number or 0)
 
         grades_raw = h.get("grades", [])
         grade_str = json.dumps(grades_raw) if grades_raw else None
 
-        hadith_rows.append(
+        ara_match = ara_by_number.get(hadith_number)
+        matn_ar = ara_match.get("text") if ara_match else None
+        if ara_match:
+            matched_ara_numbers.add(hadith_number)
+
+        rows.append(
             {
                 "source_id": source_id,
                 "source_corpus": SOURCE_CORPUS,
@@ -81,11 +100,11 @@ def _parse_edition(
                 "book_number": None,
                 "chapter_number": None,
                 "hadith_number": hadith_number,
-                "matn_ar": None,
+                "matn_ar": matn_ar,
                 "matn_en": h.get("text"),
                 "isnad_raw_ar": None,
                 "isnad_raw_en": None,
-                "full_text_ar": None,
+                "full_text_ar": matn_ar,
                 "full_text_en": h.get("text"),
                 "grade": grade_str,
                 "chapter_name_ar": None,
@@ -94,25 +113,48 @@ def _parse_edition(
             }
         )
 
-    # Build collection row
-    collection_row: dict[str, Any] | None = None
-    if hadiths:
-        collection_row = {
-            "collection_id": generate_source_id(SOURCE_CORPUS, collection_name),
-            "name_ar": metadata.get("name_ar"),
-            "name_en": metadata.get("name", collection_name),
-            "compiler_name": metadata.get("author"),
-            "compilation_year_ah": None,
-            "sect": sect,
-            "total_hadiths": len(hadiths),
-            "source_corpus": SOURCE_CORPUS,
-        }
+    # Process Arabic-only hadiths (no English counterpart)
+    for h in ara_hadiths:
+        hadith_number = safe_int(h.get("hadithnumber"))
+        if hadith_number in matched_ara_numbers:
+            continue
 
-    return hadith_rows, collection_row
+        logger.warning(
+            "arabic_only_hadith",
+            collection=collection_name,
+            hadith_number=hadith_number,
+        )
+
+        source_id = generate_source_id(SOURCE_CORPUS, collection_name, hadith_number or 0)
+        grades_raw = h.get("grades", [])
+        grade_str = json.dumps(grades_raw) if grades_raw else None
+
+        rows.append(
+            {
+                "source_id": source_id,
+                "source_corpus": SOURCE_CORPUS,
+                "collection_name": collection_name,
+                "book_number": None,
+                "chapter_number": None,
+                "hadith_number": hadith_number,
+                "matn_ar": h.get("text"),
+                "matn_en": None,
+                "isnad_raw_ar": None,
+                "isnad_raw_en": None,
+                "full_text_ar": h.get("text"),
+                "full_text_en": None,
+                "grade": grade_str,
+                "chapter_name_ar": None,
+                "chapter_name_en": None,
+                "sect": sect,
+            }
+        )
+
+    return rows
 
 
 def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
-    """Parse all Fawaz English editions into staging Parquet files."""
+    """Parse all Fawaz English + Arabic editions into staging Parquet files."""
     fawaz_dir = raw_dir / "fawaz"
 
     # Load editions catalog for enumeration
@@ -120,33 +162,69 @@ def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
     with open(editions_path) as f:
         editions_data: dict[str, Any] = json.load(f)
 
-    # Load info.json for grading metadata
-    info_path = fawaz_dir / "info.json"
-    info: dict[str, Any] = {}
-    if info_path.exists():
-        with open(info_path) as f:
-            info = json.load(f)
-
-    # Filter to English edition keys that have downloaded files
+    # Group edition keys by collection name (e.g. "bukhari" -> ["eng-bukhari", "ara-bukhari"])
     eng_keys = sorted(k for k in editions_data if k.startswith("eng-"))
+    ara_keys_set = {k for k in editions_data if k.startswith("ara-")}
 
     all_hadiths: list[dict[str, Any]] = []
     all_collections: list[dict[str, Any]] = []
 
-    for key in eng_keys:
-        edition_file = fawaz_dir / f"{key}.json"
-        if not edition_file.exists():
-            logger.warning("edition_file_missing", key=key, path=str(edition_file))
+    for eng_key in eng_keys:
+        collection_name = _collection_name_from_key(eng_key)
+        ara_key = f"ara-{collection_name}"
+
+        eng_file = fawaz_dir / f"{eng_key}.json"
+        if not eng_file.exists():
+            logger.warning("edition_file_missing", key=eng_key, path=str(eng_file))
             continue
 
-        hadith_rows, collection_row = _parse_edition(edition_file, info)
+        eng_metadata, eng_hadiths = _load_edition(eng_file)
+        sect = _detect_sect(eng_key, eng_metadata)
+
+        # Load Arabic edition if available
+        ara_hadiths: list[dict[str, Any]] = []
+        ara_file = fawaz_dir / f"{ara_key}.json"
+        if ara_key in ara_keys_set and ara_file.exists():
+            _, ara_hadiths = _load_edition(ara_file)
+            logger.info(
+                "arabic_edition_loaded",
+                key=ara_key,
+                hadiths=len(ara_hadiths),
+            )
+        else:
+            logger.warning("arabic_edition_missing", collection=collection_name)
+
+        # Log English hadiths that have no Arabic match
+        if ara_hadiths:
+            ara_numbers = {safe_int(h.get("hadithnumber")) for h in ara_hadiths}
+            for h in eng_hadiths:
+                num = safe_int(h.get("hadithnumber"))
+                if num not in ara_numbers:
+                    logger.warning(
+                        "english_only_hadith",
+                        collection=collection_name,
+                        hadith_number=num,
+                    )
+
+        hadith_rows = _merge_editions(eng_hadiths, ara_hadiths, collection_name, eng_metadata, sect)
         all_hadiths.extend(hadith_rows)
-        if collection_row is not None:
+
+        if eng_hadiths or ara_hadiths:
+            collection_row = {
+                "collection_id": generate_source_id(SOURCE_CORPUS, collection_name),
+                "name_ar": eng_metadata.get("name_ar"),
+                "name_en": eng_metadata.get("name", collection_name),
+                "compiler_name": eng_metadata.get("author"),
+                "compilation_year_ah": None,
+                "sect": sect,
+                "total_hadiths": len(hadith_rows),
+                "source_corpus": SOURCE_CORPUS,
+            }
             all_collections.append(collection_row)
 
         logger.info(
             "edition_parsed",
-            key=key,
+            key=eng_key,
             hadiths=len(hadith_rows),
         )
 

--- a/tests/test_parse/test_fawaz_parser.py
+++ b/tests/test_parse/test_fawaz_parser.py
@@ -11,28 +11,58 @@ from src.parse.fawaz import run
 from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA
 
 
-def _make_fawaz_data(raw_dir: Path) -> None:
+def _make_fawaz_data(
+    raw_dir: Path,
+    *,
+    include_arabic: bool = True,
+    arabic_extra_hadith: bool = False,
+    english_extra_hadith: bool = False,
+) -> None:
     """Create minimal Fawaz edition JSON test data."""
     fawaz_dir = raw_dir / "fawaz"
     fawaz_dir.mkdir(parents=True)
 
-    # editions.json catalog
-    editions = {"eng-bukhari": {"name": "Sahih al-Bukhari", "collection": "bukhari"}}
-    (fawaz_dir / "editions.json").write_text(json.dumps(editions), encoding="utf-8")
+    editions: dict[str, dict[str, str]] = {
+        "eng-bukhari": {"name": "Sahih al-Bukhari", "collection": "bukhari"},
+    }
+    if include_arabic:
+        editions["ara-bukhari"] = {"name": "صحيح البخاري", "collection": "bukhari"}
 
-    # info.json (can be empty)
+    (fawaz_dir / "editions.json").write_text(json.dumps(editions), encoding="utf-8")
     (fawaz_dir / "info.json").write_text(json.dumps({}), encoding="utf-8")
 
-    # Edition file
-    edition_data = {
+    # English edition
+    eng_hadiths = [
+        {"hadithnumber": 1, "text": "Actions are by intentions", "grades": []},
+        {"hadithnumber": 2, "text": "Islam is built on five pillars", "grades": []},
+        {"hadithnumber": 3, "text": "None of you truly believes", "grades": []},
+    ]
+    if english_extra_hadith:
+        eng_hadiths.append({"hadithnumber": 4, "text": "English-only hadith", "grades": []})
+
+    eng_data = {
         "metadata": {"name": "Sahih al-Bukhari", "author": "Imam al-Bukhari"},
-        "hadiths": [
-            {"hadithnumber": 1, "text": "Actions are by intentions", "grades": []},
-            {"hadithnumber": 2, "text": "Islam is built on five pillars", "grades": []},
-            {"hadithnumber": 3, "text": "None of you truly believes", "grades": []},
-        ],
+        "hadiths": eng_hadiths,
     }
-    (fawaz_dir / "eng-bukhari.json").write_text(json.dumps(edition_data), encoding="utf-8")
+    (fawaz_dir / "eng-bukhari.json").write_text(json.dumps(eng_data), encoding="utf-8")
+
+    # Arabic edition
+    if include_arabic:
+        ara_hadiths = [
+            {"hadithnumber": 1, "text": "إنما الأعمال بالنيات", "grades": []},
+            {"hadithnumber": 2, "text": "بني الإسلام على خمس", "grades": []},
+            {"hadithnumber": 3, "text": "لا يؤمن أحدكم", "grades": []},
+        ]
+        if arabic_extra_hadith:
+            ara_hadiths.append({"hadithnumber": 5, "text": "حديث عربي فقط", "grades": []})
+
+        ara_data = {
+            "metadata": {"name": "صحيح البخاري", "author": "الإمام البخاري"},
+            "hadiths": ara_hadiths,
+        }
+        (fawaz_dir / "ara-bukhari.json").write_text(
+            json.dumps(ara_data, ensure_ascii=False), encoding="utf-8"
+        )
 
 
 class TestFawazParser:
@@ -78,3 +108,109 @@ class TestFawazParser:
         table = pq.read_table(hadiths_path)
         corpora = table.column("source_corpus").to_pylist()
         assert all(c == "fawaz" for c in corpora)
+
+    def test_arabic_text_merged(self, tmp_path: Path) -> None:
+        """Arabic matn_ar should be populated when Arabic edition exists."""
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_fawaz_data(raw_dir, include_arabic=True)
+
+        hadiths_path, _ = run(raw_dir, staging_dir)
+
+        table = pq.read_table(hadiths_path)
+        ar_texts = table.column("matn_ar").to_pylist()
+        en_texts = table.column("matn_en").to_pylist()
+
+        # All 3 hadiths should have both Arabic and English
+        assert all(t is not None for t in ar_texts)
+        assert all(t is not None for t in en_texts)
+        assert ar_texts[0] == "إنما الأعمال بالنيات"
+        assert en_texts[0] == "Actions are by intentions"
+
+    def test_no_arabic_edition(self, tmp_path: Path) -> None:
+        """When no Arabic edition exists, matn_ar should be None."""
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_fawaz_data(raw_dir, include_arabic=False)
+
+        hadiths_path, _ = run(raw_dir, staging_dir)
+
+        table = pq.read_table(hadiths_path)
+        ar_texts = table.column("matn_ar").to_pylist()
+        assert all(t is None for t in ar_texts)
+
+    def test_arabic_only_hadith(self, tmp_path: Path) -> None:
+        """Hadiths present only in Arabic should still appear in output."""
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_fawaz_data(raw_dir, include_arabic=True, arabic_extra_hadith=True)
+
+        hadiths_path, _ = run(raw_dir, staging_dir)
+
+        table = pq.read_table(hadiths_path)
+        # 3 shared + 1 Arabic-only = 4
+        assert table.num_rows == 4
+
+        numbers = table.column("hadith_number").to_pylist()
+        ar_texts = table.column("matn_ar").to_pylist()
+        en_texts = table.column("matn_en").to_pylist()
+
+        # Arabic-only hadith (number 5) should have Arabic but no English
+        idx = numbers.index(5)
+        assert ar_texts[idx] == "حديث عربي فقط"
+        assert en_texts[idx] is None
+
+    def test_english_only_hadith(self, tmp_path: Path) -> None:
+        """Hadiths present only in English should have no Arabic text."""
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_fawaz_data(raw_dir, include_arabic=True, english_extra_hadith=True)
+
+        hadiths_path, _ = run(raw_dir, staging_dir)
+
+        table = pq.read_table(hadiths_path)
+        # 3 shared + 1 English-only = 4
+        assert table.num_rows == 4
+
+        numbers = table.column("hadith_number").to_pylist()
+        ar_texts = table.column("matn_ar").to_pylist()
+        en_texts = table.column("matn_en").to_pylist()
+
+        # English-only hadith (number 4) should have English but no Arabic
+        idx = numbers.index(4)
+        assert ar_texts[idx] is None
+        assert en_texts[idx] == "English-only hadith"
+
+    def test_mixed_missing_languages(self, tmp_path: Path) -> None:
+        """Both Arabic-only and English-only hadiths in the same collection."""
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_fawaz_data(
+            raw_dir,
+            include_arabic=True,
+            arabic_extra_hadith=True,
+            english_extra_hadith=True,
+        )
+
+        hadiths_path, _ = run(raw_dir, staging_dir)
+
+        table = pq.read_table(hadiths_path)
+        # 3 shared + 1 English-only + 1 Arabic-only = 5
+        assert table.num_rows == 5
+
+    def test_collection_total_includes_merged(self, tmp_path: Path) -> None:
+        """Collection total_hadiths should count all merged rows."""
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_fawaz_data(
+            raw_dir,
+            include_arabic=True,
+            arabic_extra_hadith=True,
+        )
+
+        _, collections_path = run(raw_dir, staging_dir)
+
+        table = pq.read_table(collections_path)
+        totals = table.column("total_hadiths").to_pylist()
+        # 3 shared + 1 Arabic-only = 4
+        assert totals[0] == 4


### PR DESCRIPTION
## Summary
- Download both eng-* and ara-* editions from Fawaz CDN
- Parse Arabic editions into matn_ar field
- Merge Arabic + English by hadith number for parallel text
- Handle missing-language cases gracefully (Arabic-only and English-only hadiths logged as warnings)
- 6 new test cases covering merge logic, missing languages, and collection totals

## Related Issues
Closes #211

## Test plan
- [x] All 10 fawaz parser tests pass (4 existing + 6 new)
- [x] 323/324 total tests pass (1 pre-existing failure in test_dedup unrelated to these changes)
- [x] Ruff format + lint clean

Co-Authored-By: Amara Diallo <parametrization+Amara.Diallo@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>