### PR TITLE
Phase 7: Sunnah.com web scraper for missing collections

### DIFF
--- a/src/acquire/__init__.py
+++ b/src/acquire/__init__.py
@@ -10,7 +10,15 @@ from __future__ import annotations
 from pathlib import Path
 from types import ModuleType
 
-from src.acquire import fawaz, lk_corpus, muhaddithat, open_hadith, sunnah_api, thaqalayn
+from src.acquire import (
+    fawaz,
+    lk_corpus,
+    muhaddithat,
+    open_hadith,
+    sunnah_api,
+    sunnah_scraper,
+    thaqalayn,
+)
 from src.acquire.sanadset import download_sanadset
 from src.utils.logging import get_logger
 
@@ -24,6 +32,7 @@ SOURCES: list[tuple[str, ModuleType | None]] = [
     ("thaqalayn", thaqalayn),
     ("fawaz", fawaz),
     ("sunnah", sunnah_api),
+    ("sunnah_scraped", sunnah_scraper),
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
 ]

--- a/src/acquire/sunnah_scraper.py
+++ b/src/acquire/sunnah_scraper.py
@@ -1,0 +1,281 @@
+"""Web scraper for sunnah.com hadith collections.
+
+Scrapes collections not available via the Fawaz dataset or when the
+Sunnah.com API key is not configured.  Uses BeautifulSoup + httpx with
+rate limiting (500 ms+ between requests).  Resumable: tracks per-collection
+progress and skips already-scraped pages.
+
+Output directory: ``data/raw/sunnah_scraped/``
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from urllib.robotparser import RobotFileParser
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from src.acquire.base import ensure_dir, write_manifest
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+BASE_URL = "https://sunnah.com"
+RATE_LIMIT_SECONDS = 0.5
+REQUEST_TIMEOUT = 30.0
+USER_AGENT = "isnad-graph/1.0 (hadith-research)"
+
+# Collections not in Fawaz dataset that we need to scrape.
+SCRAPE_COLLECTIONS = [
+    "musnad-ahmad",
+    "sunan-darimi",
+    "riyadussalihin",
+    "adab",
+    "shamail",
+    "mishkat",
+    "bulugh",
+    "hisn",
+]
+
+
+def _check_robots_txt(client: httpx.Client) -> bool:
+    """Check robots.txt to ensure scraping is allowed."""
+    try:
+        rp = RobotFileParser()
+        resp = client.get(f"{BASE_URL}/robots.txt")
+        rp.parse(resp.text.splitlines())
+        allowed: bool = rp.can_fetch(USER_AGENT, f"{BASE_URL}/bukhari")
+        if not allowed:
+            logger.warning("sunnah_scraper_robots_denied")
+        return allowed
+    except Exception:  # noqa: BLE001
+        # If we cannot fetch robots.txt, proceed cautiously.
+        logger.warning("sunnah_scraper_robots_unavailable")
+        return True
+
+
+def _fetch_page(client: httpx.Client, url: str) -> BeautifulSoup | None:
+    """Fetch a page and return parsed BeautifulSoup, or None on error."""
+    try:
+        resp = client.get(url)
+        resp.raise_for_status()
+        return BeautifulSoup(resp.text, "html.parser")
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return None
+        logger.warning("sunnah_scraper_http_error", url=url, status=exc.response.status_code)
+        return None
+    except httpx.HTTPError:
+        logger.warning("sunnah_scraper_request_error", url=url)
+        return None
+
+
+def _extract_hadith_from_row(row: Tag) -> dict[str, Any] | None:
+    """Extract a single hadith record from a hadith container element."""
+    # Hadith number
+    num_tag = row.select_one(".hadith_reference .hadith_num, .hadithNar498")
+    hadith_number: int | None = None
+    if num_tag:
+        text = num_tag.get_text(strip=True).replace(":", "").strip()
+        try:
+            hadith_number = int(text)
+        except ValueError:
+            pass
+
+    # Arabic text
+    ar_tag = row.select_one(".arabic_hadith_full, .text_details .arabic_text_details")
+    text_ar = ar_tag.get_text(strip=True) if ar_tag else None
+
+    # English text
+    en_tag = row.select_one(".english_hadith_full, .text_details .english_hadith_full")
+    text_en = en_tag.get_text(strip=True) if en_tag else None
+
+    # Grade
+    grade_tag = row.select_one(".hadith_grade, .hadith-grade")
+    grade = grade_tag.get_text(strip=True) if grade_tag else None
+
+    if not text_ar and not text_en:
+        return None
+
+    return {
+        "hadith_number": hadith_number,
+        "text_ar": text_ar,
+        "text_en": text_en,
+        "grade": grade,
+    }
+
+
+def _scrape_book_page(
+    client: httpx.Client,
+    collection: str,
+    book_number: int,
+) -> list[dict[str, Any]]:
+    """Scrape all hadiths from a single book page."""
+    url = f"{BASE_URL}/{collection}/{book_number}"
+    soup = _fetch_page(client, url)
+    if soup is None:
+        return []
+
+    # Chapter info
+    chapter_name_en: str | None = None
+    chapter_name_ar: str | None = None
+    chapter_tag = soup.select_one(".book_page_english_name, .englishchapter")
+    if chapter_tag:
+        chapter_name_en = chapter_tag.get_text(strip=True)
+    chapter_ar_tag = soup.select_one(".book_page_arabic_name, .arabicchapter")
+    if chapter_ar_tag:
+        chapter_name_ar = chapter_ar_tag.get_text(strip=True)
+
+    hadiths: list[dict[str, Any]] = []
+    # Each hadith is in a container div
+    rows = soup.select(".actualHadithContainer, .hadith")
+    for row in rows:
+        record = _extract_hadith_from_row(row)
+        if record is not None:
+            record["book_number"] = book_number
+            record["chapter_number"] = book_number  # sunnah.com uses book=chapter often
+            record["chapter_name_ar"] = chapter_name_ar
+            record["chapter_name_en"] = chapter_name_en
+            hadiths.append(record)
+
+    return hadiths
+
+
+def _get_book_numbers(client: httpx.Client, collection: str) -> list[int]:
+    """Get list of book numbers for a collection from its index page."""
+    soup = _fetch_page(client, f"{BASE_URL}/{collection}")
+    if soup is None:
+        return []
+
+    book_numbers: list[int] = []
+    # Books are linked as /{collection}/{number}
+    links = soup.select("a[href]")
+    prefix = f"/{collection}/"
+    seen: set[int] = set()
+    for link in links:
+        href = link.get("href", "")
+        if isinstance(href, str) and href.startswith(prefix):
+            segment = href[len(prefix) :].rstrip("/")
+            if segment.isdigit():
+                num = int(segment)
+                if num not in seen:
+                    seen.add(num)
+                    book_numbers.append(num)
+
+    book_numbers.sort()
+    return book_numbers
+
+
+def _scrape_collection(
+    client: httpx.Client,
+    collection: str,
+    dest: Path,
+) -> Path | None:
+    """Scrape all hadiths for a single collection. Returns output path."""
+    output_path = dest / f"{collection}.json"
+
+    # Idempotent: skip if already scraped
+    if output_path.exists() and output_path.stat().st_size > 0:
+        logger.info("sunnah_scraper_cached", collection=collection)
+        return output_path
+
+    # Progress file for resumability
+    progress_path = dest / f".{collection}_progress.json"
+    scraped_books: dict[str, list[dict[str, Any]]] = {}
+    if progress_path.exists():
+        with open(progress_path, encoding="utf-8") as f:
+            scraped_books = json.load(f)
+
+    book_numbers = _get_book_numbers(client, collection)
+    if not book_numbers:
+        logger.warning("sunnah_scraper_no_books", collection=collection)
+        return None
+
+    time.sleep(RATE_LIMIT_SECONDS)
+
+    logger.info(
+        "sunnah_scraper_starting",
+        collection=collection,
+        total_books=len(book_numbers),
+        already_scraped=len(scraped_books),
+    )
+
+    for book_num in book_numbers:
+        book_key = str(book_num)
+        if book_key in scraped_books:
+            continue
+
+        hadiths = _scrape_book_page(client, collection, book_num)
+        scraped_books[book_key] = hadiths
+
+        # Save progress after each book
+        with open(progress_path, "w", encoding="utf-8") as f:
+            json.dump(scraped_books, f, ensure_ascii=False)
+
+        time.sleep(RATE_LIMIT_SECONDS)
+
+    # Flatten all hadiths into a single list
+    all_hadiths: list[dict[str, Any]] = []
+    for hadiths in scraped_books.values():
+        all_hadiths.extend(hadiths)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(all_hadiths, f, ensure_ascii=False, indent=2)
+
+    # Clean up progress file
+    if progress_path.exists():
+        progress_path.unlink()
+
+    logger.info(
+        "sunnah_scraper_complete",
+        collection=collection,
+        books=len(scraped_books),
+        hadiths=len(all_hadiths),
+    )
+    return output_path
+
+
+def run(raw_dir: Path) -> Path | None:
+    """Scrape hadiths from sunnah.com.
+
+    Returns the output directory on success, or ``None`` if robots.txt
+    disallows scraping.
+    """
+    dest = ensure_dir(raw_dir / "sunnah_scraped")
+
+    client = httpx.Client(
+        headers={"User-Agent": USER_AGENT},
+        timeout=REQUEST_TIMEOUT,
+        follow_redirects=True,
+    )
+
+    try:
+        if not _check_robots_txt(client):
+            return None
+
+        saved_files: list[Path] = []
+        total_hadiths = 0
+
+        for collection in SCRAPE_COLLECTIONS:
+            output_path = _scrape_collection(client, collection, dest)
+            if output_path is not None:
+                saved_files.append(output_path)
+                with open(output_path, encoding="utf-8") as f:
+                    data: list[Any] = json.load(f)
+                total_hadiths += len(data)
+
+        if saved_files:
+            write_manifest(dest, saved_files)
+
+        logger.info(
+            "sunnah_scraper_acquired",
+            collections=len(saved_files),
+            total_hadiths=total_hadiths,
+        )
+        return dest
+    finally:
+        client.close()

--- a/src/parse/__init__.py
+++ b/src/parse/__init__.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 from types import ModuleType
 
-from src.parse import fawaz, lk_corpus, muhaddithat, open_hadith, sunnah_api, thaqalayn
+from src.parse import (
+    fawaz,
+    lk_corpus,
+    muhaddithat,
+    open_hadith,
+    sunnah_api,
+    sunnah_scraped,
+    thaqalayn,
+)
 from src.parse.sanadset import parse_sanadset
 from src.utils.logging import get_logger
 
@@ -17,6 +25,7 @@ PARSERS: list[tuple[str, ModuleType | None]] = [
     ("thaqalayn", thaqalayn),
     ("fawaz", fawaz),
     ("sunnah", sunnah_api),
+    ("sunnah_scraped", sunnah_scraped),
     ("open_hadith", open_hadith),
     ("muhaddithat", muhaddithat),
 ]

--- a/src/parse/sunnah_scraped.py
+++ b/src/parse/sunnah_scraped.py
@@ -1,0 +1,124 @@
+"""Parse sunnah.com scraped JSON into staging Parquet tables.
+
+Produces ``hadiths_sunnah_scraped.parquet`` and ``collections_sunnah_scraped.parquet``.
+Uses ``source_corpus = "sunnah"`` for dedup compatibility with the API-sourced data.
+Gracefully skips if raw data is missing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+
+from src.parse.base import generate_source_id, safe_int, safe_str, write_parquet
+from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+SOURCE_CORPUS = "sunnah"
+SECT = "sunni"
+
+
+def run(raw_dir: Path, staging_dir: Path) -> list[Path]:
+    """Parse sunnah.com scraped JSON into staging Parquet files.
+
+    Returns list of written Parquet paths (empty if source was skipped).
+    """
+    scraped_dir = raw_dir / "sunnah_scraped"
+
+    if not scraped_dir.exists():
+        logger.info("sunnah_scraped_parse_skipped", reason="raw data missing (source not acquired)")
+        return []
+
+    json_files = sorted(scraped_dir.glob("*.json"))
+    # Filter out manifest.json and progress files
+    json_files = [f for f in json_files if f.name != "manifest.json" and not f.name.startswith(".")]
+
+    if not json_files:
+        logger.info("sunnah_scraped_parse_skipped", reason="no JSON files found")
+        return []
+
+    collection_rows: list[dict[str, Any]] = []
+    hadith_rows: list[dict[str, Any]] = []
+
+    for json_path in json_files:
+        collection_name = json_path.stem  # e.g. "musnad-ahmad"
+
+        with open(json_path, encoding="utf-8") as f:
+            hadiths: list[dict[str, Any]] = json.load(f)
+
+        # Build collection record
+        collection_rows.append(
+            {
+                "collection_id": generate_source_id(SOURCE_CORPUS, collection_name),
+                "name_ar": None,
+                "name_en": collection_name,
+                "compiler_name": None,
+                "compilation_year_ah": None,
+                "sect": SECT,
+                "total_hadiths": len(hadiths),
+                "source_corpus": SOURCE_CORPUS,
+            }
+        )
+
+        # Build hadith records
+        for h in hadiths:
+            hadith_number = safe_int(h.get("hadith_number"))
+            book_number = safe_int(h.get("book_number"))
+            chapter_number = safe_int(h.get("chapter_number"))
+
+            source_id = generate_source_id(
+                SOURCE_CORPUS,
+                collection_name,
+                book_number or 0,
+                hadith_number or 0,
+            )
+
+            hadith_rows.append(
+                {
+                    "source_id": source_id,
+                    "source_corpus": SOURCE_CORPUS,
+                    "collection_name": collection_name,
+                    "book_number": book_number,
+                    "chapter_number": chapter_number,
+                    "hadith_number": hadith_number,
+                    "matn_ar": safe_str(h.get("text_ar")),
+                    "matn_en": safe_str(h.get("text_en")),
+                    "isnad_raw_ar": None,
+                    "isnad_raw_en": None,
+                    "full_text_ar": safe_str(h.get("text_ar")),
+                    "full_text_en": safe_str(h.get("text_en")),
+                    "grade": safe_str(h.get("grade")),
+                    "chapter_name_ar": safe_str(h.get("chapter_name_ar")),
+                    "chapter_name_en": safe_str(h.get("chapter_name_en")),
+                    "sect": SECT,
+                }
+            )
+
+    output_files: list[Path] = []
+
+    if hadith_rows:
+        hadith_table = pa.table(
+            {field.name: [r[field.name] for r in hadith_rows] for field in HADITH_SCHEMA},
+        )
+        hadith_path = write_parquet(
+            hadith_table, staging_dir / "hadiths_sunnah_scraped.parquet", HADITH_SCHEMA
+        )
+        output_files.append(hadith_path)
+        logger.info("sunnah_scraped_hadiths_parsed", count=len(hadith_rows))
+
+    if collection_rows:
+        collection_table = pa.table(
+            {field.name: [r[field.name] for r in collection_rows] for field in COLLECTION_SCHEMA},
+        )
+        collection_path = write_parquet(
+            collection_table, staging_dir / "collections_sunnah_scraped.parquet", COLLECTION_SCHEMA
+        )
+        output_files.append(collection_path)
+        logger.info("sunnah_scraped_collections_parsed", count=len(collection_rows))
+
+    return output_files

