### PR TITLE
Extract inline styles to CSS and refactor D3 timeline

### DIFF
--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -22,35 +22,19 @@ export default function AdminLayout() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <header
-        style={{
-          padding: '0.75rem 1.5rem',
-          borderBottom: '1px solid #ddd',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '1rem',
-          background: '#f8f9fa',
-        }}
+        className="flex-row"
+        style={{ padding: '0.75rem 1.5rem', borderBottom: '1px solid #ddd', background: '#f8f9fa' }}
       >
         <NavLink to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
           <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Isnad Graph</h1>
         </NavLink>
-        <span style={{ color: '#666', fontSize: '0.875rem' }}>Admin Dashboard</span>
+        <span className="small-muted">Admin Dashboard</span>
       </header>
       <div style={{ display: 'flex', flex: 1 }}>
-        <nav
-          style={{
-            width: 220,
-            padding: '1rem',
-            borderRight: '1px solid #ddd',
-            background: '#fafafa',
-          }}
-        >
+        <nav style={{ width: 220, padding: '1rem', borderRight: '1px solid #ddd', background: '#fafafa' }}>
           <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             <li style={{ marginBottom: '1rem' }}>
-              <NavLink
-                to="/"
-                style={{ textDecoration: 'none', color: '#666', fontSize: '0.875rem' }}
-              >
+              <NavLink to="/" className="small-muted" style={{ textDecoration: 'none' }}>
                 Back to main site
               </NavLink>
             </li>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,20 +3,10 @@ import Sidebar from './Sidebar'
 
 export default function Layout() {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <header
-        style={{
-          padding: '0.75rem 1.5rem',
-          borderBottom: '1px solid #ddd',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '1rem',
-        }}
-      >
+    <div className="flex-row" style={{ flexDirection: 'column', minHeight: '100vh', alignItems: 'stretch' }}>
+      <header className="flex-row" style={{ padding: '0.75rem 1.5rem', borderBottom: '1px solid #ddd' }}>
         <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Isnad Graph</h1>
-        <span style={{ color: '#666', fontSize: '0.875rem' }}>
-          Hadith Analysis Platform
-        </span>
+        <span className="small-muted">Hadith Analysis Platform</span>
       </header>
       <div style={{ display: 'flex', flex: 1 }}>
         <Sidebar />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './styles/common.css'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -16,51 +16,39 @@ export default function CollectionDetailPage() {
   })
 
   if (isLoading) return <p>Loading...</p>
-  if (error) return <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>
+  if (error) return <p className="error-text">Error: {(error as Error).message}</p>
   if (!collection) return <p>Collection not found.</p>
 
   const isSunni = collection.sect.toLowerCase() === 'sunni'
 
   return (
     <div>
-      <Link to="/collections" style={{ color: '#1a73e8' }}>
+      <Link to="/collections" className="link-primary">
         &larr; Back to Collections
       </Link>
 
       <h2 style={{ marginTop: '1rem' }}>
         {collection.name_en}
-        <span
-          style={{
-            marginLeft: '0.75rem',
-            padding: '0.15rem 0.5rem',
-            borderRadius: 4,
-            fontSize: '0.9rem',
-            fontWeight: 600,
-            background: isSunni ? '#e8f5e9' : '#e3f2fd',
-            color: isSunni ? '#2e7d32' : '#1565c0',
-          }}
-        >
+        <span className={`badge ${isSunni ? 'badge-sunni' : 'badge-shia'}`} style={{ marginLeft: '0.75rem', fontSize: '0.9rem' }}>
           {collection.sect}
         </span>
       </h2>
 
-      <p style={{ direction: 'rtl', textAlign: 'right', fontSize: '1.1rem', color: '#555' }}>
+      <p className="text-rtl" style={{ fontSize: '1.1rem', color: '#555' }}>
         {collection.name_ar}
       </p>
 
-      <div style={{ color: '#666', marginBottom: '1.5rem' }}>
+      <div className="collection-meta">
         {collection.compiler_name && <span>Compiler: {collection.compiler_name}</span>}
-        {collection.compiler_name && <span style={{ margin: '0 0.5rem' }}>|</span>}
+        {collection.compiler_name && <span className="separator">|</span>}
         {collection.compilation_year_ah != null && (
           <span>Compiled: {collection.compilation_year_ah} AH</span>
         )}
-        {collection.compilation_year_ah != null && (
-          <span style={{ margin: '0 0.5rem' }}>|</span>
-        )}
+        {collection.compilation_year_ah != null && <span className="separator">|</span>}
         <span>{collection.total_hadiths != null ? collection.total_hadiths.toLocaleString() : '?'} hadiths</span>
         {collection.book_count != null && (
           <>
-            <span style={{ margin: '0 0.5rem' }}>|</span>
+            <span className="separator">|</span>
             <span>{collection.book_count} books</span>
           </>
         )}

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -10,34 +10,22 @@ export default function CollectionsPage() {
     queryFn: () => fetchCollections(),
   })
 
