### PR TITLE
fix(frontend): recheck auth state after OAuth callback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import TimelinePage from './pages/TimelinePage'
 import ComparativePage from './pages/ComparativePage'
 import GraphExplorerPage from './pages/GraphExplorerPage'
 import LoginPage from './pages/LoginPage'
+import OAuthCallbackPage from './pages/OAuthCallbackPage'
 import UserManagementPage from './pages/admin/UserManagementPage'
 import SystemHealthPage from './pages/admin/SystemHealthPage'
 import ContentStatsPage from './pages/admin/ContentStatsPage'
@@ -41,7 +42,7 @@ export default function App() {
           <Routes>
             {/* Public routes — no auth required */}
             <Route path="login" element={<LoginPage />} />
-            <Route path="auth/callback/:provider" element={<div>Processing login...</div>} />
+            <Route path="auth/callback/:provider" element={<OAuthCallbackPage />} />
 
             {/* Protected routes — require authentication */}
             <Route element={<ProtectedRoute />}>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -52,6 +52,11 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   if (res.status === 401) {
     const refreshed = await refreshOnce()
     if (refreshed) {
+      // Notify useAuth to re-fetch user state after token refresh
+      const refreshFn = (window as unknown as Record<string, unknown>).__refreshAuthState
+      if (typeof refreshFn === 'function') {
+        ;(refreshFn as () => Promise<void>)()
+      }
       const retry = await fetch(url, {
         ...init,
         credentials: 'include',

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from 'react'
 import { createElement } from 'react'
@@ -22,24 +23,117 @@ interface AuthContextValue {
   isAdmin: boolean
   isAuthenticated: boolean
   logout: () => Promise<void>
+  refreshAuthState: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
+/** Threshold in seconds — refresh proactively when token expires within this window. */
+const PROACTIVE_REFRESH_THRESHOLD_S = 60
+/** How often to check the expiry cookie (ms). */
+const PROACTIVE_CHECK_INTERVAL_MS = 15_000
+
+/** Read a cookie value by name. Returns null if not found. */
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'))
+  return match && match[1] !== undefined ? decodeURIComponent(match[1]) : null
+}
+
+/** BroadcastChannel name for cross-tab auth state sync. */
+const AUTH_CHANNEL_NAME = 'isnad-auth-sync'
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [loading, setLoading] = useState(true)
+  const proactiveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  useEffect(() => {
-    fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
-      .then((res) => {
-        if (!res.ok) throw new Error('Unauthorized')
-        return res.json()
-      })
-      .then((data: AuthUser) => setUser(data))
-      .catch(() => setUser(null))
-      .finally(() => setLoading(false))
+  const fetchAuthState = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
+      if (!res.ok) throw new Error('Unauthorized')
+      const data: AuthUser = await res.json()
+      setUser(data)
+    } catch {
+      setUser(null)
+    }
   }, [])
+
+  const refreshAuthState = useCallback(async () => {
+    await fetchAuthState()
+  }, [fetchAuthState])
+
+  // Expose refreshAuthState globally so client.ts interceptor can call it
+  useEffect(() => {
+    const w = window as unknown as Record<string, unknown>
+    w.__refreshAuthState = refreshAuthState
+    return () => {
+      delete w.__refreshAuthState
+    }
+  }, [refreshAuthState])
+
+  // Initial auth state check
+  useEffect(() => {
+    fetchAuthState().finally(() => setLoading(false))
+  }, [fetchAuthState])
+
+  // Proactive token refresh: check the token_expires_at cookie periodically
+  useEffect(() => {
+    async function checkAndRefresh() {
+      const expiresAtStr = getCookie('token_expires_at')
+      if (!expiresAtStr) return
+      const expiresAt = parseInt(expiresAtStr, 10)
+      if (isNaN(expiresAt)) return
+      const nowS = Math.floor(Date.now() / 1000)
+      if (expiresAt - nowS <= PROACTIVE_REFRESH_THRESHOLD_S) {
+        try {
+          const res = await fetch(`${API_BASE}/auth/refresh`, {
+            method: 'POST',
+            credentials: 'include',
+          })
+          if (res.ok) {
+            await refreshAuthState()
+            try {
+              const bc = new BroadcastChannel(AUTH_CHANNEL_NAME)
+              bc.postMessage({ type: 'token-refreshed' })
+              bc.close()
+            } catch {
+              // BroadcastChannel not supported
+            }
+          }
+        } catch {
+          // Refresh failed — will be caught by 401 interceptor on next request
+        }
+      }
+    }
+
+    proactiveTimerRef.current = setInterval(checkAndRefresh, PROACTIVE_CHECK_INTERVAL_MS)
+    checkAndRefresh()
+    return () => {
+      if (proactiveTimerRef.current) clearInterval(proactiveTimerRef.current)
+    }
+  }, [refreshAuthState])
+
+  // Cross-tab sync via BroadcastChannel
+  useEffect(() => {
+    let bc: BroadcastChannel | null = null
+    try {
+      bc = new BroadcastChannel(AUTH_CHANNEL_NAME)
+      bc.onmessage = (event: MessageEvent) => {
+        const msg = event.data as { type: string }
+        if (msg.type === 'token-refreshed') {
+          refreshAuthState()
+        } else if (msg.type === 'logged-out') {
+          setUser(null)
+          window.location.href = '/login'
+        }
+      }
+    } catch {
+      // BroadcastChannel not supported — cross-tab sync unavailable
+    }
+    return () => {
+      if (bc) bc.close()
+    }
+  }, [refreshAuthState])
 
   const logout = useCallback(async () => {
     try {
@@ -51,6 +145,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Clear local state even if the server call fails
     }
     setUser(null)
+    try {
+      const bc = new BroadcastChannel(AUTH_CHANNEL_NAME)
+      bc.postMessage({ type: 'logged-out' })
+      bc.close()
+    } catch {
+      // BroadcastChannel not supported
+    }
     window.location.href = '/login'
   }, [])
 
@@ -60,6 +161,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isAdmin: user?.is_admin ?? false,
     isAuthenticated: user !== null,
     logout,
+    refreshAuthState,
   }
 
   return createElement(AuthContext.Provider, { value }, children)

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { API_BASE } from '../config'
+
+export default function OAuthCallbackPage() {
+  const { provider } = useParams<{ provider: string }>()
+  const navigate = useNavigate()
+  const { refreshAuthState } = useAuth()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('code')
+    const state = params.get('state')
+
+    if (!code || !provider) {
+      setError('Missing authorization code or provider.')
+      return
+    }
+
+    // Validate state against what was stored during the login redirect
+    const storedState = sessionStorage.getItem('oauth_state')
+    if (storedState && state !== storedState) {
+      setError('OAuth state mismatch. Please try logging in again.')
+      return
+    }
+
+    let cancelled = false
+
+    async function handleCallback() {
+      try {
+        const res = await fetch(
+          `${API_BASE}/auth/callback/${encodeURIComponent(provider!)}?code=${encodeURIComponent(code!)}&state=${encodeURIComponent(state ?? '')}`,
+          { credentials: 'include' },
+        )
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => null)
+          throw new Error(body?.detail ?? `Authentication failed (${res.status})`)
+        }
+
+        // Backend has set httpOnly cookies — now recheck auth state
+        await refreshAuthState()
+
+        // Clean up sessionStorage
+        sessionStorage.removeItem('oauth_provider')
+        sessionStorage.removeItem('oauth_state')
+
+        if (!cancelled) {
+          navigate('/', { replace: true })
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Authentication failed')
+        }
+      }
+    }
+
+    handleCallback()
+
+    return () => {
+      cancelled = true
+    }
+  }, [provider, refreshAuthState, navigate])
+
+  if (error) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          gap: '1rem',
+        }}
+      >
+        <p role="alert">{error}</p>
+        <a href="/login">Back to login</a>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <div role="status" aria-label="Completing login">
+        Processing login...
+      </div>
+    </div>
+  )
+}

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import secrets
+import time
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from starlette.responses import RedirectResponse, Response
 
 from src.api.middleware import require_auth
