### PR TITLE
fix(auth): proactive token refresh and cross-tab sync

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -52,6 +52,11 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   if (res.status === 401) {
     const refreshed = await refreshOnce()
     if (refreshed) {
+      // Notify useAuth to re-fetch user state after token refresh
+      const refreshFn = (window as unknown as Record<string, unknown>).__refreshAuthState
+      if (typeof refreshFn === 'function') {
+        ;(refreshFn as () => Promise<void>)()
+      }
       const retry = await fetch(url, {
         ...init,
         credentials: 'include',

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from 'react'
 import { createElement } from 'react'
@@ -22,24 +23,117 @@ interface AuthContextValue {
   isAdmin: boolean
   isAuthenticated: boolean
   logout: () => Promise<void>
+  refreshAuthState: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
+/** Threshold in seconds — refresh proactively when token expires within this window. */
+const PROACTIVE_REFRESH_THRESHOLD_S = 60
+/** How often to check the expiry cookie (ms). */
+const PROACTIVE_CHECK_INTERVAL_MS = 15_000
+
+/** Read a cookie value by name. Returns null if not found. */
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'))
+  return match && match[1] !== undefined ? decodeURIComponent(match[1]) : null
+}
+
+/** BroadcastChannel name for cross-tab auth state sync. */
+const AUTH_CHANNEL_NAME = 'isnad-auth-sync'
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [loading, setLoading] = useState(true)
+  const proactiveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  useEffect(() => {
-    fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
-      .then((res) => {
-        if (!res.ok) throw new Error('Unauthorized')
-        return res.json()
-      })
-      .then((data: AuthUser) => setUser(data))
-      .catch(() => setUser(null))
-      .finally(() => setLoading(false))
+  const fetchAuthState = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' })
+      if (!res.ok) throw new Error('Unauthorized')
+      const data: AuthUser = await res.json()
+      setUser(data)
+    } catch {
+      setUser(null)
+    }
   }, [])
+
+  const refreshAuthState = useCallback(async () => {
+    await fetchAuthState()
+  }, [fetchAuthState])
+
+  // Expose refreshAuthState globally so client.ts interceptor can call it
+  useEffect(() => {
+    const w = window as unknown as Record<string, unknown>
+    w.__refreshAuthState = refreshAuthState
+    return () => {
+      delete w.__refreshAuthState
+    }
+  }, [refreshAuthState])
+
+  // Initial auth state check
+  useEffect(() => {
+    fetchAuthState().finally(() => setLoading(false))
+  }, [fetchAuthState])
+
+  // Proactive token refresh: check the token_expires_at cookie periodically
+  useEffect(() => {
+    async function checkAndRefresh() {
+      const expiresAtStr = getCookie('token_expires_at')
+      if (!expiresAtStr) return
+      const expiresAt = parseInt(expiresAtStr, 10)
+      if (isNaN(expiresAt)) return
+      const nowS = Math.floor(Date.now() / 1000)
+      if (expiresAt - nowS <= PROACTIVE_REFRESH_THRESHOLD_S) {
+        try {
+          const res = await fetch(`${API_BASE}/auth/refresh`, {
+            method: 'POST',
+            credentials: 'include',
+          })
+          if (res.ok) {
+            await refreshAuthState()
+            try {
+              const bc = new BroadcastChannel(AUTH_CHANNEL_NAME)
+              bc.postMessage({ type: 'token-refreshed' })
+              bc.close()
+            } catch {
+              // BroadcastChannel not supported
+            }
+          }
+        } catch {
+          // Refresh failed — will be caught by 401 interceptor on next request
+        }
+      }
+    }
+
+    proactiveTimerRef.current = setInterval(checkAndRefresh, PROACTIVE_CHECK_INTERVAL_MS)
+    checkAndRefresh()
+    return () => {
+      if (proactiveTimerRef.current) clearInterval(proactiveTimerRef.current)
+    }
+  }, [refreshAuthState])
+
+  // Cross-tab sync via BroadcastChannel
+  useEffect(() => {
+    let bc: BroadcastChannel | null = null
+    try {
+      bc = new BroadcastChannel(AUTH_CHANNEL_NAME)
+      bc.onmessage = (event: MessageEvent) => {
+        const msg = event.data as { type: string }
+        if (msg.type === 'token-refreshed') {
+          refreshAuthState()
+        } else if (msg.type === 'logged-out') {
+          setUser(null)
+          window.location.href = '/login'
+        }
+      }
+    } catch {
+      // BroadcastChannel not supported — cross-tab sync unavailable
+    }
+    return () => {
+      if (bc) bc.close()
+    }
+  }, [refreshAuthState])
 
   const logout = useCallback(async () => {
     try {
@@ -51,6 +145,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Clear local state even if the server call fails
     }
     setUser(null)
+    try {
+      const bc = new BroadcastChannel(AUTH_CHANNEL_NAME)
+      bc.postMessage({ type: 'logged-out' })
+      bc.close()
+    } catch {
+      // BroadcastChannel not supported
+    }
     window.location.href = '/login'
   }, [])
 
@@ -60,6 +161,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isAdmin: user?.is_admin ?? false,
     isAuthenticated: user !== null,
     logout,
+    refreshAuthState,
   }
 
   return createElement(AuthContext.Provider, { value }, children)

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import secrets
+import time
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from starlette.responses import RedirectResponse, Response
 
 from src.api.middleware import require_auth
@@ -23,7 +24,7 @@ def _build_redirect_uri(provider: str) -> str:
 
 
 def _set_token_cookies(response: Response, access_token: str, refresh_token: str) -> None:
-    """Set httpOnly cookie pair on a response."""
+    """Set httpOnly cookie pair and a readable expiry metadata cookie on a response."""
     settings = get_settings().auth
     common: dict[str, object] = {
         "httponly": True,
@@ -44,6 +45,23 @@ def _set_token_cookies(response: Response, access_token: str, refresh_token: str
         value=refresh_token,
         max_age=settings.refresh_token_expire_days * 86400,
         **common,  # type: ignore[arg-type]
+    )
+    # Non-httpOnly metadata cookie so the frontend can read token expiry
+    # and trigger proactive refresh before the access token expires.
+    expires_at = int(time.time()) + settings.access_token_expire_minutes * 60
+    meta_common: dict[str, object] = {
+        "httponly": False,
+        "samesite": "lax",
+        "secure": settings.cookie_secure,
+        "path": "/",
+    }
+    if settings.cookie_domain:
+        meta_common["domain"] = settings.cookie_domain
+    response.set_cookie(
+        key="token_expires_at",
+        value=str(expires_at),
+        max_age=settings.access_token_expire_minutes * 60,
+        **meta_common,  # type: ignore[arg-type]
     )
 
 
@@ -114,12 +132,16 @@ async def callback(provider: str, code: str, state: str) -> RedirectResponse:
 
 
 @router.post("/auth/refresh", response_model=TokenResponse)
-def refresh(body: RefreshRequest) -> Response:
+def refresh(request: Request, body: RefreshRequest | None = None) -> Response:
     """Refresh an access token using a valid refresh token (with rotation).
 
+    Accepts the refresh token from a JSON body OR from the httpOnly
+    ``refresh_token`` cookie (for browser clients that cannot read the cookie).
     Returns new tokens as JSON AND sets updated httpOnly cookies.
     """
-    token = body.refresh_token
+    token = body.refresh_token if body else None
+    if not token:
+        token = request.cookies.get("refresh_token")
     if not token:
         raise HTTPException(status_code=401, detail="Missing refresh token")
 
@@ -161,6 +183,7 @@ def logout(user: User = Depends(require_auth)) -> Response:
     response = Response(status_code=204)
     response.delete_cookie("access_token", path="/")
     response.delete_cookie("refresh_token", path="/")
+    response.delete_cookie("token_expires_at", path="/")
     return response
 
 


### PR DESCRIPTION
## Summary
- **#431 fix**: Backend now sets a non-httpOnly `token_expires_at` metadata cookie alongside the httpOnly auth cookies. `useAuth` checks this cookie every 15s and proactively refreshes when the token is within 60s of expiry — eliminating the 401 flash on first request after expiry.
- **#431 fix**: The `/auth/refresh` endpoint now also reads `refresh_token` from the httpOnly cookie (not just JSON body), enabling cookie-based browser refresh without needing to parse the body.
- **#432 fix**: `useAuth` exposes `refreshAuthState()` via a window global that the `client.ts` 401 interceptor calls after a successful reactive refresh, ensuring auth state updates immediately.
- **#432 fix**: Cross-tab auth sync via BroadcastChannel — token refresh and logout events are broadcast to all open tabs.

## Related Issues
Closes #431, Closes #432

## Changed Files
- `src/api/routes/auth.py` — metadata cookie, cookie-based refresh, logout cleanup
- `frontend/src/hooks/useAuth.ts` — proactive refresh timer, cross-tab sync, refreshAuthState
- `frontend/src/api/client.ts` — call refreshAuthState after 401 refresh

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Carolina Méndez-Ríos <parametrization+Carolina.Mendez-Rios@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
