### PR TITLE
Phase 7: Enrich Fawaz hadiths with book/chapter metadata

### DIFF
--- a/src/parse/enrich_metadata.py
+++ b/src/parse/enrich_metadata.py
@@ -1,0 +1,173 @@
+"""Enrich staging hadiths with book/chapter metadata from sunnah.com.
+
+Matches Fawaz hadiths to sunnah.com scraped data by collection name + hadith
+number, filling in book_number, chapter_number, chapter_name_ar, and
+chapter_name_en where they are null.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.base import write_parquet
+from src.parse.schemas import HADITH_SCHEMA
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Mapping from Fawaz collection names to sunnah.com collection slugs.
+# Fawaz uses short names like "bukhari"; sunnah.com uses the same or similar.
+_COLLECTION_ALIASES: dict[str, str] = {
+    "bukhari": "bukhari",
+    "muslim": "muslim",
+    "nasai": "nasai",
+    "abudawud": "abudawud",
+    "tirmidhi": "tirmidhi",
+    "ibnmajah": "ibnmajah",
+    "malik": "malik",
+    "riyadussalihin": "riyadussalihin",
+    "adab": "adab",
+    "bulugh": "bulugh",
+    "nawawi40": "nawawi40",
+    "qudsi40": "qudsi40",
+}
+
+
+def _load_scraped_index(raw_dir: Path) -> dict[str, dict[str, Any]]:
+    """Build a lookup index from sunnah.com scraped data.
+
+    Returns a dict keyed by ``"collection:hadith_number"`` with values
+    containing book_number, chapter_number, chapter_name_ar, chapter_name_en.
+    """
+    scraped_dir = raw_dir / "sunnah_scraped"
+    if not scraped_dir.exists():
+        logger.warning("sunnah_scraped_dir_missing", path=str(scraped_dir))
+        return {}
+
+    index: dict[str, dict[str, Any]] = {}
+
+    for json_path in sorted(scraped_dir.glob("*.json")):
+        try:
+            with open(json_path, encoding="utf-8") as f:
+                data: list[dict[str, Any]] = json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("scraped_file_error", path=str(json_path), error=str(exc))
+            continue
+
+        for record in data:
+            collection = record.get("collection", "")
+            hadith_number = record.get("hadithNumber") or record.get("hadith_number")
+            if not collection or hadith_number is None:
+                continue
+
+            key = f"{collection}:{hadith_number}"
+            index[key] = {
+                "book_number": record.get("bookNumber") or record.get("book_number"),
+                "chapter_number": record.get("chapterNumber") or record.get("chapter_number"),
+                "chapter_name_ar": record.get("chapterNameAr") or record.get("chapter_name_ar"),
+                "chapter_name_en": record.get("chapterNameEn") or record.get("chapter_name_en"),
+            }
+
+    logger.info("scraped_index_built", total_entries=len(index))
+    return index
+
+
+def _resolve_collection_slug(fawaz_name: str) -> str:
+    """Map a Fawaz collection name to the sunnah.com slug."""
+    return _COLLECTION_ALIASES.get(fawaz_name, fawaz_name)
+
+
+def run(staging_dir: Path, raw_dir: Path) -> list[Path]:
+    """Match Fawaz hadiths to sunnah.com by collection + hadith number.
+
+    Updates null book_number, chapter_number, chapter_name_ar, chapter_name_en
+    fields with values from scraped data. Writes enriched Parquet back to
+    staging as ``hadiths_fawaz_enriched.parquet``.
+
+    Returns list of output file paths.
+    """
+    fawaz_path = staging_dir / "hadiths_fawaz.parquet"
+    if not fawaz_path.exists():
+        logger.warning("fawaz_parquet_missing", path=str(fawaz_path))
+        return []
+
+    # Load scraped lookup
+    index = _load_scraped_index(raw_dir)
+    if not index:
+        logger.warning("enrichment_skipped", reason="no scraped data available")
+        return []
+
+    # Read Fawaz hadiths
+    table = pq.read_table(fawaz_path)
+    rows = table.to_pydict()
+    num_rows = table.num_rows
+
+    enriched_count = 0
+    unmatched_count = 0
+    collection_stats: dict[str, dict[str, int]] = {}
+
+    for i in range(num_rows):
+        collection = rows["collection_name"][i]
+        hadith_number = rows["hadith_number"][i]
+
+        if collection not in collection_stats:
+            collection_stats[collection] = {"total": 0, "matched": 0}
+        collection_stats[collection]["total"] += 1
+
+        if hadith_number is None:
+            unmatched_count += 1
+            continue
+
+        slug = _resolve_collection_slug(collection)
+        key = f"{slug}:{hadith_number}"
+        meta = index.get(key)
+
+        if meta is None:
+            unmatched_count += 1
+            continue
+
+        # Only fill in null fields (don't overwrite existing data)
+        if rows["book_number"][i] is None and meta.get("book_number") is not None:
+            rows["book_number"][i] = int(meta["book_number"])
+        if rows["chapter_number"][i] is None and meta.get("chapter_number") is not None:
+            rows["chapter_number"][i] = int(meta["chapter_number"])
+        if rows["chapter_name_ar"][i] is None and meta.get("chapter_name_ar"):
+            rows["chapter_name_ar"][i] = str(meta["chapter_name_ar"])
+        if rows["chapter_name_en"][i] is None and meta.get("chapter_name_en"):
+            rows["chapter_name_en"][i] = str(meta["chapter_name_en"])
+
+        enriched_count += 1
+        collection_stats[collection]["matched"] += 1
+
+    # Log match rates per collection
+    for coll_name, stats in sorted(collection_stats.items()):
+        total = stats["total"]
+        matched = stats["matched"]
+        rate = round(100.0 * matched / total, 2) if total > 0 else 0.0
+        logger.info(
+            "enrichment_match_rate",
+            collection=coll_name,
+            matched=matched,
+            total=total,
+            rate_pct=rate,
+        )
+
+    logger.info(
+        "enrichment_complete",
+        enriched=enriched_count,
+        unmatched=unmatched_count,
+        total=num_rows,
+    )
+
+    # Build enriched table
+    enriched_table = pa.table(rows, schema=HADITH_SCHEMA)
+    output_path = write_parquet(
+        enriched_table, staging_dir / "hadiths_fawaz_enriched.parquet", HADITH_SCHEMA
+    )
+
+    return [output_path]

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -178,6 +178,20 @@ def validate_staging(staging_dir: Path) -> dict[str, Any]:
                 hadith_checks["arabic_coverage_pct"] = 0.0
                 hadith_checks["english_coverage_pct"] = 0.0
 
+            # Book/chapter metadata coverage
+            book_filled = 0
+            chapter_filled = 0
+            if "book_number" in table.column_names:
+                book_filled = num_rows - table.column("book_number").null_count
+            if "chapter_number" in table.column_names:
+                chapter_filled = num_rows - table.column("chapter_number").null_count
+            if num_rows > 0:
+                hadith_checks["book_coverage_pct"] = round(100.0 * book_filled / num_rows, 2)
+                hadith_checks["chapter_coverage_pct"] = round(100.0 * chapter_filled / num_rows, 2)
+            else:
+                hadith_checks["book_coverage_pct"] = 0.0
+                hadith_checks["chapter_coverage_pct"] = 0.0
+
             file_result["hadith_checks"] = hadith_checks
 
         results.append(file_result)
@@ -237,6 +251,10 @@ def _print_report(summary: dict[str, Any]) -> None:
             print(f"    Empty matn_en: {hc['empty_matn_en']}")
             print(f"    Arabic coverage: {hc['arabic_coverage_pct']}%")
             print(f"    English coverage: {hc['english_coverage_pct']}%")
+            if "book_coverage_pct" in hc:
+                print(f"    Book coverage: {hc['book_coverage_pct']}%")
+            if "chapter_coverage_pct" in hc:
+                print(f"    Chapter coverage: {hc['chapter_coverage_pct']}%")
 
         print()
 

--- a/tests/test_parse/test_enrich_metadata.py
+++ b/tests/test_parse/test_enrich_metadata.py
@@ -1,0 +1,254 @@
+"""Tests for the Fawaz metadata enrichment module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from src.parse.enrich_metadata import run
+from src.parse.schemas import HADITH_SCHEMA
+
+
+def _make_fawaz_parquet(staging_dir: Path, rows: list[dict] | None = None) -> Path:
+    """Write a minimal hadiths_fawaz.parquet for testing."""
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    if rows is None:
+        rows = [
+            {
+                "source_id": "fawaz:bukhari:1",
+                "source_corpus": "fawaz",
+                "collection_name": "bukhari",
+                "book_number": None,
+                "chapter_number": None,
+                "hadith_number": 1,
+                "matn_ar": None,
+                "matn_en": "Actions are by intentions",
+                "isnad_raw_ar": None,
+                "isnad_raw_en": None,
+                "full_text_ar": None,
+                "full_text_en": "Actions are by intentions",
+                "grade": None,
+                "chapter_name_ar": None,
+                "chapter_name_en": None,
+                "sect": "sunni",
+            },
+            {
+                "source_id": "fawaz:bukhari:2",
+                "source_corpus": "fawaz",
+                "collection_name": "bukhari",
+                "book_number": None,
+                "chapter_number": None,
+                "hadith_number": 2,
+                "matn_ar": None,
+                "matn_en": "Islam is built on five pillars",
+                "isnad_raw_ar": None,
+                "isnad_raw_en": None,
+                "full_text_ar": None,
+                "full_text_en": "Islam is built on five pillars",
+                "grade": None,
+                "chapter_name_ar": None,
+                "chapter_name_en": None,
+                "sect": "sunni",
+            },
+            {
+                "source_id": "fawaz:muslim:10",
+                "source_corpus": "fawaz",
+                "collection_name": "muslim",
+                "book_number": None,
+                "chapter_number": None,
+                "hadith_number": 10,
+                "matn_ar": None,
+                "matn_en": "A Muslim is one from whose tongue...",
+                "isnad_raw_ar": None,
+                "isnad_raw_en": None,
+                "full_text_ar": None,
+                "full_text_en": "A Muslim is one from whose tongue...",
+                "grade": None,
+                "chapter_name_ar": None,
+                "chapter_name_en": None,
+                "sect": "sunni",
+            },
+        ]
+
+    table = pa.table(
+        {field.name: [r[field.name] for r in rows] for field in HADITH_SCHEMA},
+        schema=HADITH_SCHEMA,
+    )
+    path = staging_dir / "hadiths_fawaz.parquet"
+    pq.write_table(table, path)
+    return path
+
+
+def _make_scraped_data(raw_dir: Path, records: list[dict] | None = None) -> Path:
+    """Write mock sunnah_scraped JSON files."""
+    scraped_dir = raw_dir / "sunnah_scraped"
+    scraped_dir.mkdir(parents=True, exist_ok=True)
+    if records is None:
+        records = [
+            {
+                "collection": "bukhari",
+                "hadithNumber": 1,
+                "bookNumber": 1,
+                "chapterNumber": 1,
+                "chapterNameAr": "\u0628\u062f\u0621 \u0627\u0644\u0648\u062d\u064a",
+                "chapterNameEn": "Revelation",
+            },
+            {
+                "collection": "bukhari",
+                "hadithNumber": 2,
+                "bookNumber": 1,
+                "chapterNumber": 1,
+                "chapterNameAr": "\u0628\u062f\u0621 \u0627\u0644\u0648\u062d\u064a",
+                "chapterNameEn": "Revelation",
+            },
+        ]
+    path = scraped_dir / "bukhari.json"
+    path.write_text(json.dumps(records), encoding="utf-8")
+    return scraped_dir
+
+
+class TestEnrichMetadata:
+    def test_enriches_matching_hadiths(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        raw_dir = tmp_path / "raw"
+        _make_fawaz_parquet(staging_dir)
+        _make_scraped_data(raw_dir)
+
+        result = run(staging_dir, raw_dir)
+
+        assert len(result) == 1
+        enriched = pq.read_table(result[0])
+        assert enriched.schema == HADITH_SCHEMA
+
+        rows = enriched.to_pydict()
+        # Bukhari hadith 1 should be enriched
+        assert rows["book_number"][0] == 1
+        assert rows["chapter_number"][0] == 1
+        assert rows["chapter_name_ar"][0] == "\u0628\u062f\u0621 \u0627\u0644\u0648\u062d\u064a"
+        assert rows["chapter_name_en"][0] == "Revelation"
+
+        # Bukhari hadith 2 should also be enriched
+        assert rows["book_number"][1] == 1
+        assert rows["chapter_number"][1] == 1
+
+    def test_unmatched_hadiths_kept_unchanged(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        raw_dir = tmp_path / "raw"
+        _make_fawaz_parquet(staging_dir)
+        _make_scraped_data(raw_dir)
+
+        result = run(staging_dir, raw_dir)
+
+        enriched = pq.read_table(result[0])
+        rows = enriched.to_pydict()
+        # Muslim hadith 10 has no match in scraped data
+        assert rows["book_number"][2] is None
+        assert rows["chapter_number"][2] is None
+        assert rows["chapter_name_ar"][2] is None
+        assert rows["chapter_name_en"][2] is None
+        # But original data is preserved
+        assert rows["collection_name"][2] == "muslim"
+        assert rows["hadith_number"][2] == 10
+
+    def test_idempotency(self, tmp_path: Path) -> None:
+        """Enriching already-enriched data should not change values."""
+        staging_dir = tmp_path / "staging"
+        raw_dir = tmp_path / "raw"
+        _make_fawaz_parquet(staging_dir)
+        _make_scraped_data(raw_dir)
+
+        # First enrichment
+        result1 = run(staging_dir, raw_dir)
+        first_enriched = pq.read_table(result1[0])
+
+        # Copy enriched back as fawaz source for second run
+        pq.write_table(first_enriched, staging_dir / "hadiths_fawaz.parquet")
+
+        # Second enrichment
+        result2 = run(staging_dir, raw_dir)
+        second_enriched = pq.read_table(result2[0])
+
+        assert first_enriched.equals(second_enriched)
+
+    def test_no_scraped_data_returns_empty(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        raw_dir = tmp_path / "raw"
+        _make_fawaz_parquet(staging_dir)
+        # No scraped data directory
+
+        result = run(staging_dir, raw_dir)
+        assert result == []
+
+    def test_no_fawaz_parquet_returns_empty(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir(parents=True)
+        raw_dir = tmp_path / "raw"
+        _make_scraped_data(raw_dir)
+
+        result = run(staging_dir, raw_dir)
+        assert result == []
+
+    def test_does_not_overwrite_existing_values(self, tmp_path: Path) -> None:
+        """If a field already has a value, enrichment should not overwrite it."""
+        staging_dir = tmp_path / "staging"
+        raw_dir = tmp_path / "raw"
+
+        rows = [
+            {
+                "source_id": "fawaz:bukhari:1",
+                "source_corpus": "fawaz",
+                "collection_name": "bukhari",
+                "book_number": 99,  # pre-existing value
+                "chapter_number": 88,
+                "hadith_number": 1,
+                "matn_ar": None,
+                "matn_en": "Actions are by intentions",
+                "isnad_raw_ar": None,
+                "isnad_raw_en": None,
+                "full_text_ar": None,
+                "full_text_en": "Actions are by intentions",
+                "grade": None,
+                "chapter_name_ar": "existing_ar",
+                "chapter_name_en": "existing_en",
+                "sect": "sunni",
+            },
+        ]
+        _make_fawaz_parquet(staging_dir, rows)
+        _make_scraped_data(raw_dir)
+
+        result = run(staging_dir, raw_dir)
+        enriched = pq.read_table(result[0])
+        enriched_rows = enriched.to_pydict()
+
+        # Pre-existing values should be preserved
+        assert enriched_rows["book_number"][0] == 99
+        assert enriched_rows["chapter_number"][0] == 88
+        assert enriched_rows["chapter_name_ar"][0] == "existing_ar"
+        assert enriched_rows["chapter_name_en"][0] == "existing_en"
+
+    def test_alternate_scraped_key_format(self, tmp_path: Path) -> None:
+        """Test scraped data using snake_case field names."""
+        staging_dir = tmp_path / "staging"
+        raw_dir = tmp_path / "raw"
+        _make_fawaz_parquet(staging_dir)
+
+        records = [
+            {
+                "collection": "bukhari",
+                "hadith_number": 1,
+                "book_number": 5,
+                "chapter_number": 3,
+                "chapter_name_ar": "\u0628\u0627\u0628",
+                "chapter_name_en": "Chapter",
+            },
+        ]
+        _make_scraped_data(raw_dir, records)
+
+        result = run(staging_dir, raw_dir)
+        enriched = pq.read_table(result[0])
+        rows = enriched.to_pydict()
+        assert rows["book_number"][0] == 5
+        assert rows["chapter_number"][0] == 3


### PR DESCRIPTION
## Summary
- New enrichment module matching Fawaz hadiths to sunnah.com scraped data
- Adds book_number, chapter_number, chapter_name_ar/en to Fawaz staging
- Match by collection + hadith number with coverage logging
- Updated staging validation for book/chapter coverage
- 7 tests covering matching, unmatched handling, idempotency, and value preservation

## Related Issues
Closes #213

Co-Authored-By: Carolina Méndez-Ríos <parametrization+Carolina.Mendez-Rios@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>