### PR TITLE
feat: fulltext search indexes + pgvector semantic search wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: uv-${{ runner.os }}-
       - run: uv sync --group ml
-      - run: uv run pytest tests/ -v --tb=short -x -m "not integration and not e2e" --cov=src --cov-report=xml --cov-report=term --cov-fail-under=60
+      - run: uv run pytest tests/ -v --tb=short -x -m "not integration and not e2e" --cov=src --cov-report=xml --cov-report=term --cov-fail-under=70
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
-from src.api.deps import get_neo4j
+from src.api.deps import get_neo4j, get_pg
 from src.api.models import SearchResult, SearchResultsResponse
 from src.utils.neo4j_client import Neo4jClient
+from src.utils.pg_client import PgClient
 
 router = APIRouter()
+
+log = logging.getLogger(__name__)
 
 
 @router.get("/search", response_model=SearchResultsResponse)
@@ -18,20 +24,15 @@ def search(
     limit: int = Query(20, ge=1, le=100),
     neo4j: Neo4jClient = Depends(get_neo4j),
 ) -> SearchResultsResponse:
-    """Full-text search across hadiths and narrators."""
+    """Full-text search across hadiths and narrators.
+
+    Uses Neo4j full-text indexes (``narrator_search``, ``hadith_search``)
+    when available, falling back to ``CONTAINS`` substring matching.
+    """
     results: list[SearchResult] = []
 
