### PR TITLE
Admin dashboard frontend pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Layout from './components/Layout'
+import AdminLayout from './components/AdminLayout'
 import NarratorsPage from './pages/NarratorsPage'
 import NarratorDetailPage from './pages/NarratorDetailPage'
 import HadithsPage from './pages/HadithsPage'
@@ -11,6 +12,10 @@ import SearchPage from './pages/SearchPage'
 import TimelinePage from './pages/TimelinePage'
 import ComparativePage from './pages/ComparativePage'
 import GraphExplorerPage from './pages/GraphExplorerPage'
+import UserManagementPage from './pages/admin/UserManagementPage'
+import SystemHealthPage from './pages/admin/SystemHealthPage'
+import ContentStatsPage from './pages/admin/ContentStatsPage'
+import UsageAnalyticsPage from './pages/admin/UsageAnalyticsPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -38,6 +43,13 @@ export default function App() {
             <Route path="timeline" element={<TimelinePage />} />
             <Route path="compare" element={<ComparativePage />} />
             <Route path="graph" element={<GraphExplorerPage />} />
+          </Route>
+          <Route path="admin" element={<AdminLayout />}>
+            <Route index element={<Navigate to="/admin/users" replace />} />
+            <Route path="users" element={<UserManagementPage />} />
+            <Route path="health" element={<SystemHealthPage />} />
+            <Route path="stats" element={<ContentStatsPage />} />
+            <Route path="analytics" element={<UsageAnalyticsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -1,0 +1,68 @@
+import type {
+  AdminUser,
+  UserUpdateRequest,
+  SystemHealth,
+  ContentStats,
+  UsageAnalytics,
+} from '../types/admin'
+import type { PaginatedResponse } from '../types/api'
+
+const API_BASE = '/api/v1/admin'
+
+function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...init?.headers },
+  })
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('Unauthorized: admin access required')
+  }
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status} ${res.statusText}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export async function fetchAdminUsers(
+  page = 1,
+  limit = 20,
+  search?: string,
+  role?: string,
+): Promise<PaginatedResponse<AdminUser>> {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (search) params.set('search', search)
+  if (role) params.set('role', role)
+  return fetchAdminJson(`${API_BASE}/users?${params}`)
+}
+
+export async function fetchAdminUser(userId: string): Promise<AdminUser> {
+  return fetchAdminJson(`${API_BASE}/users/${encodeURIComponent(userId)}`)
+}
+
+export async function updateAdminUser(
+  userId: string,
+  body: UserUpdateRequest,
+): Promise<AdminUser> {
+  return fetchAdminJson(`${API_BASE}/users/${encodeURIComponent(userId)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+export async function fetchSystemHealth(): Promise<SystemHealth> {
+  return fetchAdminJson(`${API_BASE}/health/ready`)
+}
+
+export async function fetchContentStats(): Promise<ContentStats> {
+  return fetchAdminJson(`${API_BASE}/stats`)
+}
+
+export async function fetchUsageAnalytics(): Promise<UsageAnalytics> {
+  return fetchAdminJson(`${API_BASE}/analytics`)
+}

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -1,0 +1,79 @@
+import { NavLink, Outlet, Navigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+const adminNavItems = [
+  { to: '/admin/users', label: 'User Management' },
+  { to: '/admin/health', label: 'System Health' },
+  { to: '/admin/stats', label: 'Content Stats' },
+  { to: '/admin/analytics', label: 'Usage Analytics' },
+]
+
+export default function AdminLayout() {
+  const { user, loading, isAdmin } = useAuth()
+
+  if (loading) {
+    return <p style={{ padding: '2rem' }}>Loading...</p>
+  }
+
+  if (!user || !isAdmin) {
+    return <Navigate to="/narrators" replace />
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <header
+        style={{
+          padding: '0.75rem 1.5rem',
+          borderBottom: '1px solid #ddd',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '1rem',
+          background: '#f8f9fa',
+        }}
+      >
+        <NavLink to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
+          <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Isnad Graph</h1>
+        </NavLink>
+        <span style={{ color: '#666', fontSize: '0.875rem' }}>Admin Dashboard</span>
+      </header>
+      <div style={{ display: 'flex', flex: 1 }}>
+        <nav
+          style={{
+            width: 220,
+            padding: '1rem',
+            borderRight: '1px solid #ddd',
+            background: '#fafafa',
+          }}
+        >
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            <li style={{ marginBottom: '1rem' }}>
+              <NavLink
+                to="/"
+                style={{ textDecoration: 'none', color: '#666', fontSize: '0.875rem' }}
+              >
+                Back to main site
+              </NavLink>
+            </li>
+            {adminNavItems.map((item) => (
+              <li key={item.to} style={{ marginBottom: '0.5rem' }}>
+                <NavLink
+                  to={item.to}
+                  style={({ isActive }) => ({
+                    textDecoration: 'none',
+                    fontWeight: isActive ? 700 : 400,
+                    color: isActive ? '#1a73e8' : '#333',
+                  })}
+                >
+                  {item.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <main style={{ flex: 1, padding: '1.5rem' }}>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
 
 const navItems = [
   { to: '/narrators', label: 'Narrators' },
@@ -11,6 +12,8 @@ const navItems = [
 ]
 
 export default function Sidebar() {
+  const { isAdmin } = useAuth()
+
   return (
     <nav style={{ width: 220, padding: '1rem', borderRight: '1px solid #ddd' }}>
       <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
@@ -28,6 +31,20 @@ export default function Sidebar() {
             </NavLink>
           </li>
         ))}
+        {isAdmin && (
+          <li style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid #ddd' }}>
+            <NavLink
+              to="/admin"
+              style={({ isActive }) => ({
+                textDecoration: 'none',
+                fontWeight: isActive ? 700 : 400,
+                color: isActive ? '#1a73e8' : '#333',
+              })}
+            >
+              Admin Dashboard
+            </NavLink>
+          </li>
+        )}
       </ul>
     </nav>
   )

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+
+interface AuthUser {
+  id: string
+  email: string
+  name: string
+  is_admin: boolean
+}
+
+const API_BASE = '/api/v1'
+
+export function useAuth() {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const token = localStorage.getItem('access_token')
+    if (!token) {
+      setLoading(false)
+      return
+    }
+
+    fetch(`${API_BASE}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('Unauthorized')
+        return res.json()
+      })
+      .then((data: AuthUser) => setUser(data))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { user, loading, isAdmin: user?.is_admin ?? false }
+}

