### PR TITLE
fix(ci): update pre-commit hooks, verify Caddy HTTPS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@
 repos:
   # --- Ruff formatter & linter ---
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.15.8
     hooks:
       - id: ruff-format
         args: [--check]
@@ -29,7 +29,7 @@ repos:
 
   # --- Secret detection ---
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.3
+    rev: v8.30.1
     hooks:
       - id: gitleaks
         name: gitleaks

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,16 @@ help: ## Show this help
 setup: ## Install dependencies with uv
 	uv sync
 
-setup-hooks: ## Configure git hooks (legacy .githooks + pre-commit)
-	git config core.hooksPath .githooks
+setup-hooks: ## Configure git hooks (branch-name check + pre-commit)
+	git config --unset-all core.hooksPath 2>/dev/null || true
 	uv run pre-commit install
-	@echo "Git hooks configured (branch-name via .githooks, pre-commit via pre-commit framework)."
+	cp .githooks/pre-push .git/hooks/pre-push
+	@echo "Git hooks configured (pre-commit framework + branch-name pre-push check)."
 
 hooks: ## Install pre-commit hooks (one-time setup after clone)
+	git config --unset-all core.hooksPath 2>/dev/null || true
 	uv run pre-commit install
+	cp .githooks/pre-push .git/hooks/pre-push
 	@echo "Pre-commit hooks installed. They will run on every commit."
 
 infra: ## Start Docker services


### PR DESCRIPTION
## Summary

- Update ruff pre-commit hook from v0.11.6 to v0.15.8 (fixes py314 target support)
- Update gitleaks pre-commit hook from v8.24.3 to v8.30.1
- Fix `core.hooksPath` conflict that prevented `pre-commit install` from working
- Update `make hooks` and `make setup-hooks` targets to properly coexist with pre-commit framework
- Verify Caddy auto-HTTPS configuration is correct (domain set, HSTS header present)

### Pre-commit Hook Verification Results
| Hook | Status |
|------|--------|
| ruff-format | PASS (py314 now supported) |
| ruff-lint | PASS |
| gitleaks | PASS |
| pip-audit | PASS |
| mypy | PASS |
| pytest-unit | PASS |
| pytest-integration | SKIP (requires running infra) |

### Caddy HTTPS Verification
- Caddyfile correctly configured for `isnad-graph.noorinalabs.com`
- HSTS header with preload directive present
- HTTP-to-HTTPS redirect is implicit (Caddy default)
- Live certificate verification requires VPS access (post-deploy)

## Related Issues
Closes #374
Closes #373

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>