### PR TITLE
fix(infra): add docker-buildx to bootstrap-vps.sh

### DIFF
--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -29,7 +29,7 @@ fi
 # ── Step 1: System packages ─────────────────────────────────────────────────
 echo "==> [1/7] Installing system packages..."
 apt-get update -qq
-apt-get install -y -qq docker.io docker-compose-v2 git curl > /dev/null
+apt-get install -y -qq docker.io docker-compose-v2 docker-buildx git curl > /dev/null
 systemctl enable docker
 systemctl start docker
 echo "    Docker version: $(docker --version)"


### PR DESCRIPTION
## Summary
- Add `docker-buildx` package to the `apt-get install` line in `scripts/bootstrap-vps.sh`
- Eliminates the buildx warning on `docker compose build`

## Related Issues
Closes #354

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>