--- a/frontend/src/pages/admin/ContentStatsPage.tsx
+++ b/frontend/src/pages/admin/ContentStatsPage.tsx
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchContentStats } from '../../api/admin-client'
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div
+      style={{
+        border: '1px solid #ddd',
+        borderRadius: '8px',
+        padding: '1.5rem',
+        minWidth: 180,
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>{label}</div>
+      <div style={{ fontSize: '1.5rem', fontWeight: 700, color: '#333' }}>{value}</div>
+    </div>
+  )
+}
+
+export default function ContentStatsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-stats'],
+    queryFn: fetchContentStats,
+  })
+
+  return (
+    <div>
+      <h2>Content Statistics</h2>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <StatCard label="Hadiths" value={data.hadith_count.toLocaleString()} />
+          <StatCard label="Narrators" value={data.narrator_count.toLocaleString()} />
+          <StatCard label="Collections" value={data.collection_count.toLocaleString()} />
+          <StatCard label="Coverage" value={`${data.coverage_pct}%`} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/admin/SystemHealthPage.tsx
+++ b/frontend/src/pages/admin/SystemHealthPage.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchSystemHealth } from '../../api/admin-client'
+
+function StatusCard({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <div
+      style={{
+        border: '1px solid #ddd',
+        borderRadius: '8px',
+        padding: '1.5rem',
+        minWidth: 180,
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>{label}</div>
+      <div
+        style={{
+          fontSize: '1.25rem',
+          fontWeight: 700,
+          color: ok ? '#188038' : '#d93025',
+        }}
+      >
+        {ok ? 'Connected' : 'Down'}
+      </div>
+    </div>
+  )
+}
+
+export default function SystemHealthPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-health'],
+    queryFn: fetchSystemHealth,
+    refetchInterval: 30_000,
+  })
+
+  return (
+    <div>
+      <h2>System Health</h2>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <div
+            style={{
+              display: 'flex',
+              gap: '1rem',
+              marginBottom: '2rem',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div
+              style={{
+                border: '1px solid #ddd',
+                borderRadius: '8px',
+                padding: '1.5rem',
+                minWidth: 180,
+                textAlign: 'center',
+              }}
+            >
+              <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>
+                Overall Status
+              </div>
+              <div
+                style={{
+                  fontSize: '1.25rem',
+                  fontWeight: 700,
+                  color: data.status === 'ok' ? '#188038' : '#e37400',
+                }}
+              >
+                {data.status.toUpperCase()}
+              </div>
+            </div>
+            <StatusCard label="Neo4j" ok={data.neo4j} />
+            <StatusCard label="PostgreSQL" ok={data.postgres} />
+            <StatusCard label="Redis" ok={data.redis} />
+          </div>
+
+          <p style={{ color: '#666', fontSize: '0.875rem' }}>Auto-refreshes every 30 seconds.</p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/admin/UsageAnalyticsPage.tsx
+++ b/frontend/src/pages/admin/UsageAnalyticsPage.tsx
@@ -1,0 +1,79 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchUsageAnalytics } from '../../api/admin-client'
+
+export default function UsageAnalyticsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-analytics'],
+    queryFn: fetchUsageAnalytics,
+  })
+
+  return (
+    <div>
+      <h2>Usage Analytics</h2>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <div style={{ display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap' }}>
+            <div
+              style={{
+                border: '1px solid #ddd',
+                borderRadius: '8px',
+                padding: '1.5rem',
+                minWidth: 180,
+                textAlign: 'center',
+              }}
+            >
+              <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>
+                Search Volume
+              </div>
+              <div style={{ fontSize: '1.5rem', fontWeight: 700, color: '#333' }}>
+                {data.search_volume.toLocaleString()}
+              </div>
+            </div>
+            <div
+              style={{
+                border: '1px solid #ddd',
+                borderRadius: '8px',
+                padding: '1.5rem',
+                minWidth: 180,
+                textAlign: 'center',
+              }}
+            >
+              <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>
+                API Calls
+              </div>
+              <div style={{ fontSize: '1.5rem', fontWeight: 700, color: '#333' }}>
+                {data.api_call_count.toLocaleString()}
+              </div>
+            </div>
+          </div>
+
+          <h3>Popular Narrators</h3>
+          {data.popular_narrators.length === 0 ? (
+            <p style={{ color: '#666' }}>No data available yet.</p>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', maxWidth: 600 }}>
+              <thead>
+                <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
+                  <th style={{ padding: '0.5rem' }}>Narrator</th>
+                  <th style={{ padding: '0.5rem' }}>Queries</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.popular_narrators.map((n) => (
+                  <tr key={n.id} style={{ borderBottom: '1px solid #eee' }}>
+                    <td style={{ padding: '0.5rem' }}>{n.name}</td>
+                    <td style={{ padding: '0.5rem' }}>{n.query_count.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/admin/UserManagementPage.tsx
+++ b/frontend/src/pages/admin/UserManagementPage.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { fetchAdminUsers, updateAdminUser } from '../../api/admin-client'
+import type { AdminUser } from '../../types/admin'
+
+export default function UserManagementPage() {
+  const queryClient = useQueryClient()
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const [inputValue, setInputValue] = useState('')
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-users', page, search],
+    queryFn: () => fetchAdminUsers(page, 20, search || undefined),
+  })
+
+  const suspendMutation = useMutation({
+    mutationFn: (user: AdminUser) =>
+      updateAdminUser(user.id, { is_suspended: !user.is_suspended }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+  })
+
+  const promoteMutation = useMutation({
+    mutationFn: (user: AdminUser) =>
+      updateAdminUser(user.id, { is_admin: !user.is_admin }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+  })
+
+  const handleSearch = () => {
+    setSearch(inputValue)
+    setPage(1)
+  }
+
+  const totalPages = data ? Math.ceil(data.total / data.limit) : 0
+
+  return (
+    <div>
+      <h2>User Management</h2>
+
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Search users by name or email..."
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          style={{ padding: '0.5rem', flex: 1, maxWidth: 400 }}
+        />
+        <button onClick={handleSearch} style={{ padding: '0.5rem 1rem' }}>
+          Search
+        </button>
+      </div>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
+                <th style={{ padding: '0.5rem' }}>Name</th>
+                <th style={{ padding: '0.5rem' }}>Email</th>
+                <th style={{ padding: '0.5rem' }}>Provider</th>
+                <th style={{ padding: '0.5rem' }}>Role</th>
+                <th style={{ padding: '0.5rem' }}>Status</th>
+                <th style={{ padding: '0.5rem' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((u) => (
+                <tr key={u.id} style={{ borderBottom: '1px solid #eee' }}>
+                  <td style={{ padding: '0.5rem' }}>
+                    {u.name}
+                    {u.is_admin && (
+                      <span
+                        style={{
+                          marginLeft: '0.5rem',
+                          fontSize: '0.75rem',
+                          background: '#e8f0fe',
+                          color: '#1a73e8',
+                          padding: '0.125rem 0.375rem',
+                          borderRadius: '4px',
+                        }}
+                      >
+                        Admin
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ padding: '0.5rem' }}>{u.email}</td>
+                  <td style={{ padding: '0.5rem' }}>{u.provider}</td>
+                  <td style={{ padding: '0.5rem' }}>{u.role ?? '-'}</td>
+                  <td style={{ padding: '0.5rem' }}>
+                    <span
+                      style={{
+                        color: u.is_suspended ? '#d93025' : '#188038',
+                        fontWeight: 600,
+                      }}
+                    >
+                      {u.is_suspended ? 'Suspended' : 'Active'}
+                    </span>
+                  </td>
+                  <td style={{ padding: '0.5rem', display: 'flex', gap: '0.25rem' }}>
+                    <button
+                      onClick={() => suspendMutation.mutate(u)}
+                      disabled={suspendMutation.isPending}
+                      style={{
+                        padding: '0.25rem 0.5rem',
+                        fontSize: '0.8rem',
+                        cursor: 'pointer',
+                        background: u.is_suspended ? '#e6f4ea' : '#fce8e6',
+                        border: '1px solid #ccc',
+                        borderRadius: '4px',
+                      }}
+                    >
+                      {u.is_suspended ? 'Unsuspend' : 'Suspend'}
+                    </button>
+                    <button
+                      onClick={() => promoteMutation.mutate(u)}
+                      disabled={promoteMutation.isPending}
+                      style={{
+                        padding: '0.25rem 0.5rem',
+                        fontSize: '0.8rem',
+                        cursor: 'pointer',
+                        background: u.is_admin ? '#fce8e6' : '#e8f0fe',
+                        border: '1px solid #ccc',
+                        borderRadius: '4px',
+                      }}
+                    >
+                      {u.is_admin ? 'Demote' : 'Promote'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div
+            style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}
+          >
+            <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              Previous
+            </button>
+            <span>
+              Page {data.page} of {totalPages}
+            </span>
+            <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -1,0 +1,42 @@
+export interface AdminUser {
+  id: string
+  email: string
+  name: string
+  provider: string
+  is_admin: boolean
+  is_suspended: boolean
+  created_at: string
+  role: string | null
+}
+
+export interface UserUpdateRequest {
+  is_admin?: boolean
+  is_suspended?: boolean
+  role?: string
+}
+
+export interface SystemHealth {
+  status: string
+  neo4j: boolean
+  postgres: boolean
+  redis: boolean
+}
+
+export interface ContentStats {
+  hadith_count: number
+  narrator_count: number
+  collection_count: number
+  coverage_pct: number
+}
+
+export interface PopularNarrator {
+  id: string
+  name: string
+  query_count: number
+}
+
+export interface UsageAnalytics {
+  search_volume: number
+  api_call_count: number
+  popular_narrators: PopularNarrator[]
+}


### PR DESCRIPTION
## Summary
- Add four admin dashboard pages: User Management, System Health, Content Stats, Usage Analytics
- Admin-only route protection via `useAuth` hook — non-admins redirected to `/narrators`
- `AdminLayout` component with dedicated sidebar navigation and "back to main site" link
- `admin-client.ts` API layer with auth header injection for all admin endpoints
- Sidebar conditionally shows "Admin Dashboard" link only for admin users

## Files Added
- `frontend/src/types/admin.ts` — TypeScript types matching backend admin models
- `frontend/src/hooks/useAuth.ts` — auth hook checking `/auth/me` for admin status
- `frontend/src/api/admin-client.ts` — admin API client functions
- `frontend/src/components/AdminLayout.tsx` — admin layout with sidebar + auth guard
- `frontend/src/pages/admin/UserManagementPage.tsx` — user table with search, suspend/promote
- `frontend/src/pages/admin/SystemHealthPage.tsx` — Neo4j/PG/Redis status cards (30s refresh)
- `frontend/src/pages/admin/ContentStatsPage.tsx` — hadith/narrator/collection counts + coverage
- `frontend/src/pages/admin/UsageAnalyticsPage.tsx` — search trends, API volume, popular narrators

## Files Modified
- `frontend/src/App.tsx` — added `/admin` routes with `AdminLayout`
- `frontend/src/components/Sidebar.tsx` — admin link visible only to admins

## Test plan
- [ ] Verify `/admin` redirects to `/narrators` when not logged in
- [ ] Verify `/admin` redirects to `/narrators` for non-admin users
- [ ] Verify admin users see "Admin Dashboard" in main sidebar
- [ ] Verify User Management page loads, search filters, suspend/promote buttons work
- [ ] Verify System Health page shows service status cards and auto-refreshes
- [ ] Verify Content Stats page renders stat cards
- [ ] Verify Usage Analytics page renders volume cards and narrator table

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)