### PR TITLE
Phase 8: Tech debt triage + cleanup

### DIFF
--- a/src/api/security.py
+++ b/src/api/security.py
@@ -65,10 +65,11 @@ def audit_cypher_queries(root: Path | None = None) -> list[dict[str, str]]:
     # of node types (no user input). Flag but note as low-risk.
     constraint_pattern = re.compile(r"CREATE CONSTRAINT IF NOT EXISTS")
 
+    _skip_dirs = {".venv", "__pycache__", ".git", "build", "dist", "node_modules", ".tox"}
+
     for py_file in root.rglob("*.py"):
-        # Skip __pycache__
         parts = py_file.parts
-        if "__pycache__" in parts:
+        if _skip_dirs & set(parts):
             continue
         try:
             content = py_file.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## Summary
- Triaged all 35 open issues across Phases 6-8
- Closed 12 issues: 7 Phase 6 duplicates superseded by Phase 7 equivalents, 3 retool duplicates (#208-210 = #211-213), 1 already-fixed (#233 pip-audit), 1 batch tracker (#220)
- Closed #192 (rate limiting) — implemented in PR #230
- Fixed #232: Cypher audit scanner now excludes `.venv`, `.git`, `build`, `dist`, `node_modules`, `.tox`
- Relabeled 4 Phase 7 tech-debt items (#193, #194, #195, #196) to `phase-8`
- Added `tech-debt` + `phase-8` labels to #188 (coverage ratchet)

## Triage Decisions

### Closed (12 issues)
| Issue | Reason |
|-------|--------|
| #170 | Dup of #192 |
| #169 | Dup of #193 |
| #167 | Dup of #195 |
| #152 | Dup of #195 |
| #161 | Dup of #196 |
| #156 | Dup of #194 |
| #163 | Dup of #197 (already closed) |
| #192 | Done — rate limiting in PR #230 |
| #208 | Dup of #211 (done) |
| #209 | Dup of #212 (done) |
| #210 | Dup of #213 (done) |
| #233 | Already fixed in commit 6b6e7eb |
| #220 | Batch tracker — all items resolved or tracked individually |

### Fixed (1 issue)
| Issue | Fix |
|-------|-----|
| #232 | Added directory exclusion set to `audit_cypher_queries()` |

### Remaining Open Tech Debt (Phase 8)
| Issue | Description |
|-------|-------------|
| #193 | Wire pgvector semantic search |
| #194 | Replace CONTAINS with full-text index |
| #195 | Extract inline styles to CSS modules |
| #196 | Refactor D3 enter/update/exit pattern |
| #188 | Ratchet coverage gate to 90% |
| #225 | Fawaz Arabic edition count validation |
| #226 | Columnar enrichment for large Fawaz datasets |
| #227 | Sunnah.com scraper CSS selector brittleness |
| #228 | Sunnah.com chapter_number simplification |
| #231 | Redis-backed rate limiting for multi-process |
| #234 | Configurable security headers |
| #235 | Redis-backed JWT token revocation |
| #236 | PKCE verifier persistence |
| #237 | OAuth redirect URI hardcoded |
| #238 | Apple OAuth ID token verification |

## Related Issues
Closes #232
Closes #246

## Test plan
- [x] `uv run ruff format src/api/security.py` — no changes needed
- [ ] CI passes (ruff, mypy, tests)

Co-Authored-By: Dmitri Volkov <parametrization+Dmitri.Volkov@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>