### PR TITLE
feat(deploy): integrate DB backup with rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      skip_backup:
+        description: "Skip pre-deploy backup (emergency hotfixes only)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-production
@@ -16,7 +22,66 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # ---------------------------------------------------------------
+      # Pre-deploy backup
+      # Stops the API container for cross-DB consistency, runs backup.sh
+      # on VPS via SSH, and records the current git commit SHA so that
+      # rollback can restore both data AND code to the pre-deploy state.
+      # If backup fails, the workflow aborts — deploy never proceeds.
+      # ---------------------------------------------------------------
+      - name: Pre-deploy backup
+        id: backup
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_backup != true }}
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+          B2_BUCKET: ${{ secrets.B2_BUCKET }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: B2_KEY_ID,B2_APP_KEY,B2_BUCKET
+          command_timeout: 10m
+          script: |
+            set -euo pipefail
+            cd /opt/isnad-graph
+
+            # Record current commit SHA for rollback (Renaud's feedback)
+            CURRENT_SHA=$(git rev-parse HEAD)
+            echo "Pre-deploy commit SHA: ${CURRENT_SHA}"
+            echo "${CURRENT_SHA}" > /opt/isnad-graph/.last-deploy-sha
+
+            # Stop API container for cross-DB dump consistency (Elena's feedback:
+            # prevents writes between sequential PG and Neo4j dumps)
+            echo "==> Stopping API container for consistent backup..."
+            docker compose -f docker-compose.prod.yml stop api || true
+
+            echo "==> Running pre-deploy backup..."
+            export B2_KEY_ID="$B2_KEY_ID"
+            export B2_APP_KEY="$B2_APP_KEY"
+            export B2_BUCKET="$B2_BUCKET"
+            bash scripts/backup.sh
+
+            # Restart API (it will be force-recreated during deploy anyway)
+            echo "==> Restarting API container..."
+            docker compose -f docker-compose.prod.yml up -d api || true
+
+            echo "==> Pre-deploy backup completed successfully"
+
+      - name: Backup skipped notice
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_backup == true }}
+        run: |
+          echo "::warning::Pre-deploy backup was SKIPPED (skip_backup=true)"
+
+      - name: Abort on backup failure
+        if: ${{ steps.backup.outcome == 'failure' }}
+        run: |
+          echo "::error::Pre-deploy backup FAILED — aborting deployment to prevent data loss"
+          exit 1
+
       - name: Deploy to Hetzner VPS
+        id: deploy
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         env:
           NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
@@ -54,6 +119,7 @@ jobs:
             sleep 10
 
       - name: Verify health check
+        id: healthcheck
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ vars.VPS_HOST }}
@@ -83,6 +149,75 @@ jobs:
 
             echo "==> Deployment verified successfully"
 
