### PR TITLE
fix(frontend): resolve ForceGraph + SearchPage TypeScript build errors

### DIFF
--- a/frontend/src/components/ForceGraph.tsx
+++ b/frontend/src/components/ForceGraph.tsx
@@ -8,7 +8,7 @@ const COMMUNITY_COLORS = [
   '#aec7e8', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5',
 ]
 
-function communityColor(id: number | null): string {
+function communityColor(id: number | null | undefined): string {
   if (id == null) return '#999'
   return COMMUNITY_COLORS[id % COMMUNITY_COLORS.length] ?? '#999'
 }
@@ -24,10 +24,11 @@ interface ForceGraphProps {
 interface InternalNode {
   id: string
   label: string
-  community_id: number | null
+  community_id?: number | null
   type: string
   x?: number
   y?: number
+  [key: string]: unknown
 }
 
 export default function ForceGraph({ nodes, edges, onNodeClick, width, height }: ForceGraphProps) {
@@ -63,7 +64,8 @@ export default function ForceGraph({ nodes, edges, onNodeClick, width, height }:
   )
 
   const nodeCanvasObject = useCallback(
-    (node: InternalNode, ctx: CanvasRenderingContext2D) => {
+    (obj: object, ctx: CanvasRenderingContext2D) => {
+      const node = obj as InternalNode
       const x = node.x ?? 0
       const y = node.y ?? 0
       const radius = 6

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -14,7 +14,7 @@ export default function SearchPage() {
   const [query, setQuery] = useState('')
   const [mode, setMode] = useState<'fulltext' | 'semantic'>('fulltext')
   const navigate = useNavigate()
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)


### PR DESCRIPTION
## Summary
- Fix 3 TypeScript compilation errors that break `npm run build` (tsc && vite build)
- `ForceGraph.tsx`: make `community_id` optional on `InternalNode` (not present on `GraphNode` API type), add index signature for library compatibility, cast callback parameter
- `SearchPage.tsx`: pass explicit `undefined` to `useRef()` (required by React 19 types)

## Related Issues
Closes #286
Closes #285

## Review Checklist
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm run build` (tsc + vite) succeeds
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>