### PR TITLE
fix(deploy): verify VPS prereqs, add rollback docs + dry-run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,48 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ---------------------------------------------------------------
+      # VPS prerequisite verification
+      # Checks that all required tools are present on the VPS before
+      # attempting backup or deploy. Required tools:
+      #   - docker / docker compose  (container runtime)
+      #   - rclone                   (B2 backup upload/download)
+      #   - zstd                     (Neo4j dump compression)
+      #   - sha256sum                (backup checksum verification)
+      #   - git                      (code checkout / rollback)
+      # If any are missing, the step fails with an actionable message.
+      # Install missing tools via bootstrap-vps.sh or:
+      #   apt-get install -y zstd && curl -sL https://rclone.org/install.sh | bash
+      # ---------------------------------------------------------------
+      - name: Verify VPS prerequisites
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ vars.VPS_HOST }}
+          username: deploy
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          script: |
+            set -euo pipefail
+            echo "==> Verifying VPS prerequisites..."
+            MISSING=""
+            for cmd in docker rclone zstd sha256sum git; do
+              if ! command -v "$cmd" &>/dev/null; then
+                MISSING="${MISSING} ${cmd}"
+              fi
+            done
+            if ! docker compose version &>/dev/null; then
+              MISSING="${MISSING} docker-compose-v2"
+            fi
+            if [[ -n "$MISSING" ]]; then
+              echo "::error::Missing required VPS tools:${MISSING}"
+              echo ""
+              echo "Install missing prerequisites by running bootstrap-vps.sh on the VPS,"
+              echo "or install manually:"
+              echo "  apt-get install -y zstd"
+              echo "  curl -sL https://rclone.org/install.sh | bash"
+              exit 1
+            fi
+            echo "==> All prerequisites verified"
+
+      # ---------------------------------------------------------------
       # Pre-deploy backup
       # Stops the API container for cross-DB consistency, runs backup.sh
       # on VPS via SSH, and records the current git commit SHA so that

