### PR TITLE
feat(observability): structured JSON logging with structlog

### DIFF
--- a/docs/structured-logging.md
+++ b/docs/structured-logging.md
@@ -1,0 +1,92 @@
+# Structured Logging
+
+The isnad-graph platform uses [structlog](https://www.structlog.org/) for structured logging across all backend services.
+
+## Log Format
+
+All log output follows a consistent schema. When `LOG_FORMAT=json` (recommended for production), each log line is a single JSON object:
+
+```json
+{
+  "timestamp": "2026-03-25T12:34:56.789000Z",
+  "level": "info",
+  "service": "isnad-graph",
+  "logger_name": "src.api.middleware",
+  "event": "request_completed",
+  "request_id": "a1b2c3d4e5f6...",
+  "method": "GET",
+  "path": "/api/v1/narrators",
+  "status_code": 200,
+  "duration_ms": 42.3
+}
+```
+
+### Standard Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string | ISO-8601 UTC timestamp |
+| `level` | string | Log level: `debug`, `info`, `warning`, `error`, `critical` |
+| `service` | string | Always `isnad-graph` |
+| `logger_name` | string | Python module that emitted the log |
+| `event` | string | Event name / human-readable message |
+
+### API Request Fields
+
+API requests include additional fields via the `RequestLoggingMiddleware`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `request_id` | string | Unique ID per request (UUID4 hex or client-supplied) |
+| `method` | string | HTTP method (GET, POST, etc.) |
+| `path` | string | Request path |
+| `status_code` | int | HTTP response status (on `request_completed`) |
+| `duration_ms` | float | Request duration in milliseconds |
+
+## Configuration
+
+Two environment variables control logging behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOG_LEVEL` | `INFO` | Minimum log level. Options: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
+| `LOG_FORMAT` | `console` | Output format. `json` for structured JSON, `console` for human-readable |
+
+Set these in `.env` or as environment variables:
+
+```bash
+LOG_LEVEL=DEBUG
+LOG_FORMAT=json
+```
+
+## Request ID Tracing
+
+Every API request is assigned a unique `request_id`:
+
+- If the client sends an `X-Request-ID` header, it is used (truncated to 64 chars)
+- Otherwise, a UUID4 hex string is generated
+- The `request_id` is included in all log lines within the request scope
+- The `X-Request-ID` header is returned in the response for client-side correlation
+
+## Usage in Code
+
+```python
+from src.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+log.info("operation_started", entity_id="nar:001")
+log.warning("slow_query", duration_ms=1500, query="MATCH ...")
+log.error("connection_failed", service="neo4j", retries=3)
+```
+
+## Architecture
+
+Logging is configured centrally in `src/utils/logging.py`:
+
+- `configure_logging()` — called once at module import time; reads `LOG_LEVEL` and `LOG_FORMAT`
+- `get_logger(name)` — returns a structlog bound logger with `logger_name` set
+- `_add_service_name` — processor that injects the `service` field
+- `RequestLoggingMiddleware` — FastAPI middleware that assigns request IDs and logs request lifecycle
+
+The middleware uses `structlog.contextvars` to bind `request_id`, `method`, and `path` to all log lines within a request without explicit passing.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.api.middleware import (
     RateLimitMiddleware,
+    RequestLoggingMiddleware,
     RequestSizeLimitMiddleware,
     SecurityHeadersMiddleware,
     require_admin,
@@ -131,6 +132,7 @@ def create_app() -> FastAPI:
     app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(RequestSizeLimitMiddleware, max_body_size=1_048_576)
     app.add_middleware(RateLimitMiddleware, requests_per_minute=120)
+    app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins,

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import time
+import uuid
 from datetime import UTC, datetime
 
+import structlog
 from fastapi import Request
 from fastapi.exceptions import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -14,6 +17,8 @@ from src.auth.models import User
 
 # Default maximum request body size: 1 MB.
 DEFAULT_MAX_BODY_SIZE = 1_048_576
+
+log = structlog.get_logger(logger_name=__name__)
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -92,8 +97,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self, request: StarletteRequest, call_next: RequestResponseEndpoint
     ) -> Response:
-        import time
-
         client_ip = request.client.host if request.client else "unknown"
         now = time.monotonic()
         window_start = now - 60.0
@@ -113,6 +116,49 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         timestamps.append(now)
         self._window[client_ip] = timestamps
         return await call_next(request)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Assign a unique request ID to every request and log request lifecycle.
+
+    The request ID is:
+    - stored in structlog contextvars so all logs within the request include it
+    - returned in the ``X-Request-ID`` response header for client-side tracing
+
+    If the caller supplies an ``X-Request-ID`` header it is respected (truncated
+    to 64 chars); otherwise a new UUID4 is generated.
+    """
+
+    async def dispatch(
+        self, request: StarletteRequest, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = (request.headers.get("X-Request-ID") or uuid.uuid4().hex)[:64]
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id,
+            method=request.method,
+            path=str(request.url.path),
+        )
+
+        start = time.monotonic()
+        log.info("request_started")
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = round((time.monotonic() - start) * 1000, 1)
+            log.exception("request_failed", duration_ms=duration_ms)
+            raise
+
+        duration_ms = round((time.monotonic() - start) * 1000, 1)
+        log.info(
+            "request_completed",
+            status_code=response.status_code,
+            duration_ms=duration_ms,
+        )
+        response.headers["X-Request-ID"] = request_id
+        structlog.contextvars.clear_contextvars()
+        return response
 
 
 async def require_admin(request: Request) -> User:

--- a/src/resolve/__init__.py
+++ b/src/resolve/__init__.py
@@ -144,7 +144,7 @@ def run_all(raw_dir: Path, staging_dir: Path, output_dir: Path) -> dict[str, lis
             staging_dir=str(staging_dir),
             msg="No Parquet files found in staging directory",
         )
-        print("Resolution skipped: no staging Parquet files found.")
+        logger.warning("resolution_skipped", reason="no staging Parquet files found")
         return results
 
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -216,6 +216,6 @@ def run_all(raw_dir: Path, staging_dir: Path, output_dir: Path) -> dict[str, lis
         parallel_links=metrics.parallel_links_count,
     )
 
-    print(metrics.summary())
+    logger.info("resolve_metrics_summary", summary=metrics.summary())
 
     return results

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,12 +1,13 @@
 """Arabic text processing, Neo4j/PG clients, and structured logging utilities."""
 
-from src.utils.logging import configure_logging, get_logger
+from src.utils.logging import SERVICE_NAME, configure_logging, get_logger
 from src.utils.neo4j_client import Neo4jClient
 from src.utils.pg_client import PgClient
 
 __all__ = [
     "Neo4jClient",
     "PgClient",
+    "SERVICE_NAME",
     "configure_logging",
     "get_logger",
 ]

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,29 +1,75 @@
-"""Structured logging via structlog. Configured once at import time."""
+"""Structured JSON logging via structlog.
+
+Centralised logging configuration for the isnad-graph platform.
+
+Standard log fields
+-------------------
+- ``timestamp`` — ISO-8601 UTC timestamp
+- ``level`` — log level (info, warning, error, ...)
+- ``service`` — service name (``isnad-graph``)
+- ``logger_name`` — Python module / logger name
+- ``message`` — human-readable event description
+- ``request_id`` — (API requests only) unique per-request trace ID
+
+Configuration
+-------------
+``LOG_LEVEL``  — environment variable controlling verbosity (default ``INFO``)
+``LOG_FORMAT`` — ``json`` for structured JSON output, ``console`` for human-readable
+"""
 
 from __future__ import annotations
 
 import logging
+import os
 
 import structlog
 
-from src.config import get_settings
+SERVICE_NAME = "isnad-graph"
 
-__all__ = ["configure_logging", "get_logger"]
+__all__ = ["SERVICE_NAME", "configure_logging", "get_logger"]
+
+
+def _add_service_name(
+    logger: object,
+    method_name: str,
+    event_dict: structlog.types.EventDict,
+) -> structlog.types.EventDict:
+    """Inject the ``service`` field into every log event."""
+    event_dict.setdefault("service", SERVICE_NAME)
+    return event_dict
 
 
 def configure_logging() -> None:
-    """Configure structlog once. Call at application startup."""
-    settings = get_settings()
+    """Configure structlog once. Call at application startup.
+
+    Reads ``LOG_LEVEL`` and ``LOG_FORMAT`` from :func:`src.config.get_settings`
+    when available, falling back to environment variables / defaults when settings
+    cannot be loaded (e.g. during early import or in test environments).
+
+    When ``LOG_FORMAT`` is ``json`` the output is newline-delimited JSON suitable
+    for log aggregation systems (ELK, Datadog, CloudWatch, etc.).
+    """
+    try:
+        from src.config import get_settings
+
+        settings = get_settings()
+        log_level = settings.log_level.upper()
+        log_format = settings.log_format
+    except Exception:  # noqa: BLE001
+        log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+        log_format = os.environ.get("LOG_FORMAT", "console")
+
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
         structlog.processors.add_log_level,
+        _add_service_name,
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
-        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
     ]
 
     renderer: structlog.types.Processor
-    if settings.log_format == "json":
+    if log_format == "json":
         renderer = structlog.processors.JSONRenderer()
     else:
         renderer = structlog.dev.ConsoleRenderer()
@@ -31,7 +77,7 @@ def configure_logging() -> None:
     structlog.configure(
         processors=[*shared_processors, renderer],
         wrapper_class=structlog.make_filtering_bound_logger(
-            getattr(logging, settings.log_level.upper(), logging.INFO)
+            getattr(logging, log_level, logging.INFO)
         ),
         context_class=dict,
         logger_factory=structlog.PrintLoggerFactory(),

--- a/tests/test_api/test_request_logging.py
+++ b/tests/test_api/test_request_logging.py
@@ -1,0 +1,62 @@
+"""Tests for request logging middleware (request ID, structured log output)."""
+
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.api.middleware import RequestLoggingMiddleware
+
+
+def _homepage(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+def _make_app() -> Starlette:
+    """Create a minimal Starlette app with only the RequestLoggingMiddleware."""
+    app = Starlette(routes=[Route("/", _homepage)])
+    app.add_middleware(RequestLoggingMiddleware)
+    return app
+
+
+class TestRequestLoggingMiddleware:
+    """Verify X-Request-ID header and request lifecycle logging."""
+
+    def test_response_includes_request_id(self) -> None:
+        """Every response must include an X-Request-ID header."""
+        client = TestClient(_make_app())
+        resp = client.get("/")
+        assert "X-Request-ID" in resp.headers
+        assert len(resp.headers["X-Request-ID"]) > 0
+
+    def test_client_supplied_request_id_is_respected(self) -> None:
+        """If the client sends X-Request-ID, the server echoes it back."""
+        client = TestClient(_make_app())
+        custom_id = "my-trace-id-12345"
+        resp = client.get("/", headers={"X-Request-ID": custom_id})
+        assert resp.headers["X-Request-ID"] == custom_id
+
+    def test_request_id_truncated_to_64_chars(self) -> None:
+        """Overly long request IDs are truncated to 64 characters."""
+        client = TestClient(_make_app())
+        long_id = "x" * 100
+        resp = client.get("/", headers={"X-Request-ID": long_id})
+        assert len(resp.headers["X-Request-ID"]) == 64
+
+    def test_auto_generated_request_id_is_hex(self) -> None:
+        """Auto-generated request IDs are hex UUID4 strings (32 chars)."""
+        client = TestClient(_make_app())
+        resp = client.get("/")
+        rid = resp.headers["X-Request-ID"]
+        # uuid4().hex produces a 32-char lowercase hex string
+        assert len(rid) == 32
+        assert all(c in "0123456789abcdef" for c in rid)
+
+    def test_unique_ids_per_request(self) -> None:
+        """Each request gets a different auto-generated ID."""
+        client = TestClient(_make_app())
+        ids = {client.get("/").headers["X-Request-ID"] for _ in range(5)}
+        assert len(ids) == 5

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -1,0 +1,116 @@
+"""Tests for structured logging configuration."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import structlog
+
+from src.utils.logging import SERVICE_NAME, _add_service_name, configure_logging, get_logger
+
+
+class TestConfigureLogging:
+    """Verify structlog configuration for JSON and console modes."""
+
+    def test_get_logger_returns_bound_logger(self) -> None:
+        logger = get_logger("test.module")
+        assert logger is not None
+
+    def test_service_name_constant(self) -> None:
+        assert SERVICE_NAME == "isnad-graph"
+
+    def test_json_output_contains_standard_fields(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When LOG_FORMAT=json, output must be valid JSON with standard fields."""
+        monkeypatch.setenv("LOG_FORMAT", "json")
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+        structlog.reset_defaults()
+        configure_logging()
+
+        logger = get_logger("test.json_output")
+        logger.info("test_event", extra_field="value")
+
+        captured = capsys.readouterr()
+        # The log line should be valid JSON
+        line = captured.out.strip().splitlines()[-1]
+        parsed = json.loads(line)
+        assert parsed["event"] == "test_event"
+        assert parsed["level"] == "info"
+        assert parsed["service"] == "isnad-graph"
+        assert "timestamp" in parsed
+        assert parsed["extra_field"] == "value"
+        assert parsed["logger_name"] == "test.json_output"
+
+        # Cleanup: restore console mode
+        monkeypatch.setenv("LOG_FORMAT", "console")
+        structlog.reset_defaults()
+        configure_logging()
+
+    def test_json_renderer_produces_valid_json(self) -> None:
+        """Directly test that the JSON processor chain produces valid JSON."""
+        processors: list[structlog.types.Processor] = [
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            _add_service_name,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.JSONRenderer(),
+        ]
+
+        event_dict: dict[str, object] = {"event": "test_event", "extra": "data"}
+        for proc in processors:
+            event_dict = proc(None, "info", event_dict)  # type: ignore[assignment]
+
+        assert isinstance(event_dict, str)
+        parsed = json.loads(event_dict)  # type: ignore[arg-type]
+        assert parsed["event"] == "test_event"
+        assert parsed["level"] == "info"
+        assert parsed["service"] == "isnad-graph"
+        assert "timestamp" in parsed
+        assert parsed["extra"] == "data"
+
+    def test_add_service_name_processor(self) -> None:
+        """The _add_service_name processor injects service field."""
+        event_dict: dict[str, object] = {"event": "test"}
+        result = _add_service_name(None, "info", event_dict)
+        assert result["service"] == "isnad-graph"
+
+    def test_add_service_name_does_not_override(self) -> None:
+        """If service is already set, _add_service_name preserves it."""
+        event_dict: dict[str, object] = {"event": "test", "service": "custom"}
+        result = _add_service_name(None, "info", event_dict)
+        assert result["service"] == "custom"
+
+    def test_log_level_configurable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Setting LOG_LEVEL=WARNING should suppress INFO messages."""
+        monkeypatch.setenv("LOG_FORMAT", "json")
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+
+        structlog.reset_defaults()
+        configure_logging()
+
+        logger = get_logger("test.level")
+        logger.info("should_not_appear")
+        logger.warning("should_appear")
+
+        captured = capsys.readouterr()
+        lines = [line for line in captured.out.strip().splitlines() if line.strip()]
+        # Only the warning should have been emitted
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["event"] == "should_appear"
+        assert parsed["level"] == "warning"
+
+        # Cleanup
+        monkeypatch.setenv("LOG_FORMAT", "console")
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        structlog.reset_defaults()
+        configure_logging()


### PR DESCRIPTION
## Summary
- Enhance `src/utils/logging.py` with structlog-based structured JSON logging: service name injection, UTC timestamps, resilient settings loading
- Add `RequestLoggingMiddleware` for API request tracing with unique request IDs (`X-Request-ID` header)
- Centralized logging configuration with `LOG_LEVEL` and `LOG_FORMAT` env vars
- Replace `print()` statements in `src/resolve/__init__.py` with structured logging
- Add 12 tests covering logging configuration and request ID middleware
- Add `docs/structured-logging.md` documenting log format, fields, and usage

## Related Issues
Closes #294

## Changes
| File | Change |
|------|--------|
| `src/utils/logging.py` | Enhanced with `_add_service_name` processor, UTC timestamps, resilient settings fallback |
| `src/api/middleware.py` | Added `RequestLoggingMiddleware` with request ID assignment and lifecycle logging |
| `src/api/app.py` | Wired `RequestLoggingMiddleware` into FastAPI app |
| `src/resolve/__init__.py` | Replaced 2 `print()` calls with structured logging |
| `src/utils/__init__.py` | Export `SERVICE_NAME` |
| `tests/test_utils/test_logging.py` | 7 tests for logging config, JSON output, log levels |
| `tests/test_api/test_request_logging.py` | 5 tests for request ID middleware |
| `docs/structured-logging.md` | Full documentation of log format and fields |

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Kwame Asante <parametrization+Kwame.Asante@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>