-  const sectBadge = (sect: string) => {
-    const isSunni = sect.toLowerCase() === 'sunni'
-    return {
-      background: isSunni ? '#e8f5e9' : '#e3f2fd',
-      color: isSunni ? '#2e7d32' : '#1565c0',
-      padding: '0.15rem 0.5rem',
-      borderRadius: 4,
-      fontSize: '0.85rem',
-      fontWeight: 600 as const,
-    }
-  }
-
   return (
     <div>
       <h2>Collections</h2>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table className="data-table">
           <thead>
-            <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-              <th style={{ padding: '0.5rem' }}>Name (Arabic)</th>
-              <th style={{ padding: '0.5rem' }}>Name (English)</th>
-              <th style={{ padding: '0.5rem' }}>Compiler</th>
-              <th style={{ padding: '0.5rem' }}>Sect</th>
-              <th style={{ padding: '0.5rem', textAlign: 'right' }}>Hadiths</th>
+            <tr>
+              <th>Name (Arabic)</th>
+              <th>Name (English)</th>
+              <th>Compiler</th>
+              <th>Sect</th>
+              <th style={{ textAlign: 'right' }}>Hadiths</th>
             </tr>
           </thead>
           <tbody>
@@ -45,15 +33,17 @@ export default function CollectionsPage() {
               <tr
                 key={c.id}
                 onClick={() => navigate(`/collections/${c.id}`)}
-                style={{ borderBottom: '1px solid #eee', cursor: 'pointer' }}
+                className="clickable-row"
               >
-                <td style={{ padding: '0.5rem', direction: 'rtl' }}>{c.name_ar}</td>
-                <td style={{ padding: '0.5rem' }}>{c.name_en}</td>
-                <td style={{ padding: '0.5rem' }}>{c.compiler_name ?? '-'}</td>
-                <td style={{ padding: '0.5rem' }}>
-                  <span style={sectBadge(c.sect)}>{c.sect}</span>
+                <td className="text-rtl">{c.name_ar}</td>
+                <td>{c.name_en}</td>
+                <td>{c.compiler_name ?? '-'}</td>
+                <td>
+                  <span className={`badge ${c.sect.toLowerCase() === 'sunni' ? 'badge-sunni' : 'badge-shia'}`}>
+                    {c.sect}
+                  </span>
                 </td>
-                <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+                <td style={{ textAlign: 'right' }}>
                   {c.total_hadiths != null ? c.total_hadiths.toLocaleString() : '-'}
                 </td>
               </tr>

--- a/frontend/src/pages/ComparativePage.tsx
+++ b/frontend/src/pages/ComparativePage.tsx
@@ -17,33 +17,30 @@ export default function ComparativePage() {
   return (
     <div>
       <h2>Comparative Analysis</h2>
-      <p style={{ color: '#666', marginBottom: '1rem' }}>
+      <p className="muted-text" style={{ marginBottom: '1rem' }}>
         Browse cross-sectarian parallel hadith pairs (PARALLEL_OF relationships).
       </p>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
         <>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                <th style={{ padding: '0.5rem' }}>Sunni Hadith</th>
-                <th style={{ padding: '0.5rem' }}>Shia Hadith</th>
-                <th style={{ padding: '0.5rem' }}>Similarity</th>
-                <th style={{ padding: '0.5rem' }}>Variant Type</th>
-                <th style={{ padding: '0.5rem' }}>Cross-Sect</th>
+              <tr>
+                <th>Sunni Hadith</th>
+                <th>Shia Hadith</th>
+                <th>Similarity</th>
+                <th>Variant Type</th>
+                <th>Cross-Sect</th>
               </tr>
             </thead>
             <tbody>
               {data.items.map((pair, idx) => (
-                <tr
-                  key={`${pair.hadith_a_id}-${pair.hadith_b_id}-${idx}`}
-                  style={{ borderBottom: '1px solid #eee' }}
-                >
+                <tr key={`${pair.hadith_a_id}-${pair.hadith_b_id}-${idx}`}>
                   <td
-                    style={{ padding: '0.5rem', cursor: 'pointer', color: '#1a73e8' }}
+                    style={{ cursor: 'pointer', color: '#1a73e8' }}
                     onClick={() => navigate(`/hadiths/${pair.hadith_a_id}`)}
                   >
                     {pair.hadith_a_id}
@@ -51,39 +48,30 @@ export default function ComparativePage() {
                     <small style={{ color: '#888' }}>{pair.hadith_a_corpus}</small>
                   </td>
                   <td
-                    style={{ padding: '0.5rem', cursor: 'pointer', color: '#1a73e8' }}
+                    style={{ cursor: 'pointer', color: '#1a73e8' }}
                     onClick={() => navigate(`/hadiths/${pair.hadith_b_id}`)}
                   >
                     {pair.hadith_b_id}
                     <br />
                     <small style={{ color: '#888' }}>{pair.hadith_b_corpus}</small>
                   </td>
-                  <td style={{ padding: '0.5rem' }}>
+                  <td>
                     {pair.similarity_score != null ? (
-                      <span
-                        style={{
-                          background: pair.similarity_score > 0.8 ? '#e6f4ea' : '#fef7e0',
-                          padding: '0.15rem 0.4rem',
-                          borderRadius: 4,
-                          fontSize: '0.875rem',
-                        }}
-                      >
+                      <span className={pair.similarity_score > 0.8 ? 'badge-similarity-high' : 'badge-similarity-low'}>
                         {(pair.similarity_score * 100).toFixed(1)}%
                       </span>
                     ) : (
                       '-'
                     )}
                   </td>
-                  <td style={{ padding: '0.5rem' }}>{pair.variant_type ?? '-'}</td>
-                  <td style={{ padding: '0.5rem' }}>{pair.cross_sect ? 'Yes' : 'No'}</td>
+                  <td>{pair.variant_type ?? '-'}</td>
+                  <td>{pair.cross_sect ? 'Yes' : 'No'}</td>
                 </tr>
               ))}
             </tbody>
           </table>
 
-          <div
-            style={{ marginTop: '1.5rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}
-          >
+          <div className="pagination" style={{ marginTop: '1.5rem' }}>
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
               Previous
             </button>

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -69,20 +69,21 @@ export default function GraphExplorerPage() {
     <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 120px)' }}>
       <div style={{ marginBottom: '1rem' }}>
         <h2 style={{ margin: '0 0 0.5rem' }}>Graph Explorer</h2>
-        <p style={{ color: '#666', margin: '0 0 1rem' }}>
+        <p className="muted-text" style={{ margin: '0 0 1rem' }}>
           Interactive force-directed graph. Search for a narrator to start, then click nodes to
           expand.
         </p>
 
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <div className="flex-row" style={{ flexWrap: 'wrap' }}>
           <input
             type="text"
             placeholder="Search for a narrator to start..."
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            style={{ padding: '0.5rem', width: 300 }}
+            className="form-input"
+            style={{ width: 300 }}
           />
-          <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+          <label className="flex-row" style={{ gap: '0.25rem' }}>
             Depth:
             <select
               value={depth}
@@ -94,26 +95,14 @@ export default function GraphExplorerPage() {
               <option value={3}>3</option>
             </select>
           </label>
-          <button onClick={handleReset} style={{ padding: '0.5rem 1rem' }}>
+          <button onClick={handleReset} className="btn">
             Reset
           </button>
-          {isLoading && <span style={{ color: '#666' }}>Loading...</span>}
+          {isLoading && <span className="muted-text">Loading...</span>}
         </div>
 
         {searchInput && searchResults && (
-          <div
-            style={{
-              marginTop: '0.5rem',
-              border: '1px solid #ddd',
-              borderRadius: 4,
-              maxHeight: 200,
-              overflowY: 'auto',
-              background: '#fff',
-              position: 'relative',
-              zIndex: 10,
-              maxWidth: 400,
-            }}
-          >
+          <div className="search-dropdown">
             {searchResults.items.map((n) => (
               <div
                 key={n.id}
@@ -121,11 +110,7 @@ export default function GraphExplorerPage() {
                   setSelectedNarratorId(n.id)
                   setSearchInput('')
                 }}
-                style={{
-                  padding: '0.5rem',
-                  cursor: 'pointer',
-                  borderBottom: '1px solid #eee',
-                }}
+                className="search-dropdown-item"
               >
                 <span style={{ direction: 'rtl' }}>{n.name_ar}</span>
                 {n.name_en && (
@@ -139,17 +124,7 @@ export default function GraphExplorerPage() {
         )}
       </div>
 
-      <div
-        ref={containerRef}
-        style={{
-          flex: 1,
-          border: '1px solid #ddd',
-          borderRadius: 6,
-          overflow: 'hidden',
-          background: '#fafafa',
-          minHeight: 400,
-        }}
-      >
+      <div ref={containerRef} className="graph-container">
         {allNodes.length > 0 ? (
           <ForceGraph
             nodes={allNodes}
@@ -159,22 +134,14 @@ export default function GraphExplorerPage() {
             height={dimensions.height}
           />
         ) : (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-              color: '#999',
-            }}
-          >
+          <div className="graph-placeholder">
             Search for a narrator above to begin exploring the graph.
           </div>
         )}
       </div>
 
       {allNodes.length > 0 && (
-        <div style={{ marginTop: '0.5rem', color: '#666', fontSize: '0.85rem' }}>
+        <div style={{ marginTop: '0.5rem' }} className="small-muted">
           {allNodes.length} nodes, {allEdges.length} edges loaded
         </div>
       )}

--- a/frontend/src/pages/HadithDetailPage.tsx
+++ b/frontend/src/pages/HadithDetailPage.tsx
@@ -22,12 +22,12 @@ export default function HadithDetailPage() {
   })
 
   if (isLoading) return <p>Loading...</p>
-  if (error) return <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>
+  if (error) return <p className="error-text">Error: {(error as Error).message}</p>
   if (!hadith) return <p>Hadith not found.</p>
 
   return (
     <div>
-      <Link to="/hadiths" style={{ color: '#1a73e8' }}>
+      <Link to="/hadiths" className="link-primary">
         &larr; Back to Hadiths
       </Link>
 
@@ -37,69 +37,31 @@ export default function HadithDetailPage() {
 
       {hadith.grade_composite && (
         <span
-          style={{
-            display: 'inline-block',
-            padding: '0.2rem 0.6rem',
-            borderRadius: 4,
-            fontSize: '0.9rem',
-            background:
-              hadith.grade_composite.toLowerCase() === 'sahih' ? '#e6f4ea' : '#fef7e0',
-            color: hadith.grade_composite.toLowerCase() === 'sahih' ? '#137333' : '#b06000',
-            marginBottom: '1rem',
-          }}
+          className={`badge ${hadith.grade_composite.toLowerCase() === 'sahih' ? 'badge-sahih' : 'badge-other-grade'}`}
+          style={{ display: 'inline-block', padding: '0.2rem 0.6rem', fontSize: '0.9rem', marginBottom: '1rem' }}
         >
           {hadith.grade_composite}
         </span>
       )}
 
-      <section style={{ marginTop: '1.5rem' }}>
+      <section className="section">
         <h3>Matn (Arabic)</h3>
-        <div
-          style={{
-            direction: 'rtl',
-            textAlign: 'right',
-            padding: '1rem',
-            background: '#fafafa',
-            borderRadius: 4,
-            lineHeight: 1.8,
-            fontSize: '1.1rem',
-          }}
-        >
-          {hadith.matn_ar}
-        </div>
+        <div className="text-arabic-block">{hadith.matn_ar}</div>
       </section>
 
       {hadith.matn_en && (
-        <section style={{ marginTop: '1.5rem' }}>
+        <section className="section">
           <h3>English Translation</h3>
-          <div
-            style={{
-              padding: '1rem',
-              background: '#fafafa',
-              borderRadius: 4,
-              lineHeight: 1.6,
-            }}
-          >
-            {hadith.matn_en}
-          </div>
+          <div className="text-english-block">{hadith.matn_en}</div>
         </section>
       )}
 
       {hadith.topic_tags && hadith.topic_tags.length > 0 && (
-        <section style={{ marginTop: '1.5rem' }}>
+        <section className="section">
           <h3>Topics</h3>
-          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <div className="flex-row-wrap" style={{ gap: '0.5rem' }}>
             {hadith.topic_tags.map((tag) => (
-              <span
-                key={tag}
-                style={{
-                  padding: '0.3rem 0.6rem',
-                  borderRadius: 4,
-                  background: '#e8eaf6',
-                  color: '#283593',
-                  fontSize: '0.9rem',
-                }}
-              >
+              <span key={tag} className="badge-topic-lg">
                 {tag}
               </span>
             ))}
@@ -108,30 +70,30 @@ export default function HadithDetailPage() {
       )}
 
       {parallelsData && parallelsData.parallels.length > 0 && (
-        <section style={{ marginTop: '1.5rem' }}>
+        <section className="section">
           <h3>Parallel Hadiths ({parallelsData.total})</h3>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                <th style={{ padding: '0.5rem' }}>Source Corpus</th>
-                <th style={{ padding: '0.5rem' }}>Grade</th>
-                <th style={{ padding: '0.5rem' }}>Similarity</th>
-                <th style={{ padding: '0.5rem' }}>Cross-sect</th>
+              <tr>
+                <th>Source Corpus</th>
+                <th>Grade</th>
+                <th>Similarity</th>
+                <th>Cross-sect</th>
               </tr>
             </thead>
             <tbody>
               {parallelsData.parallels.map((p) => (
-                <tr key={p.id} style={{ borderBottom: '1px solid #eee' }}>
-                  <td style={{ padding: '0.5rem' }}>
-                    <Link to={`/hadiths/${p.id}`} style={{ color: '#1a73e8' }}>
+                <tr key={p.id}>
+                  <td>
+                    <Link to={`/hadiths/${p.id}`} className="link-primary">
                       {p.source_corpus}
                     </Link>
                   </td>
-                  <td style={{ padding: '0.5rem' }}>{p.grade ?? '-'}</td>
-                  <td style={{ padding: '0.5rem' }}>
+                  <td>{p.grade ?? '-'}</td>
+                  <td>
                     {p.similarity_score != null ? `${(p.similarity_score * 100).toFixed(0)}%` : '-'}
                   </td>
-                  <td style={{ padding: '0.5rem' }}>{p.cross_sect ? 'Yes' : 'No'}</td>
+                  <td>{p.cross_sect ? 'Yes' : 'No'}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -19,16 +19,16 @@ export default function HadithsPage() {
       <h2>Hadiths</h2>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
         <>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                <th style={{ padding: '0.5rem' }}>Source</th>
-                <th style={{ padding: '0.5rem' }}>Grade</th>
-                <th style={{ padding: '0.5rem' }}>Topics</th>
+              <tr>
+                <th>Source</th>
+                <th>Grade</th>
+                <th>Topics</th>
               </tr>
             </thead>
             <tbody>
@@ -36,40 +36,21 @@ export default function HadithsPage() {
                 <tr
                   key={h.id}
                   onClick={() => navigate(`/hadiths/${h.id}`)}
-                  style={{ borderBottom: '1px solid #eee', cursor: 'pointer' }}
+                  className="clickable-row"
                 >
-                  <td style={{ padding: '0.5rem' }}>{h.source_corpus}</td>
-                  <td style={{ padding: '0.5rem' }}>
+                  <td>{h.source_corpus}</td>
+                  <td>
                     {h.grade_composite && (
                       <span
-                        style={{
-                          padding: '0.15rem 0.5rem',
-                          borderRadius: 4,
-                          fontSize: '0.85rem',
-                          background:
-                            h.grade_composite.toLowerCase() === 'sahih' ? '#e6f4ea' : '#fef7e0',
-                          color:
-                            h.grade_composite.toLowerCase() === 'sahih' ? '#137333' : '#b06000',
-                        }}
+                        className={`badge ${h.grade_composite.toLowerCase() === 'sahih' ? 'badge-sahih' : 'badge-other-grade'}`}
                       >
                         {h.grade_composite}
                       </span>
                     )}
                   </td>
-                  <td style={{ padding: '0.5rem' }}>
+                  <td>
                     {h.topic_tags?.map((tag) => (
-                      <span
-                        key={tag}
-                        style={{
-                          display: 'inline-block',
-                          marginRight: '0.25rem',
-                          padding: '0.1rem 0.4rem',
-                          borderRadius: 3,
-                          fontSize: '0.8rem',
-                          background: '#e8eaf6',
-                          color: '#283593',
-                        }}
-                      >
+                      <span key={tag} className="badge-topic">
                         {tag}
                       </span>
                     ))}
@@ -79,7 +60,7 @@ export default function HadithsPage() {
             </tbody>
           </table>
 
-          <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <div className="pagination">
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
               Previous
             </button>

--- a/frontend/src/pages/NarratorDetailPage.tsx
+++ b/frontend/src/pages/NarratorDetailPage.tsx
@@ -22,38 +22,32 @@ export default function NarratorDetailPage() {
   })
 
   if (isLoading) return <p>Loading...</p>
-  if (error) return <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>
+  if (error) return <p className="error-text">Error: {(error as Error).message}</p>
   if (!narrator) return <p>Narrator not found.</p>
 
   return (
     <div>
-      <Link to="/narrators" style={{ color: '#1a73e8' }}>
+      <Link to="/narrators" className="link-primary">
         &larr; Back to Narrators
       </Link>
 
-      <h2 style={{ direction: 'rtl', textAlign: 'right', marginTop: '1rem' }}>
+      <h2 className="text-rtl" style={{ marginTop: '1rem' }}>
         {narrator.name_ar}
       </h2>
       {narrator.name_en && (
         <h3 style={{ color: '#555', fontWeight: 400 }}>{narrator.name_en}</h3>
       )}
 
-      <section style={{ marginTop: '1.5rem' }}>
+      <section className="section">
         <h3>Biography</h3>
-        <table style={{ borderCollapse: 'collapse' }}>
+        <table className="bio-table">
           <tbody>
             {[
               ['Kunya', narrator.kunya],
               ['Nisba', narrator.nisba],
               ['Laqab', narrator.laqab],
-              [
-                'Birth Year',
-                narrator.birth_year_ah != null ? `${narrator.birth_year_ah} AH` : null,
-              ],
-              [
-                'Death Year',
-                narrator.death_year_ah != null ? `${narrator.death_year_ah} AH` : null,
-              ],
+              ['Birth Year', narrator.birth_year_ah != null ? `${narrator.birth_year_ah} AH` : null],
+              ['Death Year', narrator.death_year_ah != null ? `${narrator.death_year_ah} AH` : null],
               ['Generation', narrator.generation],
               ['Gender', narrator.gender],
               ['Sect Affiliation', narrator.sect_affiliation],
@@ -61,11 +55,9 @@ export default function NarratorDetailPage() {
             ].map(
               ([label, value]) =>
                 value && (
-                  <tr key={label as string} style={{ borderBottom: '1px solid #eee' }}>
-                    <td style={{ padding: '0.4rem 1rem 0.4rem 0', fontWeight: 600 }}>
-                      {label}
-                    </td>
-                    <td style={{ padding: '0.4rem 0' }}>{value}</td>
+                  <tr key={label as string}>
+                    <td>{label}</td>
+                    <td>{value}</td>
                   </tr>
                 ),
             )}
@@ -73,9 +65,9 @@ export default function NarratorDetailPage() {
         </table>
       </section>
 
-      <section style={{ marginTop: '1.5rem' }}>
+      <section className="section">
         <h3>Network Statistics</h3>
-        <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap' }}>
+        <div className="flex-row-wrap" style={{ gap: '2rem' }}>
           {[
             ['In-Degree', narrator.in_degree],
             ['Out-Degree', narrator.out_degree],
@@ -85,18 +77,9 @@ export default function NarratorDetailPage() {
           ].map(
             ([label, value]) =>
               value != null && (
-                <div
-                  key={label as string}
-                  style={{
-                    padding: '0.75rem 1rem',
-                    border: '1px solid #ddd',
-                    borderRadius: 4,
-                    minWidth: 100,
-                    textAlign: 'center',
-                  }}
-                >
-                  <div style={{ fontSize: '0.75rem', color: '#666' }}>{label}</div>
-                  <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>{value}</div>
+                <div key={label as string} className="network-stat">
+                  <div className="network-stat-label">{label}</div>
+                  <div className="network-stat-value">{value}</div>
                 </div>
               ),
           )}
@@ -104,12 +87,12 @@ export default function NarratorDetailPage() {
       </section>
 
       {chainsData && chainsData.chains.length > 0 && (
-        <section style={{ marginTop: '1.5rem' }}>
+        <section className="section">
           <h3>Chains ({chainsData.total})</h3>
           <ul style={{ paddingLeft: '1.25rem' }}>
             {chainsData.chains.map((chain) => (
               <li key={chain.chain_id} style={{ marginBottom: '0.5rem' }}>
-                <Link to={`/hadiths/${chain.hadith_id}`} style={{ color: '#1a73e8' }}>
+                <Link to={`/hadiths/${chain.hadith_id}`} className="link-primary">
                   Hadith {chain.hadith_id}
                 </Link>
                 {chain.grade && (

--- a/frontend/src/pages/NarratorsPage.tsx
+++ b/frontend/src/pages/NarratorsPage.tsx
@@ -25,33 +25,34 @@ export default function NarratorsPage() {
     <div>
       <h2>Narrators</h2>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div className="flex-row" style={{ marginBottom: '1rem' }}>
         <input
           type="text"
           placeholder="Search narrators..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-          style={{ padding: '0.5rem', flex: 1, maxWidth: 400 }}
+          className="form-input"
+          style={{ flex: 1, maxWidth: 400 }}
         />
-        <button onClick={handleSearch} style={{ padding: '0.5rem 1rem' }}>
+        <button onClick={handleSearch} className="btn">
           Search
         </button>
       </div>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
         <>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                <th style={{ padding: '0.5rem' }}>Name (Arabic)</th>
-                <th style={{ padding: '0.5rem' }}>Name (English)</th>
-                <th style={{ padding: '0.5rem' }}>Generation</th>
-                <th style={{ padding: '0.5rem' }}>Trustworthiness</th>
-                <th style={{ padding: '0.5rem' }}>Community</th>
+              <tr>
+                <th>Name (Arabic)</th>
+                <th>Name (English)</th>
+                <th>Generation</th>
+                <th>Trustworthiness</th>
+                <th>Community</th>
               </tr>
             </thead>
             <tbody>
@@ -59,21 +60,19 @@ export default function NarratorsPage() {
                 <tr
                   key={n.id}
                   onClick={() => navigate(`/narrators/${n.id}`)}
-                  style={{ borderBottom: '1px solid #eee', cursor: 'pointer' }}
+                  className="clickable-row"
                 >
-                  <td style={{ padding: '0.5rem', direction: 'rtl' }}>{n.name_ar}</td>
-                  <td style={{ padding: '0.5rem' }}>{n.name_en ?? '-'}</td>
-                  <td style={{ padding: '0.5rem' }}>{n.generation ?? '-'}</td>
-                  <td style={{ padding: '0.5rem' }}>{n.trustworthiness_consensus ?? '-'}</td>
-                  <td style={{ padding: '0.5rem' }}>
-                    {n.community_id != null ? `#${n.community_id}` : '-'}
-                  </td>
+                  <td className="text-rtl">{n.name_ar}</td>
+                  <td>{n.name_en ?? '-'}</td>
+                  <td>{n.generation ?? '-'}</td>
+                  <td>{n.trustworthiness_consensus ?? '-'}</td>
+                  <td>{n.community_id != null ? `#${n.community_id}` : '-'}</td>
                 </tr>
               ))}
             </tbody>
           </table>
 
-          <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <div className="pagination">
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
               Previous
             </button>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -3,6 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { searchAll, searchSemantic } from '../api/client'
 
+const typeBadgeClass: Record<string, string> = {
+  narrator: 'badge-narrator',
+  hadith: 'badge-hadith',
+  collection: 'badge-collection',
+}
+
 export default function SearchPage() {
   const [inputValue, setInputValue] = useState('')
   const [query, setQuery] = useState('')
@@ -34,25 +40,20 @@ export default function SearchPage() {
     else if (result.type === 'collection') navigate(`/collections/${result.id}`)
   }
 
-  const typeBadgeColor: Record<string, { bg: string; fg: string }> = {
-    narrator: { bg: '#e8f5e9', fg: '#2e7d32' },
-    hadith: { bg: '#e3f2fd', fg: '#1565c0' },
-    collection: { bg: '#fce4ec', fg: '#c62828' },
-  }
-
   return (
     <div>
       <h2>Search</h2>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', alignItems: 'center' }}>
+      <div className="flex-row" style={{ marginBottom: '1rem' }}>
         <input
           type="text"
           placeholder="Search narrators, hadiths, collections..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-          style={{ padding: '0.5rem', flex: 1, maxWidth: 500 }}
+          className="form-input"
+          style={{ flex: 1, maxWidth: 500 }}
         />
-        <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <label className="flex-row" style={{ gap: '0.25rem' }}>
           <input
             type="radio"
             checked={mode === 'fulltext'}
@@ -60,7 +61,7 @@ export default function SearchPage() {
           />
           Full-text
         </label>
-        <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <label className="flex-row" style={{ gap: '0.25rem' }}>
           <input
             type="radio"
             checked={mode === 'semantic'}
@@ -73,54 +74,33 @@ export default function SearchPage() {
       {isLoading && <p>Searching...</p>}
 
       {results && results.length === 0 && query.length >= 2 && (
-        <p style={{ color: '#666' }}>No results found for &quot;{query}&quot;</p>
+        <p className="muted-text">No results found for &quot;{query}&quot;</p>
       )}
 
       {results && results.length > 0 && (
         <div>
-          {results.map((r) => {
-            const badge = typeBadgeColor[r.type] ?? { bg: '#eee', fg: '#333' }
-            return (
-              <div
-                key={`${r.type}-${r.id}`}
-                onClick={() => handleResultClick(r)}
-                style={{
-                  padding: '0.75rem',
-                  borderBottom: '1px solid #eee',
-                  cursor: 'pointer',
-                }}
-              >
-                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                  <span
-                    style={{
-                      padding: '0.1rem 0.4rem',
-                      borderRadius: 3,
-                      fontSize: '0.75rem',
-                      fontWeight: 600,
-                      background: badge.bg,
-                      color: badge.fg,
-                      textTransform: 'capitalize',
-                    }}
-                  >
-                    {r.type}
-                  </span>
-                  <span style={{ fontWeight: 500 }}>{r.title}</span>
-                </div>
-                {r.title_ar && (
-                  <p
-                    style={{
-                      margin: '0.25rem 0 0',
-                      color: '#666',
-                      fontSize: '0.9rem',
-                      direction: 'rtl',
-                    }}
-                  >
-                    {r.title_ar}
-                  </p>
-                )}
+          {results.map((r) => (
+            <div
+              key={`${r.type}-${r.id}`}
+              onClick={() => handleResultClick(r)}
+              className="search-result"
+            >
+              <div className="flex-row">
+                <span
+                  className={`badge-sm ${typeBadgeClass[r.type] ?? ''}`}
+                  style={{ fontWeight: 600, textTransform: 'capitalize' }}
+                >
+                  {r.type}
+                </span>
+                <span style={{ fontWeight: 500 }}>{r.title}</span>
               </div>
-            )
-          })}
+              {r.title_ar && (
+                <p className="text-rtl" style={{ margin: '0.25rem 0 0', color: '#666', fontSize: '0.9rem' }}>
+                  {r.title_ar}
+                </p>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -43,14 +43,20 @@ export default function TimelinePage() {
   }, [])
 
   useEffect(() => {
-    if (!events?.length || !svgRef.current) return
+    if (!svgRef.current) return
 
     const svg = d3.select(svgRef.current)
     const width = svgRef.current.clientWidth || 800
-    const height = Math.max(400, events.length * 30 + MARGIN.top + MARGIN.bottom)
 
+    if (!events?.length) {
+      svg.attr('height', 400)
+      svg.selectAll('.x-axis').remove()
+      svg.selectAll('.event-bar').remove()
+      return
+    }
+
+    const height = Math.max(400, events.length * 30 + MARGIN.top + MARGIN.bottom)
     svg.attr('height', height)
-    svg.selectAll('*').remove()
 
     const allYears = events.flatMap((e) => [e.year_ah, e.end_year_ah ?? e.year_ah])
     const xMin = d3.min(allYears) ?? 0
@@ -67,60 +73,78 @@ export default function TimelinePage() {
       .range([MARGIN.top, height - MARGIN.bottom])
       .padding(0.3)
 
-    svg
+    // --- X Axis: enter/update ---
+    let axisG = svg.selectAll<SVGGElement, null>('.x-axis').data([null])
+    axisG = axisG
+      .enter()
       .append('g')
+      .attr('class', 'x-axis')
+      .merge(axisG)
+
+    axisG
       .attr('transform', `translate(0,${height - MARGIN.bottom})`)
       .call(d3.axisBottom(xScale).tickFormat((d) => `${d} AH`))
       .selectAll('text')
       .style('font-size', '11px')
 
-    const bars = svg
-      .selectAll('.event-bar')
-      .data(events)
-      .join('g')
+    // --- Event bars: enter/update/exit ---
+    const barGroups = svg
+      .selectAll<SVGGElement, TimelineEntry>('.event-bar')
+      .data(events, (d) => d.id)
+
+    // Exit: remove bars no longer in data
+    barGroups.exit().remove()
+
+    // Enter: create new bar groups
+    const barEnter = barGroups
+      .enter()
+      .append('g')
       .attr('class', 'event-bar')
       .style('cursor', 'pointer')
 
-    bars
-      .append('rect')
+    barEnter.append('rect').attr('rx', 3).attr('fill', '#1a73e8').attr('opacity', 0.75)
+    barEnter.append('text')
+      .attr('text-anchor', 'end')
+      .attr('dominant-baseline', 'central')
+      .style('font-size', '11px')
+      .style('fill', '#333')
+
+    // Merge: update all (enter + existing)
+    const barMerged = barEnter.merge(barGroups)
+
+    barMerged
+      .select('rect')
       .attr('x', (d) => xScale(d.year_ah))
       .attr('y', (_d, i) => yScale(i) ?? 0)
       .attr('width', (d) =>
         Math.max(4, xScale(d.end_year_ah ?? d.year_ah) - xScale(d.year_ah)),
       )
       .attr('height', yScale.bandwidth())
-      .attr('rx', 3)
-      .attr('fill', '#1a73e8')
-      .attr('opacity', 0.75)
 
-    bars
-      .append('text')
+    barMerged
+      .select('text')
       .attr('x', (d) => xScale(d.year_ah) - 4)
       .attr('y', (_d, i) => (yScale(i) ?? 0) + yScale.bandwidth() / 2)
-      .attr('text-anchor', 'end')
-      .attr('dominant-baseline', 'central')
-      .style('font-size', '11px')
-      .style('fill', '#333')
       .text((d) => d.name)
 
-    bars.on('click', (_event, d) => handleEventClick(d))
+    barMerged.on('click', (_event, d) => handleEventClick(d))
   }, [events, handleEventClick])
 
   return (
     <div>
       <h2>Timeline</h2>
-      <p style={{ color: '#666', marginBottom: '1rem' }}>
+      <p className="muted-text" style={{ marginBottom: '1rem' }}>
         Historical events and narrator activity periods (Anno Hegirae).
       </p>
 
-      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem', alignItems: 'center' }}>
+      <div className="timeline-controls">
         <label>
           From (AH):{' '}
           <input
             type="number"
             value={effectiveRange[0]}
             onChange={(e) => setYearRange([Number(e.target.value), effectiveRange[1]])}
-            style={{ width: 80, padding: '0.25rem' }}
+            className="form-input-sm"
           />
         </label>
         <label>
@@ -129,37 +153,29 @@ export default function TimelinePage() {
             type="number"
             value={effectiveRange[1]}
             onChange={(e) => setYearRange([effectiveRange[0], Number(e.target.value)])}
-            style={{ width: 80, padding: '0.25rem' }}
+            className="form-input-sm"
           />
         </label>
       </div>
 
       {isLoading && <p>Loading timeline...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
-      <div style={{ display: 'flex', gap: '1.5rem' }}>
-        <div style={{ flex: 1, overflowX: 'auto' }}>
+      <div className="timeline-body">
+        <div className="timeline-chart">
           <svg ref={svgRef} width="100%" height={400} />
         </div>
 
         {selectedEvent && (
-          <div
-            style={{
-              width: 300,
-              padding: '1rem',
-              border: '1px solid #ddd',
-              borderRadius: 6,
-              background: '#fafafa',
-            }}
-          >
-            <h3 style={{ margin: '0 0 0.5rem' }}>{selectedEvent.name}</h3>
-            <p style={{ color: '#666', fontSize: '0.875rem' }}>
+          <div className="timeline-detail">
+            <h3>{selectedEvent.name}</h3>
+            <p className="small-muted">
               {selectedEvent.year_ah}
               {selectedEvent.end_year_ah ? ` - ${selectedEvent.end_year_ah}` : ''} AH
             </p>
             {selectedEvent.description && <p>{selectedEvent.description}</p>}
             {selectedEvent.narrator_count > 0 && (
-              <p style={{ color: '#666', fontSize: '0.875rem' }}>
+              <p className="small-muted">
                 {selectedEvent.narrator_count} active narrators
               </p>
             )}

--- a/frontend/src/pages/admin/ConfigPage.tsx
+++ b/frontend/src/pages/admin/ConfigPage.tsx
@@ -148,16 +148,16 @@ export default function ConfigPage() {
     })
   }
 
-  if (isLoading) return <div style={{ padding: 24 }}>Loading configuration...</div>
-  if (error) return <div style={{ padding: 24, color: 'red' }}>Error loading config: {String(error)}</div>
+  if (isLoading) return <div className="admin-page">Loading configuration...</div>
+  if (error) return <div className="admin-page error-text">Error loading config: {String(error)}</div>
 
   return (
-    <div style={{ padding: 24, maxWidth: 800 }}>
+    <div className="admin-page">
       <h1>System Configuration</h1>
 
-      <section style={{ marginBottom: 32 }}>
+      <section className="section-mb">
         <h2>Rate Limiting &amp; Pagination</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}>
+        <div className="grid-2col">
           <label>
             Rate limit (req/min)
             <input
@@ -167,7 +167,7 @@ export default function ConfigPage() {
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, rate_limit_per_minute: Number(e.target.value) }))
               }
-              style={{ display: 'block', width: '100%', marginTop: 4, padding: 8 }}
+              className="form-input-block"
             />
           </label>
           <label>
@@ -179,7 +179,7 @@ export default function ConfigPage() {
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, max_search_results: Number(e.target.value) }))
               }
-              style={{ display: 'block', width: '100%', marginTop: 4, padding: 8 }}
+              className="form-input-block"
             />
           </label>
           <label>
@@ -191,13 +191,13 @@ export default function ConfigPage() {
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, max_pagination_limit: Number(e.target.value) }))
               }
-              style={{ display: 'block', width: '100%', marginTop: 4, padding: 8 }}
+              className="form-input-block"
             />
           </label>
         </div>
       </section>
 
-      <section style={{ marginBottom: 32 }}>
+      <section className="section-mb">
         <h2>CORS Origins</h2>
         <label>
           Comma-separated origins
@@ -205,27 +205,28 @@ export default function ConfigPage() {
             type="text"
             value={corsInput}
             onChange={(e) => setCorsInput(e.target.value)}
-            style={{ display: 'block', width: '100%', marginTop: 4, padding: 8 }}
+            className="form-input-block"
           />
         </label>
       </section>
 
-      <section style={{ marginBottom: 32 }}>
+      <section className="section-mb">
         <h2>Feature Flags</h2>
         {Object.entries(formData.feature_flags ?? {}).map(([key, val]) => (
-          <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <div key={key} className="flag-row">
             <input type="checkbox" checked={val} onChange={() => toggleFlag(key)} />
             <span style={{ flex: 1 }}>{key}</span>
-            <button onClick={() => removeFlag(key)} style={{ color: 'red' }}>Remove</button>
+            <button onClick={() => removeFlag(key)} className="btn-danger">Remove</button>
           </div>
         ))}
-        <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+        <div className="flex-row" style={{ marginTop: 8 }}>
           <input
             type="text"
             placeholder="New flag name"
             value={newFlagKey}
             onChange={(e) => setNewFlagKey(e.target.value)}
-            style={{ flex: 1, padding: 8 }}
+            className="form-input"
+            style={{ flex: 1 }}
           />
           <button onClick={addFlag}>Add Flag</button>
         </div>
@@ -235,12 +236,12 @@ export default function ConfigPage() {
         <button
           onClick={handleSave}
           disabled={mutation.isPending}
-          style={{ padding: '8px 24px', fontWeight: 'bold' }}
+          className="btn-primary"
         >
           {mutation.isPending ? 'Saving...' : 'Save Configuration'}
         </button>
         {saveMessage && (
-          <span style={{ marginLeft: 12, color: saveMessage.startsWith('Error') ? 'red' : 'green' }}>
+          <span className={saveMessage.startsWith('Error') ? 'save-error' : 'save-success'}>
             {saveMessage}
           </span>
         )}
@@ -251,30 +252,30 @@ export default function ConfigPage() {
       <section>
         <h2>Audit Log</h2>
         {auditData?.entries.length === 0 && <p>No config changes recorded yet.</p>}
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table className="data-table">
           <thead>
             <tr>
-              <th style={{ textAlign: 'left', padding: 8, borderBottom: '1px solid #ccc' }}>Key</th>
-              <th style={{ textAlign: 'left', padding: 8, borderBottom: '1px solid #ccc' }}>Old Value</th>
-              <th style={{ textAlign: 'left', padding: 8, borderBottom: '1px solid #ccc' }}>New Value</th>
-              <th style={{ textAlign: 'left', padding: 8, borderBottom: '1px solid #ccc' }}>Changed By</th>
-              <th style={{ textAlign: 'left', padding: 8, borderBottom: '1px solid #ccc' }}>Changed At</th>
+              <th className="audit-th">Key</th>
+              <th className="audit-th">Old Value</th>
+              <th className="audit-th">New Value</th>
+              <th className="audit-th">Changed By</th>
+              <th className="audit-th">Changed At</th>
             </tr>
           </thead>
           <tbody>
             {auditData?.entries.map((entry, i) => (
               <tr key={i}>
-                <td style={{ padding: 8, borderBottom: '1px solid #eee' }}>{entry.key}</td>
-                <td style={{ padding: 8, borderBottom: '1px solid #eee', maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis' }}>{entry.old_value}</td>
-                <td style={{ padding: 8, borderBottom: '1px solid #eee', maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis' }}>{entry.new_value}</td>
-                <td style={{ padding: 8, borderBottom: '1px solid #eee' }}>{entry.changed_by}</td>
-                <td style={{ padding: 8, borderBottom: '1px solid #eee' }}>{entry.changed_at}</td>
+                <td className="audit-td">{entry.key}</td>
+                <td className="cell-truncate">{entry.old_value}</td>
+                <td className="cell-truncate">{entry.new_value}</td>
+                <td className="audit-td">{entry.changed_by}</td>
+                <td className="audit-td">{entry.changed_at}</td>
               </tr>
             ))}
           </tbody>
         </table>
         {auditData && auditData.total > 20 && (
-          <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+          <div className="pagination" style={{ marginTop: 12 }}>
             <button disabled={auditPage <= 1} onClick={() => setAuditPage((p) => p - 1)}>
               Previous
             </button>

--- a/frontend/src/pages/admin/ModerationPage.tsx
+++ b/frontend/src/pages/admin/ModerationPage.tsx
@@ -7,6 +7,12 @@ import {
 } from '../../api/client'
 import type { ModerationItem } from '../../types/api'
 
+function statusBadgeClass(status: string): string {
+  if (status === 'approved') return 'badge-approved'
+  if (status === 'rejected') return 'badge-rejected'
+  return 'badge-pending'
+}
+
 export default function ModerationPage() {
   const [page, setPage] = useState(1)
   const [statusFilter, setStatusFilter] = useState<string | undefined>(undefined)
@@ -41,13 +47,13 @@ export default function ModerationPage() {
     <div>
       <h2>Content Moderation</h2>
 
-      <div style={{ marginBottom: '1.5rem', padding: '1rem', border: '1px solid #ddd' }}>
-        <h3 style={{ marginTop: 0 }}>Flag Content</h3>
-        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      <div className="flag-box">
+        <h3>Flag Content</h3>
+        <div className="flex-row" style={{ flexWrap: 'wrap' }}>
           <select
             value={flagForm.entity_type}
             onChange={(e) => setFlagForm({ ...flagForm, entity_type: e.target.value })}
-            style={{ padding: '0.5rem' }}
+            className="form-input"
           >
             <option value="hadith">Hadith</option>
             <option value="narrator">Narrator</option>
@@ -57,14 +63,16 @@ export default function ModerationPage() {
             placeholder="Entity ID"
             value={flagForm.entity_id}
             onChange={(e) => setFlagForm({ ...flagForm, entity_id: e.target.value })}
-            style={{ padding: '0.5rem', flex: 1, minWidth: 200 }}
+            className="form-input"
+            style={{ flex: 1, minWidth: 200 }}
           />
           <input
             type="text"
             placeholder="Reason"
             value={flagForm.reason}
             onChange={(e) => setFlagForm({ ...flagForm, reason: e.target.value })}
-            style={{ padding: '0.5rem', flex: 2, minWidth: 200 }}
+            className="form-input"
+            style={{ flex: 2, minWidth: 200 }}
           />
           <button
             onClick={() => {
@@ -74,14 +82,14 @@ export default function ModerationPage() {
               }
             }}
             disabled={flagMutation.isPending}
-            style={{ padding: '0.5rem 1rem' }}
+            className="btn"
           >
             Flag
           </button>
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div className="flex-row" style={{ marginBottom: '1rem' }}>
         <label>Filter by status:</label>
         <select
           value={statusFilter ?? ''}
@@ -89,7 +97,7 @@ export default function ModerationPage() {
             setStatusFilter(e.target.value || undefined)
             setPage(1)
           }}
-          style={{ padding: '0.5rem' }}
+          className="form-input"
         >
           <option value="">All</option>
           <option value="pending">Pending</option>
@@ -99,63 +107,44 @@ export default function ModerationPage() {
       </div>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
         <>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                <th style={{ padding: '0.5rem' }}>Type</th>
-                <th style={{ padding: '0.5rem' }}>Entity ID</th>
-                <th style={{ padding: '0.5rem' }}>Reason</th>
-                <th style={{ padding: '0.5rem' }}>Status</th>
-                <th style={{ padding: '0.5rem' }}>Flagged</th>
-                <th style={{ padding: '0.5rem' }}>Actions</th>
+              <tr>
+                <th>Type</th>
+                <th>Entity ID</th>
+                <th>Reason</th>
+                <th>Status</th>
+                <th>Flagged</th>
+                <th>Actions</th>
               </tr>
             </thead>
             <tbody>
               {data.items.map((item: ModerationItem) => (
-                <tr key={item.id} style={{ borderBottom: '1px solid #eee' }}>
-                  <td style={{ padding: '0.5rem' }}>{item.entity_type}</td>
-                  <td style={{ padding: '0.5rem', fontFamily: 'monospace', fontSize: '0.85rem' }}>
-                    {item.entity_id}
-                  </td>
-                  <td style={{ padding: '0.5rem' }}>{item.reason}</td>
-                  <td style={{ padding: '0.5rem' }}>
-                    <span
-                      style={{
-                        padding: '0.2rem 0.5rem',
-                        borderRadius: '4px',
-                        background:
-                          item.status === 'approved'
-                            ? '#d4edda'
-                            : item.status === 'rejected'
-                              ? '#f8d7da'
-                              : '#fff3cd',
-                        color:
-                          item.status === 'approved'
-                            ? '#155724'
-                            : item.status === 'rejected'
-                              ? '#721c24'
-                              : '#856404',
-                      }}
-                    >
+                <tr key={item.id}>
+                  <td>{item.entity_type}</td>
+                  <td className="mono">{item.entity_id}</td>
+                  <td>{item.reason}</td>
+                  <td>
+                    <span className={statusBadgeClass(item.status)}>
                       {item.status}
                     </span>
                   </td>
-                  <td style={{ padding: '0.5rem', fontSize: '0.85rem' }}>
+                  <td style={{ fontSize: '0.85rem' }}>
                     {new Date(item.flagged_at).toLocaleDateString()}
                   </td>
-                  <td style={{ padding: '0.5rem' }}>
+                  <td>
                     {item.status === 'pending' && (
-                      <div style={{ display: 'flex', gap: '0.25rem' }}>
+                      <div className="flex-row" style={{ gap: '0.25rem' }}>
                         <button
                           onClick={() =>
                             updateMutation.mutate({ id: item.id, status: 'approved' })
                           }
                           disabled={updateMutation.isPending}
-                          style={{ padding: '0.25rem 0.5rem', fontSize: '0.85rem' }}
+                          className="btn-sm"
                         >
                           Approve
                         </button>
@@ -164,7 +153,7 @@ export default function ModerationPage() {
                             updateMutation.mutate({ id: item.id, status: 'rejected' })
                           }
                           disabled={updateMutation.isPending}
-                          style={{ padding: '0.25rem 0.5rem', fontSize: '0.85rem' }}
+                          className="btn-sm"
                         >
                           Reject
                         </button>
@@ -177,7 +166,7 @@ export default function ModerationPage() {
           </table>
 
           {totalPages > 1 && (
-            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+            <div className="pagination">
               <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
                 Previous
               </button>

--- a/frontend/src/pages/admin/ReportsPage.tsx
+++ b/frontend/src/pages/admin/ReportsPage.tsx
@@ -4,17 +4,8 @@ import type { SystemReport } from '../../types/api'
 
 function MetricCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div
-      style={{
-        border: '1px solid #ddd',
-        borderRadius: '8px',
-        padding: '1rem',
-        marginBottom: '1rem',
-      }}
-    >
-      <h3 style={{ marginTop: 0, borderBottom: '1px solid #eee', paddingBottom: '0.5rem' }}>
-        {title}
-      </h3>
+    <div className="metric-card">
+      <h3>{title}</h3>
       {children}
     </div>
   )
@@ -22,7 +13,7 @@ function MetricCard({ title, children }: { title: string; children: React.ReactN
 
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0.25rem 0' }}>
+    <div className="stat-row">
       <span>{label}</span>
       <strong>{typeof value === 'number' ? value.toLocaleString() : value}</strong>
     </div>
@@ -36,7 +27,7 @@ export default function ReportsPage() {
   })
 
   if (isLoading) return <p>Loading reports...</p>
-  if (error) return <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>
+  if (error) return <p className="error-text">Error: {(error as Error).message}</p>
   if (!data) return <p>No report data available.</p>
 
   return (
@@ -53,30 +44,22 @@ export default function ReportsPage() {
                 File details ({data.pipeline.files.length})
               </summary>
               <table
-                style={{
-                  width: '100%',
-                  borderCollapse: 'collapse',
-                  marginTop: '0.5rem',
-                  fontSize: '0.85rem',
-                }}
+                className="data-table data-table-compact"
+                style={{ marginTop: '0.5rem', fontSize: '0.85rem' }}
               >
                 <thead>
-                  <tr style={{ borderBottom: '1px solid #ddd', textAlign: 'left' }}>
-                    <th style={{ padding: '0.25rem' }}>File</th>
-                    <th style={{ padding: '0.25rem' }}>Rows</th>
-                    <th style={{ padding: '0.25rem' }}>Columns</th>
+                  <tr>
+                    <th>File</th>
+                    <th>Rows</th>
+                    <th>Columns</th>
                   </tr>
                 </thead>
                 <tbody>
                   {data.pipeline.files.map((f: Record<string, unknown>, i: number) => (
-                    <tr key={i} style={{ borderBottom: '1px solid #eee' }}>
-                      <td style={{ padding: '0.25rem', fontFamily: 'monospace' }}>
-                        {String(f.file ?? '')}
-                      </td>
-                      <td style={{ padding: '0.25rem' }}>
-                        {Number(f.rows ?? 0).toLocaleString()}
-                      </td>
-                      <td style={{ padding: '0.25rem' }}>{String(f.columns ?? '')}</td>
+                    <tr key={i}>
+                      <td className="mono">{String(f.file ?? '')}</td>
+                      <td>{Number(f.rows ?? 0).toLocaleString()}</td>
+                      <td>{String(f.columns ?? '')}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -89,15 +72,9 @@ export default function ReportsPage() {
       {data.disambiguation && (
         <MetricCard title="Disambiguation Rates">
           <StatRow label="NER mentions" value={data.disambiguation.ner_mention_count} />
-          <StatRow
-            label="Canonical narrators"
-            value={data.disambiguation.canonical_narrator_count}
-          />
+          <StatRow label="Canonical narrators" value={data.disambiguation.canonical_narrator_count} />
           <StatRow label="Ambiguous mentions" value={data.disambiguation.ambiguous_count} />
-          <StatRow
-            label="Resolution rate"
-            value={`${data.disambiguation.resolution_rate_pct}%`}
-          />
+          <StatRow label="Resolution rate" value={`${data.disambiguation.resolution_rate_pct}%`} />
           <StatRow label="Ambiguous rate" value={`${data.disambiguation.ambiguous_pct}%`} />
         </MetricCard>
       )}
@@ -116,10 +93,7 @@ export default function ReportsPage() {
         <MetricCard title="Graph Validation">
           <StatRow label="Orphan narrators" value={data.graph_validation.orphan_narrators} />
           <StatRow label="Orphan hadiths" value={data.graph_validation.orphan_hadiths} />
-          <StatRow
-            label="Chain integrity"
-            value={`${data.graph_validation.chain_integrity_pct}%`}
-          />
+          <StatRow label="Chain integrity" value={`${data.graph_validation.chain_integrity_pct}%`} />
           <StatRow
             label="Collection coverage"
             value={`${data.graph_validation.collection_coverage_pct}%`}

--- a/frontend/src/pages/admin/UsageAnalyticsPage.tsx
+++ b/frontend/src/pages/admin/UsageAnalyticsPage.tsx
@@ -12,61 +12,37 @@ export default function UsageAnalyticsPage() {
       <h2>Usage Analytics</h2>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
         <>
-          <div style={{ display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap' }}>
-            <div
-              style={{
-                border: '1px solid #ddd',
-                borderRadius: '8px',
-                padding: '1.5rem',
-                minWidth: 180,
-                textAlign: 'center',
-              }}
-            >
-              <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>
-                Search Volume
-              </div>
-              <div style={{ fontSize: '1.5rem', fontWeight: 700, color: '#333' }}>
-                {data.search_volume.toLocaleString()}
-              </div>
+          <div className="flex-row-wrap" style={{ marginBottom: '2rem' }}>
+            <div className="stat-card">
+              <div className="stat-card-label">Search Volume</div>
+              <div className="stat-card-value">{data.search_volume.toLocaleString()}</div>
             </div>
-            <div
-              style={{
-                border: '1px solid #ddd',
-                borderRadius: '8px',
-                padding: '1.5rem',
-                minWidth: 180,
-                textAlign: 'center',
-              }}
-            >
-              <div style={{ fontSize: '0.875rem', color: '#666', marginBottom: '0.5rem' }}>
-                API Calls
-              </div>
-              <div style={{ fontSize: '1.5rem', fontWeight: 700, color: '#333' }}>
-                {data.api_call_count.toLocaleString()}
-              </div>
+            <div className="stat-card">
+              <div className="stat-card-label">API Calls</div>
+              <div className="stat-card-value">{data.api_call_count.toLocaleString()}</div>
             </div>
           </div>
 
           <h3>Popular Narrators</h3>
           {data.popular_narrators.length === 0 ? (
-            <p style={{ color: '#666' }}>No data available yet.</p>
+            <p className="muted-text">No data available yet.</p>
           ) : (
-            <table style={{ width: '100%', borderCollapse: 'collapse', maxWidth: 600 }}>
+            <table className="data-table" style={{ maxWidth: 600 }}>
               <thead>
-                <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                  <th style={{ padding: '0.5rem' }}>Narrator</th>
-                  <th style={{ padding: '0.5rem' }}>Queries</th>
+                <tr>
+                  <th>Narrator</th>
+                  <th>Queries</th>
                 </tr>
               </thead>
               <tbody>
                 {data.popular_narrators.map((n) => (
-                  <tr key={n.id} style={{ borderBottom: '1px solid #eee' }}>
-                    <td style={{ padding: '0.5rem' }}>{n.name}</td>
-                    <td style={{ padding: '0.5rem' }}>{n.query_count.toLocaleString()}</td>
+                  <tr key={n.id}>
+                    <td>{n.name}</td>
+                    <td>{n.query_count.toLocaleString()}</td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/pages/admin/UserManagementPage.tsx
+++ b/frontend/src/pages/admin/UserManagementPage.tsx
@@ -37,95 +37,64 @@ export default function UserManagementPage() {
     <div>
       <h2>User Management</h2>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div className="flex-row" style={{ marginBottom: '1rem' }}>
         <input
           type="text"
           placeholder="Search users by name or email..."
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-          style={{ padding: '0.5rem', flex: 1, maxWidth: 400 }}
+          className="form-input"
+          style={{ flex: 1, maxWidth: 400 }}
         />
-        <button onClick={handleSearch} style={{ padding: '0.5rem 1rem' }}>
+        <button onClick={handleSearch} className="btn">
           Search
         </button>
       </div>
 
       {isLoading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
         <>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="data-table">
             <thead>
-              <tr style={{ borderBottom: '2px solid #ddd', textAlign: 'left' }}>
-                <th style={{ padding: '0.5rem' }}>Name</th>
-                <th style={{ padding: '0.5rem' }}>Email</th>
-                <th style={{ padding: '0.5rem' }}>Provider</th>
-                <th style={{ padding: '0.5rem' }}>Role</th>
-                <th style={{ padding: '0.5rem' }}>Status</th>
-                <th style={{ padding: '0.5rem' }}>Actions</th>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Provider</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Actions</th>
               </tr>
             </thead>
             <tbody>
               {data.items.map((u) => (
-                <tr key={u.id} style={{ borderBottom: '1px solid #eee' }}>
-                  <td style={{ padding: '0.5rem' }}>
+                <tr key={u.id}>
+                  <td>
                     {u.name}
-                    {u.is_admin && (
-                      <span
-                        style={{
-                          marginLeft: '0.5rem',
-                          fontSize: '0.75rem',
-                          background: '#e8f0fe',
-                          color: '#1a73e8',
-                          padding: '0.125rem 0.375rem',
-                          borderRadius: '4px',
-                        }}
-                      >
-                        Admin
-                      </span>
-                    )}
+                    {u.is_admin && <span className="badge-admin">Admin</span>}
                   </td>
-                  <td style={{ padding: '0.5rem' }}>{u.email}</td>
-                  <td style={{ padding: '0.5rem' }}>{u.provider}</td>
-                  <td style={{ padding: '0.5rem' }}>{u.role ?? '-'}</td>
-                  <td style={{ padding: '0.5rem' }}>
-                    <span
-                      style={{
-                        color: u.is_suspended ? '#d93025' : '#188038',
-                        fontWeight: 600,
-                      }}
-                    >
+                  <td>{u.email}</td>
+                  <td>{u.provider}</td>
+                  <td>{u.role ?? '-'}</td>
+                  <td>
+                    <span className={u.is_suspended ? 'text-suspended' : 'text-active'}>
                       {u.is_suspended ? 'Suspended' : 'Active'}
                     </span>
                   </td>
-                  <td style={{ padding: '0.5rem', display: 'flex', gap: '0.25rem' }}>
+                  <td className="flex-row" style={{ gap: '0.25rem' }}>
                     <button
                       onClick={() => suspendMutation.mutate(u)}
                       disabled={suspendMutation.isPending}
-                      style={{
-                        padding: '0.25rem 0.5rem',
-                        fontSize: '0.8rem',
-                        cursor: 'pointer',
-                        background: u.is_suspended ? '#e6f4ea' : '#fce8e6',
-                        border: '1px solid #ccc',
-                        borderRadius: '4px',
-                      }}
+                      className={`btn-action ${u.is_suspended ? 'btn-action-unsuspend' : 'btn-action-suspend'}`}
                     >
                       {u.is_suspended ? 'Unsuspend' : 'Suspend'}
                     </button>
                     <button
                       onClick={() => promoteMutation.mutate(u)}
                       disabled={promoteMutation.isPending}
-                      style={{
-                        padding: '0.25rem 0.5rem',
-                        fontSize: '0.8rem',
-                        cursor: 'pointer',
-                        background: u.is_admin ? '#fce8e6' : '#e8f0fe',
-                        border: '1px solid #ccc',
-                        borderRadius: '4px',
-                      }}
+                      className={`btn-action ${u.is_admin ? 'btn-action-demote' : 'btn-action-promote'}`}
                     >
                       {u.is_admin ? 'Demote' : 'Promote'}
                     </button>
@@ -135,9 +104,7 @@ export default function UserManagementPage() {
             </tbody>
           </table>
 
-          <div
-            style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}
-          >
+          <div className="pagination">
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
               Previous
             </button>

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -1,0 +1,538 @@
+/* Shared styles for the Isnad Graph frontend */
+
+/* --- Error / status text --- */
+.error-text {
+  color: red;
+}
+
+.muted-text {
+  color: #666;
+}
+
+.small-muted {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+/* --- Flex utilities --- */
+.flex-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.flex-row-wrap {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* --- Tables --- */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table thead tr {
+  border-bottom: 2px solid #ddd;
+  text-align: left;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.5rem;
+}
+
+.data-table tbody tr {
+  border-bottom: 1px solid #eee;
+}
+
+.data-table tbody tr.clickable-row {
+  cursor: pointer;
+}
+
+/* Compact variant for nested tables */
+.data-table-compact th,
+.data-table-compact td {
+  padding: 0.25rem;
+}
+
+/* --- Stat / status cards --- */
+.stat-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1.5rem;
+  min-width: 180px;
+  text-align: center;
+}
+
+.stat-card-label {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.stat-card-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.stat-card-value-lg {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+/* --- Metric card (bordered section) --- */
+.metric-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.metric-card h3 {
+  margin-top: 0;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0;
+}
+
+/* --- Badges --- */
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.badge-sm {
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+.badge-admin {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  background: #e8f0fe;
+  color: #1a73e8;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+}
+
+.badge-sunni {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.badge-shia {
+  background: #e3f2fd;
+  color: #1565c0;
+}
+
+.badge-sahih {
+  background: #e6f4ea;
+  color: #137333;
+}
+
+.badge-other-grade {
+  background: #fef7e0;
+  color: #b06000;
+}
+
+.badge-topic {
+  display: inline-block;
+  margin-right: 0.25rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+  background: #e8eaf6;
+  color: #283593;
+}
+
+.badge-topic-lg {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  background: #e8eaf6;
+  color: #283593;
+  font-size: 0.9rem;
+}
+
+/* Moderation status badges */
+.badge-approved {
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: #d4edda;
+  color: #155724;
+}
+
+.badge-rejected {
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.badge-pending {
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: #fff3cd;
+  color: #856404;
+}
+
+/* Search result type badges */
+.badge-narrator {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.badge-hadith {
+  background: #e3f2fd;
+  color: #1565c0;
+}
+
+.badge-collection {
+  background: #fce4ec;
+  color: #c62828;
+}
+
+/* Similarity score badges */
+.badge-similarity-high {
+  background: #e6f4ea;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.badge-similarity-low {
+  background: #fef7e0;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+/* --- Forms --- */
+.form-input {
+  padding: 0.5rem;
+}
+
+.form-input-block {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px;
+}
+
+.form-input-sm {
+  width: 80px;
+  padding: 0.25rem;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+}
+
+.btn-sm {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.btn-action {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.btn-action-suspend {
+  background: #fce8e6;
+}
+
+.btn-action-unsuspend {
+  background: #e6f4ea;
+}
+
+.btn-action-promote {
+  background: #e8f0fe;
+}
+
+.btn-action-demote {
+  background: #fce8e6;
+}
+
+.btn-primary {
+  padding: 8px 24px;
+  font-weight: bold;
+}
+
+.btn-danger {
+  color: red;
+}
+
+/* --- Pagination --- */
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  align-items: center;
+}
+
+/* --- Links --- */
+.link-primary {
+  color: #1a73e8;
+  text-decoration: none;
+}
+
+/* --- Section spacing --- */
+.section {
+  margin-top: 1.5rem;
+}
+
+.section-mb {
+  margin-bottom: 32px;
+}
+
+/* --- Grid layouts --- */
+.grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+/* --- Arabic text --- */
+.text-rtl {
+  direction: rtl;
+  text-align: right;
+}
+
+.text-arabic-block {
+  direction: rtl;
+  text-align: right;
+  padding: 1rem;
+  background: #fafafa;
+  border-radius: 4px;
+  line-height: 1.8;
+  font-size: 1.1rem;
+}
+
+.text-english-block {
+  padding: 1rem;
+  background: #fafafa;
+  border-radius: 4px;
+  line-height: 1.6;
+}
+
+/* --- Monospace --- */
+.mono {
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+/* --- Status colors --- */
+.text-success {
+  color: #188038;
+}
+
+.text-danger {
+  color: #d93025;
+}
+
+.text-warning {
+  color: #e37400;
+}
+
+.text-active {
+  color: #188038;
+  font-weight: 600;
+}
+
+.text-suspended {
+  color: #d93025;
+  font-weight: 600;
+}
+
+/* --- Flag content box --- */
+.flag-box {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+}
+
+.flag-box h3 {
+  margin-top: 0;
+}
+
+/* --- Save message --- */
+.save-success {
+  margin-left: 12px;
+  color: green;
+}
+
+.save-error {
+  margin-left: 12px;
+  color: red;
+}
+
+/* --- Audit table cell overflow --- */
+.cell-truncate {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* --- Config audit table --- */
+.audit-th {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #ccc;
+}
+
+.audit-td {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+}
+
+/* --- Feature flag row --- */
+.flag-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+/* --- Graph explorer --- */
+.graph-container {
+  flex: 1;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fafafa;
+  min-height: 400px;
+}
+
+.graph-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #999;
+}
+
+.search-dropdown {
+  margin-top: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  background: #fff;
+  position: relative;
+  z-index: 10;
+  max-width: 400px;
+}
+
+.search-dropdown-item {
+  padding: 0.5rem;
+  cursor: pointer;
+  border-bottom: 1px solid #eee;
+}
+
+/* --- Search result row --- */
+.search-result {
+  padding: 0.75rem;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+/* --- Timeline --- */
+.timeline-controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  align-items: center;
+}
+
+.timeline-body {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.timeline-chart {
+  flex: 1;
+  overflow-x: auto;
+}
+
+.timeline-detail {
+  width: 300px;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: #fafafa;
+}
+
+.timeline-detail h3 {
+  margin: 0 0 0.5rem;
+}
+
+/* --- Collection detail meta --- */
+.collection-meta {
+  color: #666;
+  margin-bottom: 1.5rem;
+}
+
+.collection-meta .separator {
+  margin: 0 0.5rem;
+}
+
+/* --- Narrator detail bio table --- */
+.bio-table {
+  border-collapse: collapse;
+}
+
+.bio-table td:first-child {
+  padding: 0.4rem 1rem 0.4rem 0;
+  font-weight: 600;
+}
+
+.bio-table td:last-child {
+  padding: 0.4rem 0;
+}
+
+.bio-table tr {
+  border-bottom: 1px solid #eee;
+}
+
+/* --- Network stat mini-cards --- */
+.network-stat {
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  min-width: 100px;
+  text-align: center;
+}
+
+.network-stat-label {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.network-stat-value {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+/* --- Admin page container --- */
+.admin-page {
+  padding: 24px;
+  max-width: 800px;
+}


### PR DESCRIPTION
## Summary
- Create shared CSS system (`frontend/src/styles/common.css`) with utility classes for tables, cards, badges, forms, pagination, layout helpers, and status colors
- Extract inline `style={{}}` objects from all React pages and components to CSS classes, reducing ~264 lines of inline style code across 18 files
- Refactor `TimelinePage.tsx` D3 visualization to use proper enter/update/exit data join pattern instead of `selectAll('*').remove()` anti-pattern, ensuring correct re-renders on data changes

Closes #195
Closes #196

## Test plan
- [ ] Verify all pages render correctly with CSS classes (narrators, hadiths, collections, search, timeline, compare, graph explorer)
- [ ] Verify admin pages render correctly (users, health, stats, analytics, moderation, reports, config)
- [ ] Verify timeline visualization updates correctly when changing year range
- [ ] Verify timeline correctly handles empty data state
- [ ] Run `npm run build` to confirm no TypeScript errors