--- a/docs/deployment/rollback-test.md
+++ b/docs/deployment/rollback-test.md
@@ -1,0 +1,132 @@
+# Rollback Test Procedure
+
+Manual test procedure for validating the backup/restore and rollback pipeline.
+
+## Prerequisites
+
+- SSH access to the VPS as the `deploy` user
+- B2 credentials configured (`B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET`)
+- A recent backup exists (check with `restore.sh --list`)
+- All VPS tools installed: `docker`, `rclone`, `zstd`, `sha256sum`, `git`
+
+## 1. Verify backup exists
+
+```bash
+ssh deploy@isnad-graph.noorinalabs.com
+cd /opt/isnad-graph
+export B2_KEY_ID="..." B2_APP_KEY="..." B2_BUCKET="..."
+bash scripts/restore.sh --list
+```
+
+Confirm at least one daily or weekly backup is listed.
+
+## 2. Dry-run restore validation
+
+The `--dry-run` flag downloads and validates the backup without overwriting any data:
+
+```bash
+bash scripts/restore.sh --dry-run latest
+```
+
+Expected output:
+- Download succeeds
+- All SHA256 checksums pass
+- Both PostgreSQL and Neo4j dump files are present and non-empty
+- Script exits with `DRY RUN complete -- no data was modified`
+
+## 3. Full restore test (staging or maintenance window)
+
+**WARNING:** This overwrites live databases. Only run during a maintenance window or on a staging environment.
+
+### 3a. Record current state
+
+Before restoring, capture the current database state for comparison:
+
+```bash
+# Record PG row counts
+docker compose -f docker-compose.prod.yml exec -T postgres \
+  psql -U isnad -d isnad_graph -c "SELECT schemaname, relname, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC LIMIT 20;"
+
+# Record Neo4j node counts
+docker compose -f docker-compose.prod.yml exec -T neo4j \
+  cypher-shell -u neo4j -p "$NEO4J_PASSWORD" "MATCH (n) RETURN labels(n)[0] AS label, count(*) AS cnt ORDER BY cnt DESC;"
+```
+
+### 3b. Create a fresh backup
+
+```bash
+bash scripts/backup.sh
+```
+
+### 3c. Restore from the backup just created
+
+```bash
+bash scripts/restore.sh --force latest
+```
+
+### 3d. Verify restore
+
+```bash
+# Check PG row counts match pre-restore state
+docker compose -f docker-compose.prod.yml exec -T postgres \
+  psql -U isnad -d isnad_graph -c "SELECT schemaname, relname, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC LIMIT 20;"
+
+# Check Neo4j node counts match
+docker compose -f docker-compose.prod.yml exec -T neo4j \
+  cypher-shell -u neo4j -p "$NEO4J_PASSWORD" "MATCH (n) RETURN labels(n)[0] AS label, count(*) AS cnt ORDER BY cnt DESC;"
+
+# Verify API health
+curl -s http://localhost:8000/health | jq .
+```
+
+## 4. Code rollback test
+
+Test that the deploy workflow's automatic rollback restores both code and data:
+
+```bash
+# Check the stored pre-deploy SHA
+cat /opt/isnad-graph/.last-deploy-sha
+
+# Simulate code rollback
+git log --oneline -5
+PREVIOUS_SHA=$(cat /opt/isnad-graph/.last-deploy-sha)
+echo "Would roll back to: ${PREVIOUS_SHA}"
+```
+
+To test via the Restore workflow, trigger it from GitHub Actions with `rollback_code: true`.
+
+## Restore ordering
+
+The restore process follows a specific order:
+
+1. **PostgreSQL first** -- graph loaders assume PG metadata exists when populating Neo4j relationships (Elena's feedback from PR #427)
+2. **Neo4j second** -- Neo4j must be stopped for offline restore, then restarted
+3. **API last** -- brought up after both databases are verified healthy
+
+This ordering is enforced by both `restore.sh` and the deploy workflow's automatic rollback step.
+
+## Automated rollback (deploy workflow)
+
+The deploy workflow (`deploy.yml`) automatically triggers rollback when:
+
+1. The health check step fails after deploy
+2. A pre-deploy backup was successfully created
+
+The automatic rollback:
+1. Reads the previous commit SHA from `.last-deploy-sha`
+2. Resets the code to that commit (`git reset --hard`)
+3. Stops all containers
+4. Brings up only PG and Neo4j
+5. Runs `restore.sh --force latest`
+6. Rebuilds and brings up all services
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|-------------|--------|
+| `restore.sh` fails on download | B2 credentials expired or bucket name wrong | Re-export `B2_KEY_ID`, `B2_APP_KEY`, `B2_BUCKET` |
+| Checksum mismatch | Corrupt upload or incomplete download | Re-run backup, then retry restore |
+| Neo4j won't stop | Container hung | `docker compose -f docker-compose.prod.yml kill neo4j` then retry |
+| PG restore warnings | Normal with `--clean --if-exists` | Check for actual errors in output; warnings about "role already exists" are harmless |
+| Neo4j unhealthy after restore | Database version mismatch | Verify Neo4j image version matches the one used for backup |
+| `.last-deploy-sha` missing | First deploy or file was deleted | Code rollback will be skipped; only data is restored |

--- a/scripts/bootstrap-vps.sh
+++ b/scripts/bootstrap-vps.sh
@@ -29,7 +29,7 @@ fi
 # ── Step 1: System packages ─────────────────────────────────────────────────
 echo "==> [1/7] Installing system packages..."
 apt-get update -qq
-apt-get install -y -qq docker.io docker-compose-v2 docker-buildx git curl > /dev/null
+apt-get install -y -qq docker.io docker-compose-v2 docker-buildx git curl zstd > /dev/null
 systemctl enable docker
 systemctl start docker
 echo "    Docker version: $(docker --version)"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -19,6 +19,7 @@
 #   ./scripts/restore.sh latest                    # Restore most recent backup
 #   ./scripts/restore.sh daily/2026-03-25          # Restore specific date
 #   ./scripts/restore.sh --force daily/2026-03-25  # Skip confirmation prompt
+#   ./scripts/restore.sh --dry-run latest          # Validate without restoring
 #   ./scripts/restore.sh --list                    # List available backups
 # =============================================================================
 set -euo pipefail
@@ -42,6 +43,7 @@ export RCLONE_CONFIG_ISNAD_ACCOUNT="${B2_KEY_ID}"
 export RCLONE_CONFIG_ISNAD_KEY="${B2_APP_KEY}"
 
 FORCE=false
+DRY_RUN=false
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -243,16 +245,22 @@ while [[ $# -gt 0 ]]; do
             FORCE=true
             shift
             ;;
+        --dry-run)
+            DRY_RUN=true
+            FORCE=true  # skip confirmation in dry-run mode
+            shift
+            ;;
         --list)
             list_backups
             exit 0
             ;;
         --help|-h)