+      # ---------------------------------------------------------------
+      # Rollback on health check failure
+      # Rolls back code to the pre-deploy commit SHA and restores DBs.
+      # PG is restored before Neo4j (Elena's feedback: graph loaders
+      # assume PG metadata exists when populating Neo4j relationships).
+      # ---------------------------------------------------------------
+      - name: Rollback on failure
+        if: ${{ failure() && steps.healthcheck.outcome == 'failure' && steps.backup.outcome == 'success' }}
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+          B2_BUCKET: ${{ secrets.B2_BUCKET }}
+          NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: B2_KEY_ID,B2_APP_KEY,B2_BUCKET,NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD
+          command_timeout: 10m
+          script: |
+            set -euo pipefail
+            cd /opt/isnad-graph
+
+            echo "::error::Health check failed — initiating rollback"
+
+            # Roll back code to previous commit (Renaud's feedback:
+            # restoring old data with new/broken code is dangerous)
+            PREVIOUS_SHA=""
+            if [[ -f /opt/isnad-graph/.last-deploy-sha ]]; then
+              PREVIOUS_SHA=$(cat /opt/isnad-graph/.last-deploy-sha)
+              echo "==> Rolling back code to commit ${PREVIOUS_SHA}..."
+              git fetch origin
+              git reset --hard "${PREVIOUS_SHA}"
+            else
+              echo "WARNING: No previous deploy SHA found — skipping code rollback"
+            fi
+
+            # Stop all containers before restore
+            echo "==> Stopping all containers..."
+            docker compose -f docker-compose.prod.yml down
+
+            # Bring up only PG and Neo4j for restore
+            export NEO4J_PASSWORD="$NEO4J_PASSWORD"
+            export POSTGRES_USER="$POSTGRES_USER"
+            export POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
+            export POSTGRES_DB="$POSTGRES_DB"
+            export REDIS_PASSWORD="$REDIS_PASSWORD"
+            docker compose -f docker-compose.prod.yml up -d postgres neo4j
+            sleep 10
+
+            # Restore databases from the pre-deploy backup
+            export B2_KEY_ID="$B2_KEY_ID"
+            export B2_APP_KEY="$B2_APP_KEY"
+            export B2_BUCKET="$B2_BUCKET"
+            bash scripts/restore.sh --force latest
+
+            # Rebuild and bring up all services with rolled-back code
+            echo "==> Rebuilding with rolled-back code..."
+            docker compose -f docker-compose.prod.yml build
+            docker compose -f docker-compose.prod.yml up -d \
+              --force-recreate --remove-orphans
+
+            echo "==> Rollback complete — running on commit ${PREVIOUS_SHA:-unknown}"
+
       - name: Clean up Docker build cache
         if: always()
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
@@ -105,8 +240,31 @@ jobs:
           else
             echo "::error::Deployment to production failed"
           fi
+
           echo "## Deployment Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Commit:** ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Branch:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Backup" >> "$GITHUB_STEP_SUMMARY"
