### PR TITLE
feat(frontend): auth state in header

### DIFF
--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet, Navigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import HeaderAuth from './HeaderAuth'
 import styles from './AdminLayout.module.css'
 
 const adminNavItems = [
@@ -27,6 +28,7 @@ export default function AdminLayout() {
           <h1 className={styles.headerTitle}>Isnad Graph</h1>
         </NavLink>
         <span className="small-muted">Admin Dashboard</span>
+        <HeaderAuth />
       </header>
       <div className={styles.body}>
         <nav className={styles.sidebar}>

--- a/frontend/src/components/HeaderAuth.module.css
+++ b/frontend/src/components/HeaderAuth.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.userName {
+  font-size: 0.875rem;
+  color: #333;
+}
+
+.loginLink {
+  font-size: 0.875rem;
+  color: #1a73e8;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.logoutButton {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+}
+
+.logoutButton:hover {
+  background: #f5f5f5;
+}

--- a/frontend/src/components/HeaderAuth.tsx
+++ b/frontend/src/components/HeaderAuth.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import styles from './HeaderAuth.module.css'
+
+export default function HeaderAuth() {
+  const { user, isAdmin, isAuthenticated, logout } = useAuth()
+
+  if (!isAuthenticated) {
+    return (
+      <div className={styles.container}>
+        <Link to="/login" className={styles.loginLink}>
+          Login
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.container}>
+      <span className={styles.userName}>{user!.name || user!.email}</span>
+      {isAdmin && (
+        <Link to="/admin" className="badge-admin">
+          Admin
+        </Link>
+      )}
+      <button
+        type="button"
+        className={styles.logoutButton}
+        onClick={() => void logout()}
+        aria-label="Log out"
+      >
+        Logout
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom'
 import Sidebar from './Sidebar'
+import HeaderAuth from './HeaderAuth'
 
 export default function Layout() {
   return (
@@ -7,6 +8,7 @@ export default function Layout() {
       <header className="flex-row" style={{ padding: '0.75rem 1.5rem', borderBottom: '1px solid #ddd' }}>
         <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Isnad Graph</h1>
         <span className="small-muted">Hadith Analysis Platform</span>
+        <HeaderAuth />
       </header>
       <div style={{ display: 'flex', flex: 1 }}>
         <Sidebar />


### PR DESCRIPTION
## Summary
- Add `HeaderAuth` component showing authenticated user name, admin badge/link, and logout button
- Show login link when not authenticated (edge case for unauthenticated state)
- Integrate `HeaderAuth` into both `Layout.tsx` and `AdminLayout.tsx` headers

## Related Issues
Closes #415

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

**Note:** Integration test `test_full_pipeline_sample` failure is pre-existing on the base branch (APPEARS_IN edge loader issue) — unrelated to this frontend change.

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>