### PR TITLE
Phase 9: Admin dashboard test suite

### DIFF
--- a/tests/test_api/test_admin_auth.py
+++ b/tests/test_api/test_admin_auth.py
@@ -1,0 +1,138 @@
+"""Tests for admin auth enforcement across all admin endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from src.api.middleware import require_admin
+from src.auth.models import User
+from tests.test_api.test_admin import _test_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    test_settings = _test_settings()
+    from src.config import get_settings
+
+    get_settings.cache_clear()
+
+    import src.config
+
+    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.return_value = []
+    client.execute_write.return_value = []
+    return client
+
+
+@pytest.fixture
+def noauth_app(mock_neo4j: MagicMock) -> FastAPI:
+    """App with no auth overrides — all admin endpoints should return 401."""
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+    return app
+
+
+@pytest.fixture
+def noauth_client(noauth_app: FastAPI) -> TestClient:
+    return TestClient(noauth_app)
+
+
+@pytest.fixture
+def regular_app(mock_neo4j: MagicMock) -> FastAPI:
+    """App with non-admin user — all admin endpoints should return 403."""
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+
+    def _raise_forbidden() -> User:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = _raise_forbidden
+    return app
+
+
+@pytest.fixture
+def regular_client(regular_app: FastAPI) -> TestClient:
+    return TestClient(regular_app)
+
+
+# All admin GET endpoints that should be protected
+ADMIN_GET_ENDPOINTS = [
+    "/api/v1/admin/health/live",
+    "/api/v1/admin/health/ready",
+    "/api/v1/admin/stats",
+    "/api/v1/admin/analytics",
+    "/api/v1/admin/users",
+    "/api/v1/admin/moderation",
+    "/api/v1/admin/reports",
+    "/api/v1/admin/config",
+    "/api/v1/admin/config/audit",
+]
+
+
+class TestAllEndpoints401:
+    """Verify every admin endpoint returns 401 without auth."""
+
+    @pytest.mark.parametrize("endpoint", ADMIN_GET_ENDPOINTS)
+    def test_get_endpoints_401(self, noauth_client: TestClient, endpoint: str) -> None:
+        resp = noauth_client.get(endpoint)
+        assert resp.status_code == 401, f"{endpoint} returned {resp.status_code}"
+
+    def test_patch_moderation_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
+        assert resp.status_code == 401
+
+    def test_post_flag_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "hadith", "entity_id": "h1", "reason": "test"},
+        )
+        assert resp.status_code == 401
+
+    def test_patch_config_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
+        assert resp.status_code == 401
+
+    def test_patch_user_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.patch("/api/v1/admin/users/u1", json={"is_admin": True})
+        assert resp.status_code == 401
+
+
+class TestAllEndpoints403:
+    """Verify every admin endpoint returns 403 for non-admin users."""
+
+    @pytest.mark.parametrize("endpoint", ADMIN_GET_ENDPOINTS)
+    def test_get_endpoints_403(self, regular_client: TestClient, endpoint: str) -> None:
+        resp = regular_client.get(endpoint)
+        assert resp.status_code == 403, f"{endpoint} returned {resp.status_code}"
+
+    def test_patch_moderation_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
+        assert resp.status_code == 403
+
+    def test_post_flag_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "hadith", "entity_id": "h1", "reason": "test"},
+        )
+        assert resp.status_code == 403
+
+    def test_patch_config_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
+        assert resp.status_code == 403
+
+    def test_patch_user_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.patch("/api/v1/admin/users/u1", json={"is_admin": True})
+        assert resp.status_code == 403

--- a/tests/test_api/test_admin_config.py
+++ b/tests/test_api/test_admin_config.py
@@ -1,0 +1,260 @@
+"""Tests for admin config endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.middleware import require_admin
+from src.auth.models import User
+from tests.test_api.test_admin import _admin_user, _test_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    test_settings = _test_settings()
+    from src.config import get_settings
+
+    get_settings.cache_clear()
+
+    import src.config
+
+    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.return_value = []
+    client.execute_write.return_value = []
+    return client
+
+
+@pytest.fixture
+def mock_pg() -> MagicMock:
+    pg = MagicMock()
+    pg.execute.return_value = []
+    return pg
+
+
+@pytest.fixture
+def admin_app(mock_neo4j: MagicMock, mock_pg: MagicMock) -> FastAPI:
+    from src.api.app import create_app
+    from src.api.deps import get_pg
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+    app.dependency_overrides[require_admin] = _admin_user
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+    return app
+
+
+@pytest.fixture
+def admin_client(admin_app: FastAPI) -> TestClient:
+    return TestClient(admin_app)
+
+
+class TestGetConfig:
+    def test_defaults(self, admin_client: TestClient) -> None:
+        resp = admin_client.get("/api/v1/admin/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rate_limit_per_minute"] == 60
+        assert data["cors_origins"] == ["http://localhost:3000"]
+        assert data["feature_flags"] == {}
+        assert data["max_search_results"] == 100
+        assert data["max_pagination_limit"] == 100
+
+    def test_from_db(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        def fake_execute(query: str, params: object = None) -> list[dict[str, object]]:
+            if "SELECT key, value FROM system_config" in query:
+                return [
+                    {"key": "rate_limit_per_minute", "value": "120"},
+                    {"key": "max_search_results", "value": "50"},
+                ]
+            return []
+
+        mock_pg.execute.side_effect = fake_execute
+        resp = admin_client.get("/api/v1/admin/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rate_limit_per_minute"] == 120
+        assert data["max_search_results"] == 50
+        # Defaults for missing keys
+        assert data["max_pagination_limit"] == 100
+
+
+class TestUpdateConfig:
+    def test_update_allowed_value(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        mock_pg.execute.return_value = []
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"rate_limit_per_minute": 120},
+        )
+        assert resp.status_code == 200
+        # Verify upsert + audit calls
+        calls = mock_pg.execute.call_args_list
+        upsert_calls = [c for c in calls if "INSERT INTO system_config" in str(c)]
+        audit_calls = [c for c in calls if "INSERT INTO config_audit" in str(c)]
+        assert len(upsert_calls) >= 1
+        assert len(audit_calls) >= 1
+
+    def test_update_multiple_fields(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        mock_pg.execute.return_value = []
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"rate_limit_per_minute": 30, "max_search_results": 200},
+        )
+        assert resp.status_code == 200
+
+    def test_reject_empty_body(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch("/api/v1/admin/config", json={})
+        assert resp.status_code == 400
+
+    def test_reject_forbidden_key_jwt_secret(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"jwt_secret": "hacked"},
+        )
+        # Unknown field is ignored by pydantic → no valid fields → 400
+        assert resp.status_code == 400
+
+    def test_reject_forbidden_key_neo4j_password(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"neo4j_password": "hacked"},
+        )
+        assert resp.status_code == 400
+
+    def test_reject_forbidden_key_pg_dsn(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"pg_dsn": "postgresql://hack:hack@evil/db"},
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_type_rejected(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"rate_limit_per_minute": "not_a_number"},
+        )
+        assert resp.status_code == 422
+
+
+class TestConfigAudit:
+    def test_empty_audit(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        def fake_execute(query: str, params: object = None) -> list[dict[str, object]]:
+            if "count(*)" in query:
+                return [{"total": 0}]
+            return []
+
+        mock_pg.execute.side_effect = fake_execute
+        resp = admin_client.get("/api/v1/admin/config/audit")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entries"] == []
+        assert data["total"] == 0
+
+    def test_audit_with_entries(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        def fake_execute(query: str, params: object = None) -> list[dict[str, object]]:
+            if "count(*)" in query:
+                return [{"total": 2}]
+            if "SELECT key, old_value" in query:
+                return [
+                    {
+                        "key": "rate_limit_per_minute",
+                        "old_value": "60",
+                        "new_value": "120",
+                        "changed_by": "admin-user",
+                        "changed_at": "2026-03-16 12:00:00+00",
+                    },
+                    {
+                        "key": "max_search_results",
+                        "old_value": "100",
+                        "new_value": "50",
+                        "changed_by": "admin-user",
+                        "changed_at": "2026-03-16 13:00:00+00",
+                    },
+                ]
+            return []
+
+        mock_pg.execute.side_effect = fake_execute
+        resp = admin_client.get("/api/v1/admin/config/audit")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert len(data["entries"]) == 2
+        assert data["entries"][0]["key"] == "rate_limit_per_minute"
+        assert data["entries"][1]["key"] == "max_search_results"
+
+    def test_audit_pagination(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        def fake_execute(query: str, params: object = None) -> list[dict[str, object]]:
+            if "count(*)" in query:
+                return [{"total": 100}]
+            return []
+
+        mock_pg.execute.side_effect = fake_execute
+        resp = admin_client.get("/api/v1/admin/config/audit?page=2&limit=10")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 100
+
+
+class TestConfigAuthEnforcement:
+    @pytest.fixture
+    def noauth_app(self, mock_neo4j: MagicMock) -> FastAPI:
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+        return app
+
+    @pytest.fixture
+    def noauth_client(self, noauth_app: FastAPI) -> TestClient:
+        return TestClient(noauth_app)
+
+    @pytest.fixture
+    def regular_app(self, mock_neo4j: MagicMock) -> FastAPI:
+        from fastapi import HTTPException
+
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+
+        def _raise_forbidden() -> User:
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+        app.dependency_overrides[require_admin] = _raise_forbidden
+        return app
+
+    @pytest.fixture
+    def regular_client(self, regular_app: FastAPI) -> TestClient:
+        return TestClient(regular_app)
+
+    def test_get_config_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.get("/api/v1/admin/config")
+        assert resp.status_code == 401
+
+    def test_get_config_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.get("/api/v1/admin/config")
+        assert resp.status_code == 403
+
+    def test_patch_config_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
+        assert resp.status_code == 401
+
+    def test_patch_config_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
+        assert resp.status_code == 403
+
+    def test_audit_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.get("/api/v1/admin/config/audit")
+        assert resp.status_code == 401
+
+    def test_audit_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.get("/api/v1/admin/config/audit")
+        assert resp.status_code == 403

--- a/tests/test_api/test_admin_moderation.py
+++ b/tests/test_api/test_admin_moderation.py
@@ -1,0 +1,294 @@
+"""Tests for admin moderation endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.middleware import require_admin
+from src.auth.models import User
+from tests.test_api.test_admin import (
+    _admin_user,
+    _test_settings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    test_settings = _test_settings()
+    from src.config import get_settings
+
+    get_settings.cache_clear()
+
+    import src.config
+
+    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.return_value = []
+    client.execute_write.return_value = []
+    return client
+
+
+@pytest.fixture
+def admin_app(mock_neo4j: MagicMock) -> FastAPI:
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+    app.dependency_overrides[require_admin] = _admin_user
+    return app
+
+
+@pytest.fixture
+def admin_client(admin_app: FastAPI) -> TestClient:
+    return TestClient(admin_app)
+
+
+@pytest.fixture
+def mock_moderation_data() -> list[dict[str, object]]:
+    return [
+        {
+            "props": {
+                "id": "mod:hadith:h1:2026-03-16T00:00:00",
+                "entity_type": "hadith",
+                "entity_id": "h1",
+                "reason": "Incorrect attribution",
+                "status": "pending",
+                "flagged_at": "2026-03-16T00:00:00",
+            }
+        },
+        {
+            "props": {
+                "id": "mod:narrator:n1:2026-03-16T00:00:00",
+                "entity_type": "narrator",
+                "entity_id": "n1",
+                "reason": "Duplicate entry",
+                "status": "pending",
+                "flagged_at": "2026-03-16T01:00:00",
+            }
+        },
+    ]
+
+
+class TestListFlaggedContent:
+    def test_list_empty(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.side_effect = [[{"total": 0}], []]
+        resp = admin_client.get("/api/v1/admin/moderation")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+
+    def test_list_with_items(
+        self,
+        admin_client: TestClient,
+        mock_neo4j: MagicMock,
+        mock_moderation_data: list[dict[str, object]],
+    ) -> None:
+        mock_neo4j.execute_read.side_effect = [
+            [{"total": 2}],
+            mock_moderation_data,
+        ]
+        resp = admin_client.get("/api/v1/admin/moderation")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert len(data["items"]) == 2
+        assert data["items"][0]["entity_type"] == "hadith"
+        assert data["items"][1]["entity_type"] == "narrator"
+
+    def test_list_pagination(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.side_effect = [[{"total": 50}], []]
+        resp = admin_client.get("/api/v1/admin/moderation?page=3&limit=10")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 50
+        assert data["page"] == 3
+        assert data["limit"] == 10
+
+    def test_list_filter_by_status(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.side_effect = [[{"total": 1}], []]
+        resp = admin_client.get("/api/v1/admin/moderation?status=approved")
+        assert resp.status_code == 200
+
+
+class TestUpdateModerationItem:
+    def test_approve(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.return_value = [
+            {
+                "props": {
+                    "id": "mod:hadith:h1:2026-03-16",
+                    "entity_type": "hadith",
+                    "entity_id": "h1",
+                    "reason": "test",
+                    "status": "approved",
+                    "flagged_at": "2026-03-16T00:00:00",
+                    "resolved_at": "2026-03-16T01:00:00",
+                    "notes": "Looks good",
+                }
+            }
+        ]
+        resp = admin_client.patch(
+            "/api/v1/admin/moderation/mod:hadith:h1:2026-03-16",
+            json={"status": "approved", "notes": "Looks good"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "approved"
+
+    def test_reject(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.return_value = [
+            {
+                "props": {
+                    "id": "mod:hadith:h1:2026-03-16",
+                    "entity_type": "hadith",
+                    "entity_id": "h1",
+                    "reason": "test",
+                    "status": "rejected",
+                    "flagged_at": "2026-03-16T00:00:00",
+                    "resolved_at": "2026-03-16T01:00:00",
+                    "notes": None,
+                }
+            }
+        ]
+        resp = admin_client.patch(
+            "/api/v1/admin/moderation/mod:hadith:h1:2026-03-16",
+            json={"status": "rejected"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "rejected"
+
+    def test_invalid_status(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        resp = admin_client.patch(
+            "/api/v1/admin/moderation/some-id",
+            json={"status": "invalid_status"},
+        )
+        assert resp.status_code == 400
+
+    def test_not_found(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.return_value = []
+        resp = admin_client.patch(
+            "/api/v1/admin/moderation/nonexistent",
+            json={"status": "approved"},
+        )
+        assert resp.status_code == 404
+
+
+class TestFlagContent:
+    def test_flag_hadith(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.return_value = [
+            {
+                "props": {
+                    "id": "mod:hadith:h1:2026-03-16T00:00:00",
+                    "entity_type": "hadith",
+                    "entity_id": "h1",
+                    "reason": "Suspect chain",
+                    "status": "pending",
+                    "flagged_at": "2026-03-16T00:00:00",
+                }
+            }
+        ]
+        resp = admin_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "hadith", "entity_id": "h1", "reason": "Suspect chain"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["entity_type"] == "hadith"
+        assert data["status"] == "pending"
+
+    def test_flag_narrator(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        mock_neo4j.execute_read.return_value = [
+            {
+                "props": {
+                    "id": "mod:narrator:n1:2026-03-16T00:00:00",
+                    "entity_type": "narrator",
+                    "entity_id": "n1",
+                    "reason": "Duplicate",
+                    "status": "pending",
+                    "flagged_at": "2026-03-16T00:00:00",
+                }
+            }
+        ]
+        resp = admin_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "narrator", "entity_id": "n1", "reason": "Duplicate"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["entity_type"] == "narrator"
+
+    def test_invalid_entity_type(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        resp = admin_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "collection", "entity_id": "c1", "reason": "test"},
+        )
+        assert resp.status_code == 400
+
+
+class TestModerationAuthEnforcement:
+    @pytest.fixture
+    def noauth_app(self, mock_neo4j: MagicMock) -> FastAPI:
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+        return app
+
+    @pytest.fixture
+    def noauth_client(self, noauth_app: FastAPI) -> TestClient:
+        return TestClient(noauth_app)
+
+    @pytest.fixture
+    def regular_app(self, mock_neo4j: MagicMock) -> FastAPI:
+        from fastapi import HTTPException
+
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+
+        def _raise_forbidden() -> User:
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+        app.dependency_overrides[require_admin] = _raise_forbidden
+        return app
+
+    @pytest.fixture
+    def regular_client(self, regular_app: FastAPI) -> TestClient:
+        return TestClient(regular_app)
+
+    def test_list_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.get("/api/v1/admin/moderation")
+        assert resp.status_code == 401
+
+    def test_list_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.get("/api/v1/admin/moderation")
+        assert resp.status_code == 403
+
+    def test_patch_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
+        assert resp.status_code == 401
+
+    def test_patch_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
+        assert resp.status_code == 403
+
+    def test_flag_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "hadith", "entity_id": "h1", "reason": "test"},
+        )
+        assert resp.status_code == 401
+
+    def test_flag_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.post(
+            "/api/v1/admin/moderation/flag",
+            json={"entity_type": "hadith", "entity_id": "h1", "reason": "test"},
+        )
+        assert resp.status_code == 403

--- a/tests/test_api/test_admin_reports.py
+++ b/tests/test_api/test_admin_reports.py
@@ -1,0 +1,207 @@
+"""Tests for admin reports endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.middleware import require_admin
+from src.auth.models import User
+from tests.test_api.test_admin import _admin_user, _test_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    test_settings = _test_settings()
+    from src.config import get_settings
+
+    get_settings.cache_clear()
+
+    import src.config
+
+    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.return_value = []
+    client.execute_write.return_value = []
+    return client
+
+
+@pytest.fixture
+def admin_app(mock_neo4j: MagicMock) -> FastAPI:
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+    app.dependency_overrides[require_admin] = _admin_user
+    return app
+
+
+@pytest.fixture
+def admin_client(admin_app: FastAPI) -> TestClient:
+    return TestClient(admin_app)
+
+
+class TestSystemReports:
+    def test_reports_returns_structure(self, admin_client: TestClient) -> None:
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "pipeline" in data
+        assert "disambiguation" in data
+        assert "dedup" in data
+        assert "graph_validation" in data
+        assert "topic_coverage" in data
+
+    def test_reports_sections_nullable(self, admin_client: TestClient) -> None:
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        # disambiguation and dedup are null without resolved/parallel data
+        assert data["disambiguation"] is None
+        assert data["dedup"] is None
+
+    @patch("src.api.routes.admin.reports._pipeline_metrics")
+    def test_reports_with_pipeline_data(
+        self, mock_pipeline: MagicMock, admin_client: TestClient
+    ) -> None:
+        from src.api.models import PipelineMetrics
+
+        mock_pipeline.return_value = PipelineMetrics(total_files=5, total_rows=1000, files=[])
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pipeline"] is not None
+        assert data["pipeline"]["total_files"] == 5
+        assert data["pipeline"]["total_rows"] == 1000
+
+    @patch("src.api.routes.admin.reports._disambiguation_metrics")
+    def test_reports_with_disambiguation_data(
+        self, mock_disambig: MagicMock, admin_client: TestClient
+    ) -> None:
+        from src.api.models import DisambiguationMetrics
+
+        mock_disambig.return_value = DisambiguationMetrics(
+            ner_mention_count=500,
+            canonical_narrator_count=200,
+            ambiguous_count=50,
+            resolution_rate_pct=90.0,
+            ambiguous_pct=10.0,
+        )
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["disambiguation"] is not None
+        assert data["disambiguation"]["ner_mention_count"] == 500
+        assert data["disambiguation"]["resolution_rate_pct"] == 90.0
+
+    @patch("src.api.routes.admin.reports._dedup_metrics")
+    def test_reports_with_dedup_data(self, mock_dedup: MagicMock, admin_client: TestClient) -> None:
+        from src.api.models import DedupMetrics
+
+        mock_dedup.return_value = DedupMetrics(
+            parallel_links_count=100,
+            parallel_verbatim=40,
+            parallel_close_paraphrase=30,
+            parallel_thematic=20,
+            parallel_cross_sect=10,
+        )
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dedup"] is not None
+        assert data["dedup"]["parallel_links_count"] == 100
+
+    def test_reports_graph_validation(
+        self, admin_client: TestClient, mock_neo4j: MagicMock
+    ) -> None:
+        # Graph validation queries Neo4j — return some data
+        mock_neo4j.execute_read.return_value = [
+            {
+                "orphan_narrators": 5,
+                "orphan_hadiths": 2,
+                "chain_integrity_pct": 95.5,
+                "collection_coverage_pct": 88.0,
+            }
+        ]
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["graph_validation"] is not None
+        assert data["graph_validation"]["orphan_narrators"] == 5
+        assert data["graph_validation"]["chain_integrity_pct"] == 95.5
+
+    def test_reports_topic_coverage(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        # Topic coverage also queries Neo4j — return after graph validation call
+        mock_neo4j.execute_read.side_effect = [
+            # graph_validation query
+            [
+                {
+                    "orphan_narrators": 0,
+                    "orphan_hadiths": 0,
+                    "chain_integrity_pct": 100.0,
+                    "collection_coverage_pct": 100.0,
+                }
+            ],
+            # topic_coverage query
+            [
+                {
+                    "total_hadiths": 1000,
+                    "classified_count": 800,
+                    "coverage_pct": 80.0,
+                }
+            ],
+        ]
+        resp = admin_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["topic_coverage"] is not None
+        assert data["topic_coverage"]["total_hadiths"] == 1000
+        assert data["topic_coverage"]["coverage_pct"] == 80.0
+
+
+class TestReportsAuthEnforcement:
+    @pytest.fixture
+    def noauth_app(self, mock_neo4j: MagicMock) -> FastAPI:
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+        return app
+
+    @pytest.fixture
+    def noauth_client(self, noauth_app: FastAPI) -> TestClient:
+        return TestClient(noauth_app)
+
+    @pytest.fixture
+    def regular_app(self, mock_neo4j: MagicMock) -> FastAPI:
+        from fastapi import HTTPException
+
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+
+        def _raise_forbidden() -> User:
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+        app.dependency_overrides[require_admin] = _raise_forbidden
+        return app
+
+    @pytest.fixture
+    def regular_client(self, regular_app: FastAPI) -> TestClient:
+        return TestClient(regular_app)
+
+    def test_reports_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 401
+
+    def test_reports_403(self, regular_client: TestClient) -> None:
+        resp = regular_client.get("/api/v1/admin/reports")
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- Comprehensive admin endpoint tests: moderation (list, approve, reject, flag), reports (structure, sections with mocked data), config (defaults, DB values, updates, forbidden keys, validation, audit log)
- Auth boundary tests: 401 unauthenticated and 403 non-admin across all admin endpoints (parametrized)
- Config security tests: forbidden keys (jwt_secret, neo4j_password, pg_dsn), invalid type validation
- 70 new tests across 4 test files

## Related Issues
Closes #257

## Test plan
- [x] All 70 new tests pass
- [x] All 91 pre-existing passing API tests still pass
- [x] Lint checks pass (ruff check)
- [x] Format checks pass for new files (pre-existing format issues in search.py are unrelated)

Co-Authored-By: Priya Nair <parametrization+Priya.Nair@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>