### PR TITLE
fix(infra): consolidate Wave 3 deployment hotfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN pip install uv && uv sync --frozen --no-dev
 COPY . .
-CMD ["/app/.venv/bin/uvicorn", "src.api.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]
+# No CMD here — docker-compose.prod.yml `command:` is the single source of truth
+# for the uvicorn invocation (includes --workers and other prod-specific flags).
+# To run standalone: docker run ... /app/.venv/bin/uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -118,12 +118,16 @@ services:
     build: .
     expose:
       - "8000"
+    # Security: read_only prevents runtime writes to the container filesystem.
+    # The venv and application code are baked into the image at build time.
+    # Only /tmp is writable at runtime (via tmpfs) for Python temp files.
     read_only: true
     tmpfs:
+      # Python stdlib (tempfile, multiprocessing) and uvicorn need a writable /tmp
       - /tmp:size=256M
-      - /root/.cache:size=64M
     environment:
       - NEO4J_URI=bolt://neo4j:7687
+      # NEO4J_USER must be "neo4j" — Neo4j requires the admin account to use this name
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
       - PG_DSN=postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}
@@ -157,6 +161,9 @@ services:
     networks:
       - backend
       - frontend
+    # Uses the venv baked into the image at build time — NOT `uv run`, which would
+    # trigger a full dependency reinstall at startup and fail on a read_only filesystem.
+    # This is the single source of truth for the uvicorn command (Dockerfile has no CMD).
     command: /app/.venv/bin/uvicorn src.api.app:create_app --factory --host 0.0.0.0 --port 8000 --workers 4
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

Closes #406

- **Removed `/root/.cache:size=64M` tmpfs** from the API service — no longer needed since `uv run` was replaced with direct `/app/.venv/bin/uvicorn` invocation (uv cache is only used during build, not at runtime)
- **Removed Dockerfile CMD** in favor of `docker-compose.prod.yml` `command:` as the single source of truth for the uvicorn invocation (includes `--workers 4` and other prod-specific flags)
- **Added inline documentation** in `docker-compose.prod.yml` explaining the read_only + tmpfs architecture, why direct venv path is used instead of `uv run`, and why `NEO4J_USER` must be `neo4j`

### Verification checklist (from issue AC)

| Item | Status |
|------|--------|
| `--no-dev` on `uv sync` in Dockerfile | Verified present |
| CMD uses `/app/.venv/bin/uvicorn` | Removed (compose is source of truth) |
| Compose `command:` uses direct venv path | Verified present |
| `/root/.cache` tmpfs still needed? | No — removed |
| `NEO4J_AUTH` uses hardcoded `neo4j` username | Verified correct |
| `NEO4J_USER=neo4j` hardcoded for API | Verified correct |
| Health check uses `docker inspect` | Verified correct |
| `NEO4J_USER` not in deploy.yml secrets | Verified correct |
| Architecture documented in comments | Done |

### Not addressed in this PR

- **Smoke test in CI** (AC item: "Add a smoke test to CI that builds the production Docker image and verifies it starts without `uv run` triggering installs") — this warrants its own issue/PR as it requires a new CI workflow step with Docker build context

## Test plan

- [x] `make lint` passes
- [x] `make test` unit tests pass (integration tests have pre-existing Neo4j testcontainers auth failure on base branch — unrelated)
- [ ] Verify prod deployment starts correctly with the `/root/.cache` tmpfs removed


Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>