+          BACKUP_OUTCOME="${{ steps.backup.outcome }}"
+          if [ "$BACKUP_OUTCOME" = "success" ]; then
+            echo "- **Backup:** Completed successfully" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$BACKUP_OUTCOME" = "skipped" ]; then
+            echo "- **Backup:** Skipped (skip_backup=true)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **Backup:** FAILED" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Health Check" >> "$GITHUB_STEP_SUMMARY"
+          HEALTH_OUTCOME="${{ steps.healthcheck.outcome }}"
+          if [ "$HEALTH_OUTCOME" = "success" ]; then
+            echo "- **Health check:** Passed" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$HEALTH_OUTCOME" = "failure" ]; then
+            echo "- **Health check:** FAILED — rollback attempted" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **Health check:** $HEALTH_OUTCOME" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/restore.yml
+++ b/.github/workflows/restore.yml
@@ -1,0 +1,127 @@
+name: Restore
+
+on:
+  workflow_dispatch:
+    inputs:
+      backup_path:
+        description: "Backup path (e.g. 'latest', 'daily/2026-03-25', 'weekly/2026-03-23')"
+        required: true
+        type: string
+        default: "latest"
+      rollback_code:
+        description: "Also roll back code to the commit stored in .last-deploy-sha"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore databases from backup
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+          B2_BUCKET: ${{ secrets.B2_BUCKET }}
+          NEO4J_PASSWORD: ${{ secrets.NEO4J_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          BACKUP_PATH: ${{ inputs.backup_path }}
+          ROLLBACK_CODE: ${{ inputs.rollback_code }}
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          envs: B2_KEY_ID,B2_APP_KEY,B2_BUCKET,NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,BACKUP_PATH,ROLLBACK_CODE
+          command_timeout: 10m
+          script: |
+            set -euo pipefail
+            cd /opt/isnad-graph
+
+            # Optionally roll back code to pre-deploy commit
+            if [[ "$ROLLBACK_CODE" == "true" ]]; then
+              if [[ -f /opt/isnad-graph/.last-deploy-sha ]]; then
+                PREVIOUS_SHA=$(cat /opt/isnad-graph/.last-deploy-sha)
+                echo "==> Rolling back code to commit ${PREVIOUS_SHA}..."
+                git fetch origin
+                git reset --hard "${PREVIOUS_SHA}"
+              else
+                echo "WARNING: No previous deploy SHA found — skipping code rollback"
+              fi
+            fi
+
+            # Stop API to prevent writes during restore
+            echo "==> Stopping API container..."
+            docker compose -f docker-compose.prod.yml stop api || true
+
+            # Ensure PG and Neo4j are running for restore
+            export NEO4J_PASSWORD="$NEO4J_PASSWORD"
+            export POSTGRES_USER="$POSTGRES_USER"
+            export POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
+            export POSTGRES_DB="$POSTGRES_DB"
+            export REDIS_PASSWORD="$REDIS_PASSWORD"
+            docker compose -f docker-compose.prod.yml up -d postgres neo4j
+            sleep 10
+
+            # Restore databases (restore.sh restores PG first, then Neo4j)
+            echo "==> Restoring from backup: ${BACKUP_PATH}..."
+            export B2_KEY_ID="$B2_KEY_ID"
+            export B2_APP_KEY="$B2_APP_KEY"
+            export B2_BUCKET="$B2_BUCKET"
+            bash scripts/restore.sh --force "$BACKUP_PATH"
+
+            # Rebuild (if code was rolled back) and bring up all services
+            echo "==> Bringing up all services..."
+            if [[ "$ROLLBACK_CODE" == "true" ]]; then
+              docker compose -f docker-compose.prod.yml build
+            fi
+            docker compose -f docker-compose.prod.yml up -d \
+              --force-recreate --remove-orphans
+
+            echo "==> Restore complete"
+
+      - name: Verify health after restore
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          script: |
+            set -euo pipefail
+
+            echo "==> Checking service health after restore..."
+            for i in $(seq 1 24); do
+              api_health=$(docker inspect --format='{{.State.Health.Status}}' isnad-graph-api-1 2>/dev/null || echo "not_found")
+              echo "Attempt $i/24: API=$api_health"
+              if [ "$api_health" = "healthy" ]; then
+                echo "API health check passed after restore"
+                break
+              fi
+              if [ "$i" -eq 24 ]; then
+                echo "::error::API health check failed after restore — manual intervention required"
+                docker compose -f /opt/isnad-graph/docker-compose.prod.yml logs --tail=50 api
+                exit 1
+              fi
+              sleep 5
+            done
+
+            docker compose -f /opt/isnad-graph/docker-compose.prod.yml ps --format '{{.Name}}\t{{.Status}}'
+
+      - name: Report restore status
+        if: always()
+        run: |
+          echo "## Restore Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Backup source:** ${{ inputs.backup_path }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Code rollback:** ${{ inputs.rollback_code }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add pre-deploy backup step in `deploy.yml` that stops the API container for cross-DB consistency, runs `scripts/backup.sh` via SSH, and stores the git commit SHA in `.last-deploy-sha` for code rollback
- If backup fails, deploy aborts with clear error; if health check fails after deploy, automatic rollback restores databases (PG first, then Neo4j) and rolls code back to the previous commit
- Add `skip_backup` workflow_dispatch input (boolean, default false) for emergency hotfixes
- Add separate `restore.yml` workflow_dispatch workflow with `backup_path` and `rollback_code` inputs

## Required GitHub Secrets

The following secrets must be configured for backup/restore to work:
- `B2_KEY_ID` — Backblaze B2 application key ID
- `B2_APP_KEY` — Backblaze B2 application key
- `B2_BUCKET` — Backblaze B2 bucket name

## Reviewer Feedback Addressed

- **Elena**: Stop API container before dump for cross-DB consistency; restore PG before Neo4j (graph loaders assume PG metadata exists)
- **Renaud**: Store git commit SHA with backup; roll back code on restore to avoid running new/broken code with old data

## Related Issues

Closes #418

## Review Checklist

- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