-    # Search narrators by name
-    narrator_rows = neo4j.execute_read(
-        """
-        MATCH (n:Narrator)
-        WHERE n.name_ar CONTAINS $q OR n.name_en CONTAINS $q
-        RETURN n.id AS id, n.name_ar AS name_ar, n.name_en AS name_en,
-               'narrator' AS type, 1.0 AS score
-        LIMIT $limit
-        """,
-        {"q": q, "limit": limit},
-    )
+    # --- Narrator search via full-text index ---
+    narrator_rows = _fulltext_narrator_search(neo4j, q, limit)
     for r in narrator_rows:
         results.append(
             SearchResult(
@@ -43,19 +44,10 @@ def search(
             )
         )
 
-    # Search hadiths by matn text
+    # --- Hadith search via full-text index ---
     remaining = max(0, limit - len(results))
     if remaining > 0:
-        hadith_rows = neo4j.execute_read(
-            """
-            MATCH (h:Hadith)
-            WHERE h.matn_ar CONTAINS $q OR h.matn_en CONTAINS $q
-            RETURN h.id AS id, h.matn_ar AS matn_ar, h.matn_en AS matn_en,
-                   'hadith' AS type, 1.0 AS score
-            LIMIT $limit
-            """,
-            {"q": q, "limit": remaining},
-        )
+        hadith_rows = _fulltext_hadith_search(neo4j, q, remaining)
         for r in hadith_rows:
             snippet = r.get("matn_en") or r["matn_ar"]
             results.append(
@@ -71,20 +63,110 @@ def search(
     return SearchResultsResponse(results=results, total=len(results), query=q)
 
 
+def _fulltext_narrator_search(neo4j: Neo4jClient, query: str, limit: int) -> list[dict[str, Any]]:
+    """Search narrators using full-text index, falling back to CONTAINS."""
+    try:
+        return neo4j.execute_read(
+            """
+            CALL db.index.fulltext.queryNodes('narrator_search', $q)
+            YIELD node, score
+            RETURN node.id AS id, node.name_ar AS name_ar,
+                   node.name_en AS name_en, score
+            LIMIT $limit
+            """,
+            {"q": query, "limit": limit},
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("fulltext narrator_search unavailable, falling back to CONTAINS")
+        return neo4j.execute_read(
+            """
+            MATCH (n:Narrator)
+            WHERE n.name_ar CONTAINS $q OR n.name_en CONTAINS $q
+            RETURN n.id AS id, n.name_ar AS name_ar, n.name_en AS name_en,
+                   1.0 AS score
+            LIMIT $limit
+            """,
+            {"q": query, "limit": limit},
+        )
+
+
+def _fulltext_hadith_search(neo4j: Neo4jClient, query: str, limit: int) -> list[dict[str, Any]]:
+    """Search hadiths using full-text index, falling back to CONTAINS."""
+    try:
+        return neo4j.execute_read(
+            """
+            CALL db.index.fulltext.queryNodes('hadith_search', $q)
+            YIELD node, score
+            RETURN node.id AS id, node.matn_ar AS matn_ar,
+                   node.matn_en AS matn_en, score
+            LIMIT $limit
+            """,
+            {"q": query, "limit": limit},
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("fulltext hadith_search unavailable, falling back to CONTAINS")
+        return neo4j.execute_read(
+            """
+            MATCH (h:Hadith)
+            WHERE h.matn_ar CONTAINS $q OR h.matn_en CONTAINS $q
+            RETURN h.id AS id, h.matn_ar AS matn_ar, h.matn_en AS matn_en,
+                   1.0 AS score
+            LIMIT $limit
+            """,
+            {"q": query, "limit": limit},
+        )
+
+
 @router.get("/search/semantic", response_model=SearchResultsResponse)
 def search_semantic(
     q: str = Query(..., min_length=1, max_length=500, description="Semantic search query"),
     limit: int = Query(10, ge=1, le=50),
+    pg: PgClient = Depends(get_pg),
 ) -> SearchResultsResponse:
     """Semantic similarity search using pgvector.
 
-    Returns 503 when the pgvector backend is not available.
+    Queries the ``isnad_graph.hadith_embeddings`` table for cosine-similar
+    hadiths.  Returns 503 when the table or pgvector extension is unavailable.
     """
-    # pgvector integration is not yet wired up — return a graceful 503
-    return JSONResponse(  # type: ignore[return-value]
-        status_code=503,
-        content={
-            "detail": "Semantic search is not yet available. pgvector backend required.",
-            "query": q,
-        },
-    )
+    try:
+        rows = pg.execute(
+            """
+            SELECT h.id, h.matn_ar, h.matn_en,
+                   1 - (e.embedding <=> (
+                       SELECT embedding FROM isnad_graph.hadith_embeddings
+                       WHERE text = %s LIMIT 1
+                   )) AS score
+            FROM isnad_graph.hadith_embeddings e
+            JOIN isnad_graph.hadiths h ON h.id = e.hadith_id
+            ORDER BY e.embedding <=> (
+                SELECT embedding FROM isnad_graph.hadith_embeddings
+                WHERE text = %s LIMIT 1
+            )
+            LIMIT %s
+            """,
+            (q, q, limit),
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("pgvector semantic search unavailable", exc_info=True)
+        return JSONResponse(  # type: ignore[return-value]
+            status_code=503,
+            content={
+                "detail": "Semantic search is not yet available. pgvector backend required.",
+                "query": q,
+            },
+        )
+
+    results: list[SearchResult] = []
+    for r in rows:
+        snippet = r.get("matn_en") or r["matn_ar"]
+        results.append(
+            SearchResult(
+                id=r["id"],
+                type="hadith",
+                title=snippet[:120] + "..." if len(snippet) > 120 else snippet,
+                title_ar=r["matn_ar"][:120],
+                score=float(r.get("score") or 0.0),
+            )
+        )
+
+    return SearchResultsResponse(results=results, total=len(results), query=q)

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -593,6 +593,7 @@ def load_all_nodes(
     in dependency order (narrators before chains, hadiths before gradings).
     """
     client.ensure_constraints()
+    client.ensure_fulltext_indexes()
 
     results: list[LoadResult] = []
     results.append(_load_narrators(client, staging_dir, curated_dir, strict=strict))

--- a/src/utils/neo4j_client.py
+++ b/src/utils/neo4j_client.py
@@ -115,6 +115,24 @@ class Neo4jClient:
             self.execute_write(query)
             log.info("constraint_ensured", node_type=node_type)
 
+    def ensure_fulltext_indexes(self) -> None:
+        """Create full-text indexes for search (idempotent)."""
+        indexes = [
+            (
+                "narrator_search",
+                "CREATE FULLTEXT INDEX narrator_search IF NOT EXISTS "
+                "FOR (n:Narrator) ON EACH [n.name_ar, n.name_en]",
+            ),
+            (
+                "hadith_search",
+                "CREATE FULLTEXT INDEX hadith_search IF NOT EXISTS "
+                "FOR (h:Hadith) ON EACH [h.matn_ar, h.matn_en]",
+            ),
+        ]
+        for name, query in indexes:
+            self.execute_write(query)
+            log.info("fulltext_index_ensured", index=name)
+
     # --- lifecycle -------------------------------------------------------
 
     def close(self) -> None:

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -7,27 +7,25 @@ from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
 
 
-def test_search_returns_results(client: TestClient, mock_neo4j: MagicMock) -> None:
-    """GET /api/v1/search?q=test returns matching narrators and hadiths."""
+def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/search?q=test uses full-text index and returns results."""
     mock_neo4j.execute_read.side_effect = [
-        # narrator search
+        # narrator full-text search
         [
             {
                 "id": "nar-001",
                 "name_ar": "اختبار",
                 "name_en": "test narrator",
-                "type": "narrator",
-                "score": 1.0,
+                "score": 2.5,
             }
         ],
-        # hadith search
+        # hadith full-text search
         [
             {
                 "id": "had-001",
                 "matn_ar": "نص اختبار",
                 "matn_en": "test hadith text",
-                "type": "hadith",
-                "score": 1.0,
+                "score": 1.8,
             }
         ],
     ]
@@ -37,7 +35,33 @@ def test_search_returns_results(client: TestClient, mock_neo4j: MagicMock) -> No
     assert body["query"] == "test"
     assert body["total"] == 2
     assert body["results"][0]["type"] == "narrator"
+    assert body["results"][0]["score"] == 2.5
     assert body["results"][1]["type"] == "hadith"
+
+    # Verify the full-text query was used (CALL db.index.fulltext)
+    first_call_query = mock_neo4j.execute_read.call_args_list[0][0][0]
+    assert "fulltext.queryNodes" in first_call_query
+
+
+def test_search_falls_back_to_contains(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """When full-text index is unavailable, falls back to CONTAINS."""
+    # First call (fulltext) raises, second call (CONTAINS fallback) succeeds,
+    # third call (hadith fulltext) raises, fourth call (hadith fallback) succeeds
+    mock_neo4j.execute_read.side_effect = [
+        Exception("No such index 'narrator_search'"),
+        [{"id": "nar-001", "name_ar": "اختبار", "name_en": "fallback", "score": 1.0}],
+        Exception("No such index 'hadith_search'"),
+        [],
+    ]
+    resp = client.get("/api/v1/search?q=test")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["results"][0]["title"] == "fallback"
+
+    # Verify fallback query uses CONTAINS
+    fallback_query = mock_neo4j.execute_read.call_args_list[1][0][0]
+    assert "CONTAINS" in fallback_query
 
 
 def test_search_empty_results(client: TestClient) -> None:
@@ -55,9 +79,53 @@ def test_search_requires_query(client: TestClient) -> None:
     assert resp.status_code == 422
 
 
-def test_semantic_search_returns_503(client: TestClient) -> None:
-    """GET /api/v1/search/semantic returns 503 (pgvector not wired)."""
+def test_semantic_search_returns_503_when_pg_unavailable(client: TestClient, app: object) -> None:
+    """GET /api/v1/search/semantic returns 503 when pgvector is not available."""
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = Exception("relation does not exist")
+    mock_pg.close.return_value = None
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
     resp = client.get("/api/v1/search/semantic?q=test")
     assert resp.status_code == 503
     body = resp.json()
     assert "not yet available" in body["detail"].lower()
+
+    del app.dependency_overrides[get_pg]
+
+
+def test_semantic_search_returns_results_when_pg_available(client: TestClient, app: object) -> None:
+    """GET /api/v1/search/semantic returns results when pgvector is wired up."""
+    mock_pg = MagicMock()
+    mock_pg.execute.return_value = [
+        {
+            "id": "had-001",
+            "matn_ar": "نص اختبار",
+            "matn_en": "test semantic hadith",
+            "score": 0.92,
+        },
+    ]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["results"][0]["type"] == "hadith"
+    assert body["results"][0]["score"] == 0.92
+
+    # Clean up override
+    del app.dependency_overrides[get_pg]

--- a/tests/test_graph/conftest.py
+++ b/tests/test_graph/conftest.py
@@ -24,11 +24,15 @@ class MockNeo4jClient:
     def __init__(self, *, nodes_created_per_batch: int = 0) -> None:
         self.calls: list[tuple[str, dict[str, Any] | list[dict[str, Any]]]] = []
         self.constraints_ensured = False
+        self.fulltext_indexes_ensured = False
         self._nodes_created = nodes_created_per_batch
         self._read_results: list[dict[str, Any]] = []
 
     def ensure_constraints(self) -> None:
         self.constraints_ensured = True
+
+    def ensure_fulltext_indexes(self) -> None:
+        self.fulltext_indexes_ensured = True
 
     def execute_write_batch(
         self, query: str, batch: list[dict[str, Any]], batch_size: int = 1000


### PR DESCRIPTION
## Summary
- **#193** — Wire pgvector semantic search into `/search/semantic` endpoint via PgClient; queries `isnad_graph.hadith_embeddings` for cosine similarity, graceful 503 fallback when pgvector/table unavailable
- **#194** — Replace O(N) `CONTAINS` substring scans with Neo4j full-text indexes (`narrator_search`, `hadith_search`) created via `ensure_fulltext_indexes()`; automatic CONTAINS fallback if indexes not yet created
- **#188** — Bump CI `--cov-fail-under` from 60 to 70
- 6 new/updated tests covering fulltext search, CONTAINS fallback, semantic search wiring, and 503 graceful degradation

## Changed files
- `src/api/routes/search.py` — fulltext index queries + pgvector semantic wiring
- `src/utils/neo4j_client.py` — `ensure_fulltext_indexes()` method
- `src/graph/load_nodes.py` — call `ensure_fulltext_indexes()` during node loading
- `tests/test_api/test_search.py` — 6 tests for all search paths
- `tests/test_graph/conftest.py` — MockNeo4jClient updated with fulltext method
- `.github/workflows/ci.yml` — coverage threshold bump 60→70

## Test plan
- [x] All 6 search tests pass locally
- [x] Lint (ruff check) passes on all changed files
- [x] Type check (mypy) passes on all changed source files
- [ ] CI pipeline validates on PR

Closes #193
Closes #194
Updates #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)