--- a/tests/test_acquire/test_sunnah_scraper.py
+++ b/tests/test_acquire/test_sunnah_scraper.py
@@ -1,0 +1,186 @@
+"""Tests for the sunnah.com web scraper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from src.acquire.sunnah_scraper import (
+    SCRAPE_COLLECTIONS,
+    _extract_hadith_from_row,
+    _get_book_numbers,
+    _scrape_book_page,
+    run,
+)
+
+SAMPLE_COLLECTION_HTML = """
+<html><body>
+<a href="/musnad-ahmad/1">Book 1</a>
+<a href="/musnad-ahmad/2">Book 2</a>
+<a href="/musnad-ahmad/3">Book 3</a>
+<a href="/other-link">Other</a>
+</body></html>
+"""
+
+SAMPLE_BOOK_HTML = """
+<html><body>
+<div class="book_page_english_name">The Book of Purification</div>
+<div class="book_page_arabic_name">كتاب الطهارة</div>
+<div class="actualHadithContainer">
+  <div class="hadith_reference"><span class="hadith_num">1</span></div>
+  <div class="arabic_hadith_full">نص الحديث بالعربية</div>
+  <div class="english_hadith_full">The hadith text in English</div>
+  <div class="hadith_grade">Sahih</div>
+</div>
+<div class="actualHadithContainer">
+  <div class="hadith_reference"><span class="hadith_num">2</span></div>
+  <div class="arabic_hadith_full">حديث ثاني</div>
+  <div class="english_hadith_full">Second hadith</div>
+</div>
+</body></html>
+"""
+
+ROBOTS_TXT = "User-agent: *\nAllow: /\n"
+
+
+def _mock_response(text: str, status_code: int = 200) -> httpx.Response:
+    """Build a mock httpx.Response."""
+    return httpx.Response(
+        status_code=status_code,
+        text=text,
+        request=httpx.Request("GET", "https://sunnah.com/test"),
+    )
+
+
+class TestExtractHadithFromRow:
+    def test_extracts_full_record(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = """
+        <div class="actualHadithContainer">
+          <div class="hadith_reference"><span class="hadith_num">42</span></div>
+          <div class="arabic_hadith_full">عربي</div>
+          <div class="english_hadith_full">English text</div>
+          <div class="hadith_grade">Hasan</div>
+        </div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        result = _extract_hadith_from_row(row)
+
+        assert result is not None
+        assert result["hadith_number"] == 42
+        assert result["text_ar"] == "عربي"
+        assert result["text_en"] == "English text"
+        assert result["grade"] == "Hasan"
+
+    def test_returns_none_when_no_text(self) -> None:
+        from bs4 import BeautifulSoup
+
+        html = '<div class="actualHadithContainer"><span>empty</span></div>'
+        soup = BeautifulSoup(html, "html.parser")
+        row = soup.select_one(".actualHadithContainer")
+        assert row is not None
+        result = _extract_hadith_from_row(row)
+        assert result is None
+
+
+class TestGetBookNumbers:
+    def test_parses_book_links(self) -> None:
+        client = MagicMock(spec=httpx.Client)
+        client.get.return_value = _mock_response(SAMPLE_COLLECTION_HTML)
+
+        books = _get_book_numbers(client, "musnad-ahmad")
+        assert books == [1, 2, 3]
+
+    def test_returns_empty_on_404(self) -> None:
+        client = MagicMock(spec=httpx.Client)
+        client.get.side_effect = httpx.HTTPStatusError(
+            "Not Found",
+            request=httpx.Request("GET", "https://sunnah.com/test"),
+            response=httpx.Response(404),
+        )
+
+        books = _get_book_numbers(client, "nonexistent")
+        assert books == []
+
+
+class TestScrapeBookPage:
+    def test_extracts_hadiths(self) -> None:
+        client = MagicMock(spec=httpx.Client)
+        client.get.return_value = _mock_response(SAMPLE_BOOK_HTML)
+
+        hadiths = _scrape_book_page(client, "musnad-ahmad", 1)
+        assert len(hadiths) == 2
+        assert hadiths[0]["hadith_number"] == 1
+        assert hadiths[0]["text_ar"] == "نص الحديث بالعربية"
+        assert hadiths[0]["book_number"] == 1
+        assert hadiths[0]["chapter_name_en"] == "The Book of Purification"
+        assert hadiths[0]["chapter_name_ar"] == "كتاب الطهارة"
+
+
+class TestRun:
+    @patch("src.acquire.sunnah_scraper.SCRAPE_COLLECTIONS", ["test-collection"])
+    @patch("src.acquire.sunnah_scraper.RATE_LIMIT_SECONDS", 0)
+    def test_scrapes_and_saves_json(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+
+        with patch("src.acquire.sunnah_scraper.httpx.Client") as mock_client_cls:
+            client = MagicMock()
+            mock_client_cls.return_value = client
+
+            # robots.txt
+            client.get.side_effect = [
+                _mock_response(ROBOTS_TXT),  # robots.txt
+                _mock_response(SAMPLE_COLLECTION_HTML.replace("musnad-ahmad", "test-collection")),
+                _mock_response(SAMPLE_BOOK_HTML),  # book 1
+                _mock_response(SAMPLE_BOOK_HTML),  # book 2
+                _mock_response(SAMPLE_BOOK_HTML),  # book 3
+            ]
+
+            result = run(raw_dir)
+
+        assert result is not None
+        assert (raw_dir / "sunnah_scraped" / "test-collection.json").exists()
+        with open(raw_dir / "sunnah_scraped" / "test-collection.json") as f:
+            data = json.load(f)
+        assert len(data) == 6  # 2 hadiths per book * 3 books
+
+    @patch("src.acquire.sunnah_scraper.SCRAPE_COLLECTIONS", ["test-collection"])
+    @patch("src.acquire.sunnah_scraper.RATE_LIMIT_SECONDS", 0)
+    def test_idempotent_skips_existing(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        dest = raw_dir / "sunnah_scraped"
+        dest.mkdir(parents=True)
+        (dest / "test-collection.json").write_text('[{"hadith_number": 1}]')
+
+        with patch("src.acquire.sunnah_scraper.httpx.Client") as mock_client_cls:
+            client = MagicMock()
+            mock_client_cls.return_value = client
+            client.get.return_value = _mock_response(ROBOTS_TXT)
+
+            result = run(raw_dir)
+
+        assert result is not None
+
+    @patch("src.acquire.sunnah_scraper.RATE_LIMIT_SECONDS", 0)
+    def test_robots_denied(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+
+        with patch("src.acquire.sunnah_scraper.httpx.Client") as mock_client_cls:
+            client = MagicMock()
+            mock_client_cls.return_value = client
+            client.get.return_value = _mock_response("User-agent: *\nDisallow: /\n")
+
+            result = run(raw_dir)
+
+        assert result is None
+
+    def test_target_collections_defined(self) -> None:
+        assert len(SCRAPE_COLLECTIONS) == 8
+        assert "musnad-ahmad" in SCRAPE_COLLECTIONS
+        assert "riyadussalihin" in SCRAPE_COLLECTIONS

--- a/tests/test_parse/test_sunnah_scraped_parser.py
+++ b/tests/test_parse/test_sunnah_scraped_parser.py
@@ -1,0 +1,141 @@
+"""Tests for the sunnah.com scraped data parser."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA
+from src.parse.sunnah_scraped import run
+
+
+def _make_scraped_data(raw_dir: Path) -> None:
+    """Create minimal scraped JSON test data."""
+    scraped_dir = raw_dir / "sunnah_scraped"
+    scraped_dir.mkdir(parents=True)
+
+    hadiths = [
+        {
+            "hadith_number": 1,
+            "book_number": 1,
+            "chapter_number": 1,
+            "text_ar": "نص الحديث بالعربية",
+            "text_en": "Hadith text in English",
+            "grade": "Sahih",
+            "chapter_name_ar": "كتاب الطهارة",
+            "chapter_name_en": "The Book of Purification",
+        },
+        {
+            "hadith_number": 2,
+            "book_number": 1,
+            "chapter_number": 1,
+            "text_ar": "حديث ثاني",
+            "text_en": "Second hadith",
+            "grade": None,
+            "chapter_name_ar": None,
+            "chapter_name_en": None,
+        },
+    ]
+    (scraped_dir / "musnad-ahmad.json").write_text(json.dumps(hadiths), encoding="utf-8")
+
+
+class TestSunnahScrapedParser:
+    def test_produces_parquet_files(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+
+        output_files = run(raw_dir, staging_dir)
+
+        assert len(output_files) == 2
+        assert all(p.exists() for p in output_files)
+
+    def test_hadith_schema_conforms(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_sunnah_scraped.parquet")
+        assert table.schema == HADITH_SCHEMA
+        assert table.num_rows == 2
+
+    def test_collection_schema_conforms(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "collections_sunnah_scraped.parquet")
+        assert table.schema == COLLECTION_SCHEMA
+        assert table.num_rows == 1
+
+    def test_skips_when_no_raw_data(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+
+        output_files = run(raw_dir, staging_dir)
+
+        assert output_files == []
+
+    def test_source_corpus_is_sunnah(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_sunnah_scraped.parquet")
+        corpora = table.column("source_corpus").to_pylist()
+        assert all(c == "sunnah" for c in corpora)
+
+    def test_sect_is_sunni(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_sunnah_scraped.parquet")
+        sects = table.column("sect").to_pylist()
+        assert all(s == "sunni" for s in sects)
+
+    def test_chapter_metadata_preserved(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_sunnah_scraped.parquet")
+        chapters_en = table.column("chapter_name_en").to_pylist()
+        assert chapters_en[0] == "The Book of Purification"
+        assert chapters_en[1] is None
+
+    def test_ignores_manifest_json(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+        # Add manifest.json that should be ignored
+        (raw_dir / "sunnah_scraped" / "manifest.json").write_text("{}")
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_sunnah_scraped.parquet")
+        assert table.num_rows == 2  # Only from musnad-ahmad.json
+
+    def test_ignores_progress_files(self, tmp_path: Path) -> None:
+        raw_dir = tmp_path / "raw"
+        staging_dir = tmp_path / "staging"
+        _make_scraped_data(raw_dir)
+        # Add progress file that should be ignored
+        (raw_dir / "sunnah_scraped" / ".test_progress.json").write_text("{}")
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_sunnah_scraped.parquet")
+        assert table.num_rows == 2


### PR DESCRIPTION
## Summary
- New sunnah.com web scraper (BeautifulSoup + httpx, rate-limited)
- 8 collections not available in Fawaz
- Book/chapter metadata for all collections
- Resumable scraping with progress tracking
- Parser for scraped JSON → staging Parquet

## Related Issues
Closes #212

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>