@@ -23,7 +24,7 @@ def _build_redirect_uri(provider: str) -> str:
 
 
 def _set_token_cookies(response: Response, access_token: str, refresh_token: str) -> None:
-    """Set httpOnly cookie pair on a response."""
+    """Set httpOnly cookie pair and a readable expiry metadata cookie on a response."""
     settings = get_settings().auth
     common: dict[str, object] = {
         "httponly": True,
@@ -44,6 +45,23 @@ def _set_token_cookies(response: Response, access_token: str, refresh_token: str
         value=refresh_token,
         max_age=settings.refresh_token_expire_days * 86400,
         **common,  # type: ignore[arg-type]
+    )
+    # Non-httpOnly metadata cookie so the frontend can read token expiry
+    # and trigger proactive refresh before the access token expires.
+    expires_at = int(time.time()) + settings.access_token_expire_minutes * 60
+    meta_common: dict[str, object] = {
+        "httponly": False,
+        "samesite": "lax",
+        "secure": settings.cookie_secure,
+        "path": "/",
+    }
+    if settings.cookie_domain:
+        meta_common["domain"] = settings.cookie_domain
+    response.set_cookie(
+        key="token_expires_at",
+        value=str(expires_at),
+        max_age=settings.access_token_expire_minutes * 60,
+        **meta_common,  # type: ignore[arg-type]
     )
 
 
@@ -114,12 +132,16 @@ async def callback(provider: str, code: str, state: str) -> RedirectResponse:
 
 
 @router.post("/auth/refresh", response_model=TokenResponse)
-def refresh(body: RefreshRequest) -> Response:
+def refresh(request: Request, body: RefreshRequest | None = None) -> Response:
     """Refresh an access token using a valid refresh token (with rotation).
 
+    Accepts the refresh token from a JSON body OR from the httpOnly
+    ``refresh_token`` cookie (for browser clients that cannot read the cookie).
     Returns new tokens as JSON AND sets updated httpOnly cookies.
     """
-    token = body.refresh_token
+    token = body.refresh_token if body else None
+    if not token:
+        token = request.cookies.get("refresh_token")
     if not token:
         raise HTTPException(status_code=401, detail="Missing refresh token")
 
@@ -161,6 +183,7 @@ def logout(user: User = Depends(require_auth)) -> Response:
     response = Response(status_code=204)
     response.delete_cookie("access_token", path="/")
     response.delete_cookie("refresh_token", path="/")
+    response.delete_cookie("token_expires_at", path="/")
     return response
 
 


### PR DESCRIPTION
## Summary
- Replace placeholder OAuth callback route with `OAuthCallbackPage` that extracts code/state from URL params, calls the backend callback endpoint, triggers `refreshAuthState()`, then redirects — eliminating the race condition flash redirect to /login
- Add `refreshAuthState` to `useAuth` hook with proactive token refresh (via `token_expires_at` metadata cookie), cross-tab sync via BroadcastChannel, and global exposure for the 401 interceptor in `client.ts`
- Backend: add `token_expires_at` non-httpOnly metadata cookie, support reading refresh token from cookie, and clear the new cookie on logout

## Related Issues
Closes #434

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>