### PR TITLE
Implement Phase 8 retro feedback (4 items)

### DIFF
--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -370,6 +370,27 @@ This removes references to worktrees whose directories no longer exist. Without 
 
 The orchestrating agent is responsible for running `git worktree prune` after shutting down all wave agents and before creating the next wave's deployments branch.
 
+### Agent Naming Convention
+
+**Every spawned agent MUST map to a team roster member.** No anonymous functional agents.
+
+- **Naming pattern:** `{firstname}-{task-description}` (e.g., `tomasz-ci-fix`, `fatima-issue-audit`)
+- The orchestrator determines the most appropriate team member for the task BEFORE spawning
+- Tasks are assigned based on role fit (DevOps tasks → Tomasz, security → Yara, tests → Carolina, etc.)
+- **Violations:** Agents named with functional-only names (e.g., `ci-fixer`, `issue-closer`, `wave1-p7-launcher`) are NOT allowed
+
+**Mapping guide:**
+| Task Type | Assigned To |
+|-----------|-------------|
+| CI/CD, Docker, infrastructure | Tomasz Wójcik |
+| Security reviews, auth, OWASP | Yara Hadid |
+| Issue management, planning, retros | Fatima Okonkwo |
+| Architecture, diagrams, ADRs | Renaud Tremblay |
+| Code review, tech lead decisions | Dmitri Volkov |
+| Data quality, profiling, validation | Elena Petrova |
+| Test suites, QA | Priya Nair / Carolina Méndez-Ríos |
+| Feature implementation | Kwame / Amara / Hiro / Carolina |
+
 ## Code Review & Tech Debt
 
 ### Peer Review
@@ -410,6 +431,16 @@ When all work on a feature branch is complete (code committed, peer review done,
    - **Non-trivial tech debt**: Create a GitHub Issue assigned to themselves (labeled `tech-debt` + their `FIRSTNAME_LASTNAME` label) for the Tech Lead to allocate in future planning (max 20% of any team member's capacity).
 5. **Push final changes** from the review fixes.
 6. **The team merges** the PR into the deployments branch themselves — no user approval needed for PRs into deployments branches.
+
+### Cross-PR Dependency Sequencing
+
+When multiple PRs in the same wave have dependencies (e.g., PR B imports a module created by PR A):
+
+1. **Identify dependencies** before merging — check if any PR imports files from another PR's branch
+2. **Merge in dependency order** — base PR first, dependent PR second
+3. **Do NOT merge dependent PRs in parallel** — even if both have green CI, the dependent PR's CI ran against the base branch WITHOUT the dependency
+4. **After merging the base PR**, the dependent PR must rebase/merge the updated base before its CI result is trusted
+5. **Document dependencies** in PR descriptions: "Depends on PR #N (must merge first)"
 
 At the **end of a phase**, the Manager creates a PR from the final deployments branch into `main`. The **user reviews and merges** this PR. Do not proceed to the next phase until the user has merged.
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,4 +18,5 @@ if [[ ! "$branch" =~ ^[A-Z]\.[A-Za-z-]+/[0-9]{4}-[a-z0-9_-]+$ ]]; then
 fi
 
 echo "Branch name OK: $branch"
+echo "Reminder: run 'make check' before pushing to verify CI will pass."
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-hooks infra infra-down infra-reset acquire parse resolve load enrich test test-integration sample-data lint typecheck format clean pipeline validate-staging validate-pipeline profile-data test-e2e test-e2e-headed
+.PHONY: help setup setup-hooks infra infra-down infra-reset acquire parse resolve load enrich test test-integration sample-data lint typecheck format clean pipeline validate-staging validate-pipeline profile-data test-e2e test-e2e-headed check
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -73,6 +73,13 @@ test-e2e: ## Run Playwright browser tests (requires running app)
 
 test-e2e-headed: ## Run Playwright tests with visible browser
 	uv run pytest tests/e2e/ -v -m e2e --headed
+
+check:           ## Run all CI checks locally (lint + typecheck + test)
+	uv run ruff check src/ tests/
+	uv run ruff format --check src/ tests/
+	uv run mypy src/
+	uv run pytest tests/ -v --tb=short -x -m "not integration and not e2e"
+	@echo "All checks passed. Safe to push."
 
 pipeline: ## Run full pipeline
 	$(MAKE) acquire

--- a/docs/ci-job-name-audit.md
+++ b/docs/ci-job-name-audit.md
@@ -1,0 +1,19 @@
+# CI Job Name Audit Process
+
+After ANY change to `.github/workflows/ci.yml` that renames or adds/removes jobs:
+
+1. List current CI job names: `gh api repos/parametrization/isnad-graph/actions/workflows -q '.workflows[].name'`
+2. Check branch protection required checks: `gh api repos/parametrization/isnad-graph/branches/main/protection/required_status_checks`
+3. If mismatched, update branch protection:
+   ```bash
+   gh api repos/parametrization/isnad-graph/branches/main/protection/required_status_checks \
+     -X PATCH --input - <<'EOF'
+   {"strict": true, "contexts": ["lint-and-typecheck", "test", "security-audit"]}
+   EOF
+   ```
+4. Verify: `gh pr checks <any-open-pr>` should show all required checks.
+
+## Current Required Checks
+- `lint-and-typecheck`
+- `test`
+- `security-audit`


### PR DESCRIPTION
## Summary
- Add `make check` target for local CI pre-check (lint + format + typecheck + test)
- Create CI job name audit process doc (`docs/ci-job-name-audit.md`)
- Add Agent Naming Convention section to team charter (no anonymous functional agents)
- Add Cross-PR Dependency Sequencing rules to charter PR workflow

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>