### PR TITLE
Content moderation + system reports (#255)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import UserManagementPage from './pages/admin/UserManagementPage'
 import SystemHealthPage from './pages/admin/SystemHealthPage'
 import ContentStatsPage from './pages/admin/ContentStatsPage'
 import UsageAnalyticsPage from './pages/admin/UsageAnalyticsPage'
+import ModerationPage from './pages/admin/ModerationPage'
+import ReportsPage from './pages/admin/ReportsPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -43,6 +45,8 @@ export default function App() {
             <Route path="timeline" element={<TimelinePage />} />
             <Route path="compare" element={<ComparativePage />} />
             <Route path="graph" element={<GraphExplorerPage />} />
+            <Route path="admin/moderation" element={<ModerationPage />} />
+            <Route path="admin/reports" element={<ReportsPage />} />
           </Route>
           <Route path="admin" element={<AdminLayout />}>
             <Route index element={<Navigate to="/admin/users" replace />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,6 +10,8 @@ import type {
   ParallelsResponse,
   ParallelPairsResponse,
   NarratorNetworkResponse,
+  ModerationItem,
+  SystemReport,
 } from '../types/api'
 
 const API_BASE = '/api/v1'
@@ -120,4 +122,52 @@ export async function searchSemantic(
     limit: String(limit),
   })
   return fetchJson(`${API_BASE}/search/semantic?${params}`)
+}
+
+// --- Admin: Moderation ---
+
+export async function fetchModerationItems(
+  page = 1,
+  limit = 20,
+  status?: string,
+): Promise<PaginatedResponse<ModerationItem>> {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (status) params.set('status', status)
+  return fetchJson(`${API_BASE}/admin/moderation?${params}`)
+}
+
+export async function updateModerationItem(
+  id: string,
+  status: string,
+  notes?: string,
+): Promise<ModerationItem> {
+  const body: Record<string, string> = { status }
+  if (notes) body.notes = notes
+  const res = await fetch(`${API_BASE}/admin/moderation/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`API error: ${res.status} ${res.statusText}`)
+  return res.json() as Promise<ModerationItem>
+}
+
+export async function flagContent(
+  entityType: string,
+  entityId: string,
+  reason: string,
+): Promise<ModerationItem> {
+  const res = await fetch(`${API_BASE}/admin/moderation/flag`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ entity_type: entityType, entity_id: entityId, reason }),
+  })
+  if (!res.ok) throw new Error(`API error: ${res.status} ${res.statusText}`)
+  return res.json() as Promise<ModerationItem>
+}
+
+// --- Admin: Reports ---
+
+export async function fetchSystemReports(): Promise<SystemReport> {
+  return fetchJson(`${API_BASE}/admin/reports`)
 }

--- a/frontend/src/pages/admin/ModerationPage.tsx
+++ b/frontend/src/pages/admin/ModerationPage.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  fetchModerationItems,
+  updateModerationItem,
+  flagContent,
+} from '../../api/client'
+import type { ModerationItem } from '../../types/api'
+
+export default function ModerationPage() {
+  const [page, setPage] = useState(1)
+  const [statusFilter, setStatusFilter] = useState<string | undefined>(undefined)
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['moderation', page, statusFilter],
+    queryFn: () => fetchModerationItems(page, 20, statusFilter),
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, status, notes }: { id: string; status: string; notes?: string }) =>
+      updateModerationItem(id, status, notes),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['moderation'] })
+    },
+  })
+
+  const flagMutation = useMutation({
+    mutationFn: (body: { entity_type: string; entity_id: string; reason: string }) =>
+      flagContent(body.entity_type, body.entity_id, body.reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['moderation'] })
+    },
+  })
+
+  const [flagForm, setFlagForm] = useState({ entity_type: 'hadith', entity_id: '', reason: '' })
+
+  const totalPages = data ? Math.ceil(data.total / data.limit) : 0
+
+  return (
+    <div>
+      <h2>Content Moderation</h2>
+
+      <div style={{ marginBottom: '1.5rem', padding: '1rem', border: '1px solid #ddd' }}>
+        <h3 style={{ marginTop: 0 }}>Flag Content</h3>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <select
+            value={flagForm.entity_type}
+            onChange={(e) => setFlagForm({ ...flagForm, entity_type: e.target.value })}
+            style={{ padding: '0.5rem' }}
+          >
+            <option value="hadith">Hadith</option>
+            <option value="narrator">Narrator</option>
+          </select>
+          <input
+            type="text"
+            placeholder="Entity ID"
+            value={flagForm.entity_id}
+            onChange={(e) => setFlagForm({ ...flagForm, entity_id: e.target.value })}
+            style={{ padding: '0.5rem', flex: 1, minWidth: 200 }}
+          />
+          <input
+            type="text"
+            placeholder="Reason"
+            value={flagForm.reason}
+            onChange={(e) => setFlagForm({ ...flagForm, reason: e.target.value })}
+            style={{ padding: '0.5rem', flex: 2, minWidth: 200 }}
+          />
+          <button
+            onClick={() => {
+              if (flagForm.entity_id && flagForm.reason) {
+                flagMutation.mutate(flagForm)
+                setFlagForm({ ...flagForm, entity_id: '', reason: '' })
+              }
+            }}
+            disabled={flagMutation.isPending}
+            style={{ padding: '0.5rem 1rem' }}
+          >
+            Flag
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <label>Filter by status:</label>
+        <select
+          value={statusFilter ?? ''}
+          onChange={(e) => {
+            setStatusFilter(e.target.value || undefined)
+            setPage(1)
+          }}
+          style={{ padding: '0.5rem' }}
+        >
+          <option value="">All</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+      </div>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
+                <th style={{ padding: '0.5rem' }}>Type</th>
+                <th style={{ padding: '0.5rem' }}>Entity ID</th>
+                <th style={{ padding: '0.5rem' }}>Reason</th>
+                <th style={{ padding: '0.5rem' }}>Status</th>
+                <th style={{ padding: '0.5rem' }}>Flagged</th>
+                <th style={{ padding: '0.5rem' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((item: ModerationItem) => (
+                <tr key={item.id} style={{ borderBottom: '1px solid #eee' }}>
+                  <td style={{ padding: '0.5rem' }}>{item.entity_type}</td>
+                  <td style={{ padding: '0.5rem', fontFamily: 'monospace', fontSize: '0.85rem' }}>
+                    {item.entity_id}
+                  </td>
+                  <td style={{ padding: '0.5rem' }}>{item.reason}</td>
+                  <td style={{ padding: '0.5rem' }}>
+                    <span
+                      style={{
+                        padding: '0.2rem 0.5rem',
+                        borderRadius: '4px',
+                        background:
+                          item.status === 'approved'
+                            ? '#d4edda'
+                            : item.status === 'rejected'
+                              ? '#f8d7da'
+                              : '#fff3cd',
+                        color:
+                          item.status === 'approved'
+                            ? '#155724'
+                            : item.status === 'rejected'
+                              ? '#721c24'
+                              : '#856404',
+                      }}
+                    >
+                      {item.status}
+                    </span>
+                  </td>
+                  <td style={{ padding: '0.5rem', fontSize: '0.85rem' }}>
+                    {new Date(item.flagged_at).toLocaleDateString()}
+                  </td>
+                  <td style={{ padding: '0.5rem' }}>
+                    {item.status === 'pending' && (
+                      <div style={{ display: 'flex', gap: '0.25rem' }}>
+                        <button
+                          onClick={() =>
+                            updateMutation.mutate({ id: item.id, status: 'approved' })
+                          }
+                          disabled={updateMutation.isPending}
+                          style={{ padding: '0.25rem 0.5rem', fontSize: '0.85rem' }}
+                        >
+                          Approve
+                        </button>
+                        <button
+                          onClick={() =>
+                            updateMutation.mutate({ id: item.id, status: 'rejected' })
+                          }
+                          disabled={updateMutation.isPending}
+                          style={{ padding: '0.25rem 0.5rem', fontSize: '0.85rem' }}
+                        >
+                          Reject
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+              <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+                Previous
+              </button>
+              <span>
+                Page {page} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/admin/ReportsPage.tsx
+++ b/frontend/src/pages/admin/ReportsPage.tsx
@@ -1,0 +1,147 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchSystemReports } from '../../api/client'
+import type { SystemReport } from '../../types/api'
+
+function MetricCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        border: '1px solid #ddd',
+        borderRadius: '8px',
+        padding: '1rem',
+        marginBottom: '1rem',
+      }}
+    >
+      <h3 style={{ marginTop: 0, borderBottom: '1px solid #eee', paddingBottom: '0.5rem' }}>
+        {title}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0.25rem 0' }}>
+      <span>{label}</span>
+      <strong>{typeof value === 'number' ? value.toLocaleString() : value}</strong>
+    </div>
+  )
+}
+
+export default function ReportsPage() {
+  const { data, isLoading, error } = useQuery<SystemReport>({
+    queryKey: ['system-reports'],
+    queryFn: fetchSystemReports,
+  })
+
+  if (isLoading) return <p>Loading reports...</p>
+  if (error) return <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>
+  if (!data) return <p>No report data available.</p>
+
+  return (
+    <div>
+      <h2>System Reports</h2>
+
+      {data.pipeline && (
+        <MetricCard title="Pipeline Metrics">
+          <StatRow label="Total staging files" value={data.pipeline.total_files} />
+          <StatRow label="Total rows" value={data.pipeline.total_rows} />
+          {data.pipeline.files.length > 0 && (
+            <details style={{ marginTop: '0.5rem' }}>
+              <summary style={{ cursor: 'pointer' }}>
+                File details ({data.pipeline.files.length})
+              </summary>
+              <table
+                style={{
+                  width: '100%',
+                  borderCollapse: 'collapse',
+                  marginTop: '0.5rem',
+                  fontSize: '0.85rem',
+                }}
+              >
+                <thead>
+                  <tr style={{ borderBottom: '1px solid #ddd', textAlign: 'left' }}>
+                    <th style={{ padding: '0.25rem' }}>File</th>
+                    <th style={{ padding: '0.25rem' }}>Rows</th>
+                    <th style={{ padding: '0.25rem' }}>Columns</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.pipeline.files.map((f: Record<string, unknown>, i: number) => (
+                    <tr key={i} style={{ borderBottom: '1px solid #eee' }}>
+                      <td style={{ padding: '0.25rem', fontFamily: 'monospace' }}>
+                        {String(f.file ?? '')}
+                      </td>
+                      <td style={{ padding: '0.25rem' }}>
+                        {Number(f.rows ?? 0).toLocaleString()}
+                      </td>
+                      <td style={{ padding: '0.25rem' }}>{String(f.columns ?? '')}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          )}
+        </MetricCard>
+      )}
+
+      {data.disambiguation && (
+        <MetricCard title="Disambiguation Rates">
+          <StatRow label="NER mentions" value={data.disambiguation.ner_mention_count} />
+          <StatRow
+            label="Canonical narrators"
+            value={data.disambiguation.canonical_narrator_count}
+          />
+          <StatRow label="Ambiguous mentions" value={data.disambiguation.ambiguous_count} />
+          <StatRow
+            label="Resolution rate"
+            value={`${data.disambiguation.resolution_rate_pct}%`}
+          />
+          <StatRow label="Ambiguous rate" value={`${data.disambiguation.ambiguous_pct}%`} />
+        </MetricCard>
+      )}
+
+      {data.dedup && (
+        <MetricCard title="Dedup Coverage">
+          <StatRow label="Parallel links" value={data.dedup.parallel_links_count} />
+          <StatRow label="Verbatim" value={data.dedup.parallel_verbatim} />
+          <StatRow label="Close paraphrase" value={data.dedup.parallel_close_paraphrase} />
+          <StatRow label="Thematic" value={data.dedup.parallel_thematic} />
+          <StatRow label="Cross-sect" value={data.dedup.parallel_cross_sect} />
+        </MetricCard>
+      )}
+
+      {data.graph_validation && (
+        <MetricCard title="Graph Validation">
+          <StatRow label="Orphan narrators" value={data.graph_validation.orphan_narrators} />
+          <StatRow label="Orphan hadiths" value={data.graph_validation.orphan_hadiths} />
+          <StatRow
+            label="Chain integrity"
+            value={`${data.graph_validation.chain_integrity_pct}%`}
+          />
+          <StatRow
+            label="Collection coverage"
+            value={`${data.graph_validation.collection_coverage_pct}%`}
+          />
+        </MetricCard>
+      )}
+
+      {data.topic_coverage && (
+        <MetricCard title="Topic Classification">
+          <StatRow label="Total hadiths" value={data.topic_coverage.total_hadiths} />
+          <StatRow label="Classified" value={data.topic_coverage.classified_count} />
+          <StatRow label="Coverage" value={`${data.topic_coverage.coverage_pct}%`} />
+        </MetricCard>
+      )}
+
+      {!data.pipeline &&
+        !data.disambiguation &&
+        !data.dedup &&
+        !data.graph_validation &&
+        !data.topic_coverage && (
+          <p>No report data available. Run the pipeline to generate metrics.</p>
+        )}
+    </div>
+  )
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -163,3 +163,63 @@ export interface NarratorNetworkResponse {
   teachers: number
   students: number
 }
+
+// --- Moderation types ---
+
+export interface ModerationItem {
+  id: string
+  entity_type: string
+  entity_id: string
+  reason: string
+  status: string
+  flagged_by: string | null
+  flagged_at: string
+  resolved_by: string | null
+  resolved_at: string | null
+  notes: string | null
+}
+
+// --- System report types ---
+
+export interface PipelineMetrics {
+  total_files: number
+  total_rows: number
+  files: Record<string, unknown>[]
+}
+
+export interface DisambiguationMetrics {
+  ner_mention_count: number
+  canonical_narrator_count: number
+  ambiguous_count: number
+  resolution_rate_pct: number
+  ambiguous_pct: number
+}
+
+export interface DedupMetrics {
+  parallel_links_count: number
+  parallel_verbatim: number
+  parallel_close_paraphrase: number
+  parallel_thematic: number
+  parallel_cross_sect: number
+}
+
+export interface GraphValidationMetrics {
+  orphan_narrators: number
+  orphan_hadiths: number
+  chain_integrity_pct: number
+  collection_coverage_pct: number
+}
+
+export interface TopicCoverageMetrics {
+  total_hadiths: number
+  classified_count: number
+  coverage_pct: number
+}
+
+export interface SystemReport {
+  pipeline: PipelineMetrics | null
+  disambiguation: DisambiguationMetrics | null
+  dedup: DedupMetrics | null
+  graph_validation: GraphValidationMetrics | null
+  topic_coverage: TopicCoverageMetrics | null
+}

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -383,3 +383,112 @@ class UsageAnalyticsResponse(BaseModel):
     search_volume: int
     api_call_count: int
     popular_narrators: list[PopularNarrator]
+
+
+# --- Moderation models ---
+
+
+class ModerationItemResponse(BaseModel):
+    """A flagged content item awaiting moderation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    entity_type: str
+    entity_id: str
+    reason: str
+    status: str
+    flagged_by: str | None = None
+    flagged_at: str
+    resolved_by: str | None = None
+    resolved_at: str | None = None
+    notes: str | None = None
+
+
+class ModerationFlagRequest(BaseModel):
+    """Request body for flagging content."""
+
+    model_config = ConfigDict(frozen=True)
+
+    entity_type: str
+    entity_id: str
+    reason: str
+
+
+class ModerationUpdateRequest(BaseModel):
+    """Request body for approving/rejecting flagged content."""
+
+    model_config = ConfigDict(frozen=True)
+
+    status: str
+    notes: str | None = None
+
+
+# --- System report models ---
+
+
+class PipelineMetrics(BaseModel):
+    """Pipeline parse/staging metrics."""
+
+    model_config = ConfigDict(frozen=True)
+
+    total_files: int
+    total_rows: int
+    files: list[dict[str, object]]
+
+
+class DisambiguationMetrics(BaseModel):
+    """Disambiguation rate metrics per source."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ner_mention_count: int
+    canonical_narrator_count: int
+    ambiguous_count: int
+    resolution_rate_pct: float
+    ambiguous_pct: float
+
+
+class DedupMetrics(BaseModel):
+    """Dedup/parallel coverage metrics."""
+
+    model_config = ConfigDict(frozen=True)
+
+    parallel_links_count: int
+    parallel_verbatim: int
+    parallel_close_paraphrase: int
+    parallel_thematic: int
+    parallel_cross_sect: int
+
+
+class GraphValidationMetrics(BaseModel):
+    """Graph validation results."""
+
+    model_config = ConfigDict(frozen=True)
+
+    orphan_narrators: int
+    orphan_hadiths: int
+    chain_integrity_pct: float
+    collection_coverage_pct: float
+
+
+class TopicCoverageMetrics(BaseModel):
+    """Topic classification coverage."""
+
+    model_config = ConfigDict(frozen=True)
+
+    total_hadiths: int
+    classified_count: int
+    coverage_pct: float
+
+
+class SystemReportResponse(BaseModel):
+    """Aggregated system output report."""
+
+    model_config = ConfigDict(frozen=True)
+
+    pipeline: PipelineMetrics | None = None
+    disambiguation: DisambiguationMetrics | None = None
+    dedup: DedupMetrics | None = None
+    graph_validation: GraphValidationMetrics | None = None
+    topic_coverage: TopicCoverageMetrics | None = None

--- a/src/api/routes/admin/__init__.py
+++ b/src/api/routes/admin/__init__.py
@@ -6,6 +6,8 @@ from fastapi import APIRouter
 
 from src.api.routes.admin.analytics import router as analytics_router
 from src.api.routes.admin.health import router as health_router
+from src.api.routes.admin.moderation import router as moderation_router
+from src.api.routes.admin.reports import router as reports_router
 from src.api.routes.admin.stats import router as stats_router
 from src.api.routes.admin.users import router as users_router
 
@@ -14,3 +16,5 @@ router.include_router(users_router)
 router.include_router(health_router)
 router.include_router(stats_router)
 router.include_router(analytics_router)
+router.include_router(moderation_router)
+router.include_router(reports_router)

--- a/src/api/routes/admin/moderation.py
+++ b/src/api/routes/admin/moderation.py
@@ -1,0 +1,114 @@
+"""Admin content moderation endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.api.deps import get_neo4j
+from src.api.models import (
+    ModerationFlagRequest,
+    ModerationItemResponse,
+    ModerationUpdateRequest,
+    PaginatedResponse,
+)
+from src.utils.neo4j_client import Neo4jClient
+
+router = APIRouter()
+
+
+@router.get("/moderation", response_model=PaginatedResponse[ModerationItemResponse])
+def list_flagged_content(
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    status: str | None = Query(None, description="Filter by status: pending, approved, rejected"),
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> PaginatedResponse[ModerationItemResponse]:
+    """List flagged content items, optionally filtered by status."""
+    where = "WHERE m:MODERATION_FLAG"
+    params: dict[str, object] = {"skip": (page - 1) * limit, "limit": limit}
+    if status is not None:
+        where += " AND m.status = $status"
+        params["status"] = status
+
+    count_query = f"MATCH (m) {where} RETURN count(m) AS total"
+    count_result = neo4j.execute_read(count_query, params)
+    total = count_result[0]["total"] if count_result else 0
+
+    query = f"""
+        MATCH (m) {where}
+        RETURN properties(m) AS props
+        ORDER BY m.flagged_at DESC
+        SKIP $skip LIMIT $limit
+    """
+    rows = neo4j.execute_read(query, params)
+    items = [ModerationItemResponse(**row["props"]) for row in rows]
+    return PaginatedResponse(items=items, total=total, page=page, limit=limit)
+
+
+@router.patch("/moderation/{item_id}", response_model=ModerationItemResponse)
+def update_moderation_item(
+    item_id: str,
+    body: ModerationUpdateRequest,
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> ModerationItemResponse:
+    """Approve, reject, or update a flagged content item."""
+    if body.status not in ("approved", "rejected", "pending"):
+        raise HTTPException(status_code=400, detail="Status must be approved, rejected, or pending")
+
+    now = datetime.now(UTC).isoformat()
+    query = """
+        MATCH (m:MODERATION_FLAG {id: $id})
+        SET m.status = $status,
+            m.resolved_at = $resolved_at,
+            m.notes = $notes
+        RETURN properties(m) AS props
+    """
+    rows = neo4j.execute_read(
+        query,
+        {
+            "id": item_id,
+            "status": body.status,
+            "resolved_at": now if body.status != "pending" else None,
+            "notes": body.notes,
+        },
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="Moderation item not found")
+    return ModerationItemResponse(**rows[0]["props"])
+
+
+@router.post("/moderation/flag", response_model=ModerationItemResponse, status_code=201)
+def flag_content(
+    body: ModerationFlagRequest,
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> ModerationItemResponse:
+    """Flag a hadith or narrator for review."""
+    if body.entity_type not in ("hadith", "narrator"):
+        raise HTTPException(status_code=400, detail="entity_type must be 'hadith' or 'narrator'")
+
+    now = datetime.now(UTC).isoformat()
+    flag_id = f"mod:{body.entity_type}:{body.entity_id}:{now}"
+    query = """
+        CREATE (m:MODERATION_FLAG {
+            id: $id,
+            entity_type: $entity_type,
+            entity_id: $entity_id,
+            reason: $reason,
+            status: 'pending',
+            flagged_at: $flagged_at
+        })
+        RETURN properties(m) AS props
+    """
+    rows = neo4j.execute_read(
+        query,
+        {
+            "id": flag_id,
+            "entity_type": body.entity_type,
+            "entity_id": body.entity_id,
+            "reason": body.reason,
+            "flagged_at": now,
+        },
+    )
+    return ModerationItemResponse(**rows[0]["props"])

--- a/src/api/routes/admin/reports.py
+++ b/src/api/routes/admin/reports.py
@@ -1,0 +1,186 @@
+"""Admin system reports endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+
+from src.api.deps import get_neo4j
+from src.api.models import (
+    DedupMetrics,
+    DisambiguationMetrics,
+    GraphValidationMetrics,
+    PipelineMetrics,
+    SystemReportResponse,
+    TopicCoverageMetrics,
+)
+from src.utils.neo4j_client import Neo4jClient
+
+router = APIRouter()
+
+
+def _pipeline_metrics() -> PipelineMetrics | None:
+    """Collect pipeline parse/staging metrics from Parquet files."""
+    from src.config import get_settings
+
+    settings = get_settings()
+    staging_dir = Path(settings.data_staging_dir)
+    if not staging_dir.exists():
+        return None
+
+    try:
+        from src.parse.validate import validate_staging
+
+        summary = validate_staging(staging_dir)
+        return PipelineMetrics(
+            total_files=summary.get("total_files", 0),
+            total_rows=summary.get("total_rows", 0),
+            files=summary.get("files", []),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _disambiguation_metrics() -> DisambiguationMetrics | None:
+    """Collect disambiguation metrics from resolve output."""
+    from src.config import get_settings
+
+    settings = get_settings()
+    staging_dir = Path(settings.data_staging_dir)
+    output_dir = staging_dir / "resolved"
+    if not output_dir.exists():
+        return None
+
+    try:
+        from src.resolve import ResolveMetrics
+
+        metrics = ResolveMetrics()
+        from src.resolve import _collect_disambig_metrics, _collect_ner_metrics
+
+        _collect_ner_metrics(metrics, output_dir)
+        _collect_disambig_metrics(metrics, output_dir)
+
+        if metrics.ner_mention_count > 0:
+            resolved = metrics.ner_mention_count - metrics.ambiguous_count
+            metrics.resolution_rate_pct = resolved / metrics.ner_mention_count * 100
+            metrics.ambiguous_pct = metrics.ambiguous_count / metrics.ner_mention_count * 100
+
+        return DisambiguationMetrics(
+            ner_mention_count=metrics.ner_mention_count,
+            canonical_narrator_count=metrics.canonical_narrator_count,
+            ambiguous_count=metrics.ambiguous_count,
+            resolution_rate_pct=round(metrics.resolution_rate_pct, 2),
+            ambiguous_pct=round(metrics.ambiguous_pct, 2),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _dedup_metrics() -> DedupMetrics | None:
+    """Collect dedup/parallel metrics from staging output."""
+    from src.config import get_settings
+
+    settings = get_settings()
+    staging_dir = Path(settings.data_staging_dir)
+    path = staging_dir / "parallel_links.parquet"
+    if not path.exists():
+        return None
+
+    try:
+        from src.resolve import ResolveMetrics, _collect_dedup_metrics
+
+        metrics = ResolveMetrics()
+        _collect_dedup_metrics(metrics, staging_dir)
+        return DedupMetrics(
+            parallel_links_count=metrics.parallel_links_count,
+            parallel_verbatim=metrics.parallel_verbatim,
+            parallel_close_paraphrase=metrics.parallel_close_paraphrase,
+            parallel_thematic=metrics.parallel_thematic,
+            parallel_cross_sect=metrics.parallel_cross_sect,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _graph_validation_metrics(neo4j: Neo4jClient) -> GraphValidationMetrics | None:
+    """Query Neo4j for graph validation results."""
+    try:
+        query = """
+            OPTIONAL MATCH (n:NARRATOR)
+            WHERE NOT (n)-[:TRANSMITTED_TO]-() AND NOT (n)-[:NARRATED]-()
+            WITH count(n) AS orphan_narrators
+            OPTIONAL MATCH (h:HADITH)
+            WHERE NOT (h)-[:APPEARS_IN]->(:COLLECTION)
+            WITH orphan_narrators, count(h) AS orphan_hadiths
+            OPTIONAL MATCH (c:CHAIN)
+            WITH orphan_narrators, orphan_hadiths, count(c) AS total_chains
+            OPTIONAL MATCH (c2:CHAIN) WHERE c2.is_complete = true
+            WITH orphan_narrators, orphan_hadiths, total_chains,
+                 count(c2) AS complete_chains
+            OPTIONAL MATCH (h2:HADITH)
+            WITH orphan_narrators, orphan_hadiths, total_chains, complete_chains,
+                 count(h2) AS total_hadiths
+            OPTIONAL MATCH (h3:HADITH)-[:APPEARS_IN]->(:COLLECTION)
+            WITH orphan_narrators, orphan_hadiths, total_chains, complete_chains,
+                 total_hadiths, count(DISTINCT h3) AS linked_hadiths
+            RETURN orphan_narrators, orphan_hadiths,
+                   CASE WHEN total_chains > 0
+                        THEN toFloat(complete_chains) / toFloat(total_chains) * 100.0
+                        ELSE 0.0 END AS chain_integrity_pct,
+                   CASE WHEN total_hadiths > 0
+                        THEN toFloat(linked_hadiths) / toFloat(total_hadiths) * 100.0
+                        ELSE 0.0 END AS collection_coverage_pct
+        """
+        rows = neo4j.execute_read(query)
+        if not rows:
+            return None
+        r = rows[0]
+        return GraphValidationMetrics(
+            orphan_narrators=r.get("orphan_narrators", 0),
+            orphan_hadiths=r.get("orphan_hadiths", 0),
+            chain_integrity_pct=round(r.get("chain_integrity_pct", 0.0), 2),
+            collection_coverage_pct=round(r.get("collection_coverage_pct", 0.0), 2),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _topic_coverage_metrics(neo4j: Neo4jClient) -> TopicCoverageMetrics | None:
+    """Query Neo4j for topic classification coverage."""
+    try:
+        query = """
+            OPTIONAL MATCH (h:HADITH)
+            WITH count(h) AS total_hadiths
+            OPTIONAL MATCH (h2:HADITH)
+            WHERE size(h2.topic_tags) > 0
+            RETURN total_hadiths, count(h2) AS classified_count,
+                   CASE WHEN total_hadiths > 0
+                        THEN toFloat(count(h2)) / toFloat(total_hadiths) * 100.0
+                        ELSE 0.0 END AS coverage_pct
+        """
+        rows = neo4j.execute_read(query)
+        if not rows:
+            return None
+        r = rows[0]
+        return TopicCoverageMetrics(
+            total_hadiths=r.get("total_hadiths", 0),
+            classified_count=r.get("classified_count", 0),
+            coverage_pct=round(r.get("coverage_pct", 0.0), 2),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+@router.get("/reports", response_model=SystemReportResponse)
+def system_reports(
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> SystemReportResponse:
+    """Return aggregated system output reports."""
+    return SystemReportResponse(
+        pipeline=_pipeline_metrics(),
+        disambiguation=_disambiguation_metrics(),
+        dedup=_dedup_metrics(),
+        graph_validation=_graph_validation_metrics(neo4j),
+        topic_coverage=_topic_coverage_metrics(neo4j),
+    )


### PR DESCRIPTION
## Summary
- **Moderation API** (`/api/v1/admin/moderation`): list flagged content (paginated, filterable by status), approve/reject/flag hadiths and narrators via Neo4j `MODERATION_FLAG` nodes
- **Reports API** (`/api/v1/admin/reports`): aggregated system metrics — pipeline parse stats, disambiguation rates, dedup/parallel coverage, graph validation (orphans, chain integrity), topic classification coverage
- **Frontend**: ModerationPage with flag form + approve/reject queue; ReportsPage with metric cards for all pipeline stages
- Response models, TypeScript types, and API client functions for both features

## Test plan
- [ ] Verify `GET /api/v1/admin/moderation` returns paginated flagged items
- [ ] Verify `POST /api/v1/admin/moderation/flag` creates a new MODERATION_FLAG node
- [ ] Verify `PATCH /api/v1/admin/moderation/{id}` updates status to approved/rejected
- [ ] Verify `GET /api/v1/admin/reports` returns pipeline, disambiguation, dedup, graph, and topic metrics
- [ ] Verify admin auth gate (403 for non-admin users)
- [ ] Verify ModerationPage renders flagged items with approve/reject buttons
- [ ] Verify ReportsPage renders metric cards when data is available

Closes #255