### PR TITLE
fix(infra): resolve 3 docker-compose.prod.yml bugs (#355, #357, #362)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,9 +19,6 @@ services:
       NEO4J_PLUGINS: '["apoc", "graph-data-science"]'
       NEO4J_server_memory_heap_max__size: 4G
       NEO4J_server_memory_pagecache_size: 2G
-      NEO4J_server_metrics_enabled: "true"
-      NEO4J_server_metrics_prometheus_enabled: "true"
-      NEO4J_server_metrics_prometheus_endpoint: "0.0.0.0:2004"
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs
@@ -121,7 +118,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=256M
-      - /app/.cache:size=128M
+      - /root/.cache:size=128M
     environment:
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=${NEO4J_USER:?NEO4J_USER must be set}
@@ -129,7 +126,7 @@ services:
       - PG_DSN=postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}
       - REDIS_URL=redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set}@redis:6379/0
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 5

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -16,11 +16,6 @@ scrape_configs:
     static_configs:
       - targets: ["api:8000"]
 
-  - job_name: "neo4j"
-    metrics_path: /metrics
-    static_configs:
-      - targets: ["neo4j:2004"]
-
   - job_name: "node-exporter"
     static_configs:
       - targets: ["node-exporter:9100"]


### PR DESCRIPTION
## Summary

Consolidated fix for three bugs discovered during the first production deploy, all in `docker-compose.prod.yml`:

- **#355 — Neo4j Prometheus metrics:** Remove `server.metrics.*` env vars (Enterprise-only settings that prevent Community edition from starting). Also remove the Neo4j scrape target from `infra/prometheus/prometheus.yml`.
- **#357 — uv cache writes on read-only filesystem:** Change API tmpfs mount from `/app/.cache` to `/root/.cache` so uv can write its cache (container runs as root).
- **#362 — API healthcheck curl not found:** Replace `curl -sf` with `python -c "import urllib.request; urllib.request.urlopen(...)"` since curl is not in the slim production image.

## Files changed

- `docker-compose.prod.yml` — all three fixes
- `infra/prometheus/prometheus.yml` — remove Neo4j scrape job

## Test plan

- [ ] `docker compose -f docker-compose.prod.yml config` validates without errors
- [ ] Neo4j starts successfully with community edition (no unrecognized settings)
- [ ] API container starts with `read_only: true` — uv cache writes succeed
- [ ] API healthcheck passes (python urllib instead of curl)
- [ ] Prometheus starts without errors (no dead Neo4j target)

Closes #355
Closes #357
Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)