### PR TITLE
feat(infra): add .envrc for direnv + TF_VAR mappings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,12 @@
+# Load all variables from .env into the environment
+dotenv
+
+# Map environment variables to Terraform TF_VAR_ equivalents.
+# Only export if the source variable is set (avoid exporting empty values).
+
+# Hetzner Cloud
+[ -n "${HETZNER_API_TOKEN:-}" ] && export TF_VAR_hcloud_token="$HETZNER_API_TOKEN"
+
+# Backblaze B2 (for future Terraform use)
+[ -n "${B2_APPLICATION_KEY_ID:-}" ] && export TF_VAR_b2_key_id="$B2_APPLICATION_KEY_ID"
+[ -n "${B2_APPLICATION_KEY:-}" ] && export TF_VAR_b2_app_key="$B2_APPLICATION_KEY"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ A computational hadith analysis platform that ingests Sunni and Shia hadith coll
 | Docker | 24+ | `docker --version` |
 | Docker Compose | 2.0+ | `docker compose version` |
 | Git | 2.0+ | `git --version` |
+| direnv | 2.30+ | `direnv --version` |
+
+> **direnv setup:** Install [direnv](https://direnv.net/) and hook it into your shell.
+> When you `cd` into the project, run `direnv allow` to auto-load `.env` variables
+> and their `TF_VAR_` mappings for Terraform.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Add `.envrc` for direnv to auto-load `.env` and map to `TF_VAR_` equivalents
- Maps HETZNER_API_TOKEN, B2 credentials to Terraform variables
- Only exports TF_VAR_ mappings when source variables are non-empty
- Document direnv in README prerequisites

## Related Issues
Closes #320

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>