-            echo "Usage: $0 [--force] [--list] <backup-path|latest>"
+            echo "Usage: $0 [--force] [--dry-run] [--list] <backup-path|latest>"
             echo ""
             echo "  latest              Restore the most recent backup"
             echo "  daily/2026-03-25    Restore a specific backup"
             echo "  --force             Skip confirmation prompt"
+            echo "  --dry-run           Validate backup without overwriting data"
             echo "  --list              List available backups"
             exit 0
             ;;
@@ -264,7 +272,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$BACKUP_PATH" ]]; then
-    echo "Usage: $0 [--force] [--list] <backup-path|latest>"
+    echo "Usage: $0 [--force] [--dry-run] [--list] <backup-path|latest>"
     echo "Run '$0 --list' to see available backups."
     exit 1
 fi
@@ -320,6 +328,33 @@ verify_checksums "$RESTORE_DIR"
 # Find dump files
 PG_DUMP=$(find "$RESTORE_DIR" -name 'isnad-pg-*.dump' -type f | head -1)
 NEO4J_DUMP=$(find "$RESTORE_DIR" \( -name 'isnad-neo4j-*.dump.zst' -o -name 'isnad-neo4j-*.dump' \) -type f | head -1)
+
+# ---------------------------------------------------------------------------
+# Dry-run mode: validate backup contents without restoring
+# ---------------------------------------------------------------------------
+if [[ "$DRY_RUN" == "true" ]]; then
+    log "INFO" "=== DRY RUN — validating backup without restoring ==="
+    log "INFO" "Backup source: ${RCLONE_REMOTE}:${B2_BUCKET}/${BACKUP_PATH}/"
+    log "INFO" "Checksums: PASSED"
+
+    if [[ -n "$PG_DUMP" ]]; then
+        PG_SIZE=$(du -h "$PG_DUMP" | cut -f1)
+        log "INFO" "PostgreSQL dump: $(basename "$PG_DUMP") (${PG_SIZE})"
+    else
+        log "WARNING" "No PostgreSQL dump found in backup"
+    fi
+
+    if [[ -n "$NEO4J_DUMP" ]]; then
+        NEO4J_SIZE=$(du -h "$NEO4J_DUMP" | cut -f1)
+        log "INFO" "Neo4j dump: $(basename "$NEO4J_DUMP") (${NEO4J_SIZE})"
+    else
+        log "WARNING" "No Neo4j dump found in backup"
+    fi
+
+    log "INFO" "Restore order: PostgreSQL first, then Neo4j"
+    log "INFO" "=== DRY RUN complete — no data was modified ==="
+    exit 0
+fi
 
 if [[ -n "$PG_DUMP" ]]; then
     restore_postgres "$PG_DUMP"

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -165,7 +165,7 @@ def validate_staging(staging_dir: Path) -> dict[str, Any]:
             if "matn_ar" in table.column_names:
                 col = table.column("matn_ar")
                 non_null = col.drop_null()
-                ar_count = pc.sum(pc.match_substring_regex(non_null, r"[\u0600-\u06FF]")).as_py()
+                ar_count = pc.sum(pc.match_substring_regex(non_null, "[\u0600-\u06ff]")).as_py()
             if "matn_en" in table.column_names:
                 col = table.column("matn_en")
                 non_null = col.drop_null()


### PR DESCRIPTION
## Summary
- Add "Verify VPS prerequisites" step to deploy workflow that checks rclone, zstd, sha256sum, git, and docker compose are installed before backup runs. Fails early with actionable install instructions.
- Add `zstd` to `bootstrap-vps.sh` system package install (rclone was already covered).
- Add `--dry-run` flag to `restore.sh` that downloads a backup, verifies checksums, and reports file sizes without overwriting any data.
- Create `docs/deployment/rollback-test.md` — manual rollback test procedure covering dry-run validation, full restore test, code rollback, restore ordering (PG before Neo4j), and troubleshooting.
- Fix pre-existing pyarrow regex bug in `validate.py` (RE2 doesn't support `\u` in raw strings).

## Related Issues
Closes #430, Closes #433

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Tomasz Wójcik <parametrization+Tomasz.Wojcik@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
