### PR TITLE
feat(auth): email/password registration and login with argon2id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "uvicorn[standard]>=0.34",
     "authlib>=1.3",
     "python-jose[cryptography]>=3.3",
+    "argon2-cffi>=23.1",
     "redis>=5.0",
     "prometheus-fastapi-instrumentator>=7.0",
 ]
@@ -94,6 +95,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["testcontainers", "testcontainers.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["argon2", "argon2.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -1,18 +1,31 @@
-"""Authentication endpoints for OAuth login flows."""
+"""Authentication endpoints for OAuth login flows and email/password auth."""
 
 from __future__ import annotations
 
+import logging
 import secrets
 import time
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from starlette.responses import RedirectResponse, Response
 
 from src.api.middleware import require_auth
-from src.auth.models import AuthorizationUrlResponse, RefreshRequest, TokenResponse, User
+from src.auth.models import (
+    AuthorizationUrlResponse,
+    EmailLoginRequest,
+    RefreshRequest,
+    RegisterRequest,
+    TokenResponse,
+    User,
+    UserPublic,
+)
 from src.auth.providers import PROVIDERS, get_provider, retrieve_pkce_verifier, store_pkce_verifier
+from src.auth.rate_limit import check_rate_limit
 from src.auth.tokens import create_access_token, create_refresh_token, revoke_token, verify_token
 from src.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -63,6 +76,127 @@ def _set_token_cookies(response: Response, access_token: str, refresh_token: str
         max_age=settings.access_token_expire_minutes * 60,
         **meta_common,  # type: ignore[arg-type]
     )
+
+
+def _build_token_response(user_id: str) -> tuple[TokenResponse, str, str]:
+    """Create access + refresh tokens and build a TokenResponse."""
+    settings = get_settings().auth
+    access_token = create_access_token(user_id)
+    refresh_token = create_refresh_token(user_id)
+    token_resp = TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        expires_in=settings.access_token_expire_minutes * 60,
+    )
+    return token_resp, access_token, refresh_token
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract client IP from the request."""
+    return request.client.host if request.client else "unknown"
+
+
+# --- Email/password registration ---
+
+
+@router.post("/auth/register", response_model=TokenResponse, status_code=201)
+def register(request: Request, body: RegisterRequest) -> Response:
+    """Register a new user with email and password.
+
+    Rate limited to 3 requests per minute per IP.
+    """
+    client_ip = _get_client_ip(request)
+    if not check_rate_limit(f"register:{client_ip}", max_requests=3, window_seconds=60):
+        raise HTTPException(
+            status_code=429,
+            detail="Too many registration attempts. Try again later.",
+            headers={"Retry-After": "60"},
+        )
+
+    from src.auth.passwords import hash_password
+    from src.auth.pg_users import create_email_user, ensure_users_table
+    from src.utils.pg_client import PgClient
+
+    password_hash = hash_password(body.password)
+
+    pg = PgClient()
+    try:
+        ensure_users_table(pg)
+        try:
+            user = create_email_user(
+                pg,
+                email=body.email,
+                name=body.name,
+                password_hash=password_hash,
+            )
+        except Exception as exc:
+            err_msg = str(exc).lower()
+            if "unique" in err_msg or "duplicate" in err_msg or "ix_users_email" in err_msg:
+                raise HTTPException(
+                    status_code=409,
+                    detail="An account with this email already exists",
+                ) from exc
+            raise
+    finally:
+        pg.close()
+
+    logger.info("User registered: email=%s, id=%s", body.email, user.id)
+
+    token_resp, access_token, refresh_token = _build_token_response(user.id)
+    response = JSONResponse(content=token_resp.model_dump(), status_code=201)
+    _set_token_cookies(response, access_token, refresh_token)
+    return response
+
+
+# --- Email/password login ---
+
+
+@router.post("/auth/login/email", response_model=TokenResponse)
+def login_email(request: Request, body: EmailLoginRequest) -> Response:
+    """Authenticate with email and password.
+
+    Rate limited to 5 requests per minute per IP.
+    """
+    client_ip = _get_client_ip(request)
+    if not check_rate_limit(f"login_email:{client_ip}", max_requests=5, window_seconds=60):
+        raise HTTPException(
+            status_code=429,
+            detail="Too many login attempts. Try again later.",
+            headers={"Retry-After": "60"},
+        )
+
+    from src.auth.passwords import verify_password
+    from src.auth.pg_users import ensure_users_table, get_user_by_email
+    from src.utils.pg_client import PgClient
+
+    email = body.email.strip().lower()
+
+    pg = PgClient()
+    try:
+        ensure_users_table(pg)
+        user = get_user_by_email(pg, email)
+    finally:
+        pg.close()
+
+    if user is None or user.provider != "email" or user.password_hash is None:
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    if not verify_password(body.password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    if user.is_suspended:
+        raise HTTPException(status_code=403, detail="Account suspended")
+
+    logger.info("Email login: email=%s, id=%s", email, user.id)
+
+    token_resp, access_token, refresh_token = _build_token_response(user.id)
+    response = JSONResponse(content=token_resp.model_dump())
+    _set_token_cookies(response, access_token, refresh_token)
+    return response
+
+
+# --- OAuth login ---
 
 
 @router.post(
@@ -160,17 +294,7 @@ def refresh(request: Request, body: RefreshRequest | None = None) -> Response:
     # Revoke the old refresh token (rotation)
     revoke_token(token)
 
-    settings = get_settings().auth
-    new_access = create_access_token(user_id)
-    new_refresh = create_refresh_token(user_id)
-
-    token_resp = TokenResponse(
-        access_token=new_access,
-        refresh_token=new_refresh,
-        token_type="bearer",
-        expires_in=settings.access_token_expire_minutes * 60,
-    )
-    from fastapi.responses import JSONResponse
+    token_resp, new_access, new_refresh = _build_token_response(user_id)
 
     response = JSONResponse(content=token_resp.model_dump())
     _set_token_cookies(response, new_access, new_refresh)
@@ -187,7 +311,7 @@ def logout(user: User = Depends(require_auth)) -> Response:
     return response
 
 
-@router.get("/auth/me", response_model=User)
-def me(user: User = Depends(require_auth)) -> User:
+@router.get("/auth/me", response_model=UserPublic)
+def me(user: User = Depends(require_auth)) -> UserPublic:
     """Return the current authenticated user from PostgreSQL."""
-    return user
+    return UserPublic.from_user(user)

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from src.auth.models import TokenResponse, User
+from src.auth.models import TokenResponse, User, UserPublic
 from src.auth.providers import PROVIDERS, OAuthProvider, OAuthUserInfo, get_provider
 from src.auth.tokens import (
     create_access_token,
@@ -17,6 +17,7 @@ __all__ = [
     "OAuthUserInfo",
     "TokenResponse",
     "User",
+    "UserPublic",
     "create_access_token",
     "create_refresh_token",
     "get_provider",

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class User(BaseModel):
@@ -23,6 +24,96 @@ class User(BaseModel):
     is_suspended: bool = False
     role: str | None = None
     password_hash: str | None = None
+
+
+class UserPublic(BaseModel):
+    """User response model that excludes password_hash."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    email: str | None = None
+    name: str
+    provider: str
+    provider_user_id: str
+    created_at: datetime
+    updated_at: datetime | None = None
+    is_admin: bool = False
+    is_suspended: bool = False
+    role: str | None = None
+
+    @staticmethod
+    def from_user(user: User) -> UserPublic:
+        """Create a UserPublic from a User, stripping password_hash."""
+        return UserPublic(
+            id=user.id,
+            email=user.email,
+            name=user.name,
+            provider=user.provider,
+            provider_user_id=user.provider_user_id,
+            created_at=user.created_at,
+            updated_at=user.updated_at,
+            is_admin=user.is_admin,
+            is_suspended=user.is_suspended,
+            role=user.role,
+        )
+
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+
+
+class RegisterRequest(BaseModel):
+    """Email/password registration request body."""
+
+    model_config = ConfigDict(frozen=True)
+
+    email: str
+    password: str
+    name: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        v = v.strip().lower()
+        if not _EMAIL_RE.match(v):
+            msg = "Invalid email format"
+            raise ValueError(msg)
+        if len(v) > 320:
+            msg = "Email must not exceed 320 characters"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            msg = "Password must be at least 8 characters"
+            raise ValueError(msg)
+        if len(v) > 128:
+            msg = "Password must not exceed 128 characters"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            msg = "Name must not be empty"
+            raise ValueError(msg)
+        if len(v) > 255:
+            msg = "Name must not exceed 255 characters"
+            raise ValueError(msg)
+        return v
+
+
+class EmailLoginRequest(BaseModel):
+    """Email/password login request body."""
+
+    model_config = ConfigDict(frozen=True)
+
+    email: str
+    password: str
 
 
 class TokenResponse(BaseModel):

--- a/src/auth/passwords.py
+++ b/src/auth/passwords.py
@@ -1,0 +1,29 @@
+"""Argon2id password hashing and verification."""
+
+from __future__ import annotations
+
+from argon2 import PasswordHasher, Type
+from argon2.exceptions import VerifyMismatchError
+
+# OWASP-recommended argon2id parameters
+_hasher = PasswordHasher(
+    time_cost=2,
+    memory_cost=19456,
+    parallelism=1,
+    hash_len=32,
+    salt_len=16,
+    type=Type.ID,
+)
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using argon2id. Returns the PHC-format hash string."""
+    return str(_hasher.hash(password))
+
+
+def verify_password(password: str, hash_str: str) -> bool:
+    """Verify a password against an argon2id hash. Returns True if valid."""
+    try:
+        return bool(_hasher.verify(hash_str, password))
+    except VerifyMismatchError:
+        return False

--- a/src/auth/pg_users.py
+++ b/src/auth/pg_users.py
@@ -149,6 +149,43 @@ def update_user(
     return _row_to_user(rows[0]) if rows else None
 
 
+def create_email_user(
+    pg: PgClient,
+    *,
+    email: str,
+    name: str,
+    password_hash: str,
+) -> User:
+    """Create a new user with email/password provider. Returns the user.
+
+    Raises a duplicate-key error if the email already exists (caller should
+    catch and return 409).
+    """
+    rows = pg.execute(
+        """
+        INSERT INTO users (id, email, name, provider, provider_user_id, password_hash)
+        VALUES (%s, %s, %s, 'email', %s, %s)
+        RETURNING id, email, name, provider, provider_user_id, password_hash,
+                  is_admin, is_suspended, role, created_at, updated_at
+        """,
+        (str(uuid.uuid4()), email, name, email, password_hash),
+    )
+    return _row_to_user(rows[0])
+
+
+def get_user_by_email(pg: PgClient, email: str) -> User | None:
+    """Fetch a user by email address (any provider)."""
+    rows = pg.execute(
+        """
+        SELECT id, email, name, provider, provider_user_id, password_hash,
+               is_admin, is_suspended, role, created_at, updated_at
+        FROM users WHERE email = %s
+        """,
+        (email,),
+    )
+    return _row_to_user(rows[0]) if rows else None
+
+
 def _row_to_user(row: dict[str, Any]) -> User:
     """Convert a PG row dict to a User model."""
     return User(

--- a/src/auth/rate_limit.py
+++ b/src/auth/rate_limit.py
@@ -1,0 +1,73 @@
+"""Per-endpoint rate limiting with Redis backend and in-memory fallback."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import redis as redis_lib
+
+from src.utils.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# In-memory fallback store: key -> list of timestamps
+_memory_store: dict[str, list[float]] = {}
+
+
+def check_rate_limit(key: str, max_requests: int, window_seconds: int = 60) -> bool:
+    """Check if the request is within the rate limit.
+
+    Args:
+        key: Unique rate limit key (e.g. "register:{ip}" or "login:{ip}").
+        max_requests: Maximum number of requests in the window.
+        window_seconds: Sliding window size in seconds.
+
+    Returns:
+        True if the request is allowed, False if rate limited.
+    """
+    now = time.time()
+
+    result = _check_redis(key, max_requests, window_seconds, now)
+    if result is not None:
+        return result
+
+    return _check_memory(key, max_requests, window_seconds, now)
+
+
+def _check_redis(key: str, max_requests: int, window_seconds: int, now: float) -> bool | None:
+    """Try Redis-backed rate limit check. Returns None if Redis unavailable."""
+    redis_client = get_redis_client()
+    if redis_client is None:
+        return None
+
+    redis_key = f"ratelimit:{key}"
+    window_start = now - window_seconds
+
+    try:
+        pipe = redis_client.pipeline()
+        pipe.zremrangebyscore(redis_key, "-inf", window_start)
+        pipe.zcard(redis_key)
+        pipe.zadd(redis_key, {str(now): now})
+        pipe.expire(redis_key, window_seconds + 1)
+        results = pipe.execute()
+        count: int = results[1]
+        return count < max_requests
+    except redis_lib.ConnectionError, redis_lib.TimeoutError, OSError:
+        logger.warning("Redis rate limit check failed, falling back to in-memory")
+        return None
+
+
+def _check_memory(key: str, max_requests: int, window_seconds: int, now: float) -> bool:
+    """In-memory sliding window rate limit check."""
+    window_start = now - float(window_seconds)
+    timestamps = _memory_store.get(key, [])
+    timestamps = [t for t in timestamps if t > window_start]
+
+    if len(timestamps) >= max_requests:
+        _memory_store[key] = timestamps
+        return False
+
+    timestamps.append(now)
+    _memory_store[key] = timestamps
+    return True

--- a/tests/test_auth/test_email_auth.py
+++ b/tests/test_auth/test_email_auth.py
@@ -1,0 +1,388 @@
+"""Tests for email/password registration and login endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.auth.models import User
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_store() -> Iterator[None]:
+    """Clear in-memory rate limit store between tests."""
+    from src.auth import rate_limit
+
+    rate_limit._memory_store.clear()
+    yield
+    rate_limit._memory_store.clear()
+
+
+def _make_email_user(
+    email: str = "test@example.com",
+    name: str = "Test User",
+    user_id: str = "uuid-123",
+    password_hash: str = "$argon2id$v=19$m=19456,t=2,p=1$salt$hash",
+) -> User:
+    return User(
+        id=user_id,
+        email=email,
+        name=name,
+        provider="email",
+        provider_user_id=email,
+        password_hash=password_hash,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+class TestRegister:
+    """Tests for POST /api/v1/auth/register."""
+
+    def test_register_success(self, client: TestClient) -> None:
+        mock_user = _make_email_user()
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.passwords.PasswordHasher.hash", return_value="$argon2id$hashed"),
+            patch("src.auth.pg_users.create_email_user", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+        ):
+            resp = client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "securepass123",
+                    "name": "Test User",
+                },
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "bearer"
+        assert "expires_in" in data
+        # httpOnly cookies should be set
+        assert "access_token" in resp.cookies
+        assert "refresh_token" in resp.cookies
+
+    def test_register_password_hash_not_in_response(self, client: TestClient) -> None:
+        mock_user = _make_email_user()
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.passwords.PasswordHasher.hash", return_value="$argon2id$hashed"),
+            patch("src.auth.pg_users.create_email_user", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+        ):
+            resp = client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "securepass123",
+                    "name": "Test User",
+                },
+            )
+
+        assert resp.status_code == 201
+        body_text = resp.text
+        assert "password_hash" not in body_text
+        assert "$argon2id" not in body_text
+
+    def test_register_duplicate_email_409(self, client: TestClient) -> None:
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.passwords.PasswordHasher.hash", return_value="$argon2id$hashed"),
+            patch(
+                "src.auth.pg_users.create_email_user",
+                side_effect=Exception("duplicate key value violates unique constraint"),
+            ),
+            patch("src.auth.pg_users.ensure_users_table"),
+        ):
+            resp = client.post(
+                "/api/v1/auth/register",
+                json={"email": "dup@example.com", "password": "securepass123", "name": "Test"},
+            )
+
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"]
+
+    def test_register_invalid_email_422(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/auth/register",
+            json={"email": "not-an-email", "password": "securepass123", "name": "Test"},
+        )
+        assert resp.status_code == 422
+
+    def test_register_short_password_422(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/auth/register",
+            json={"email": "test@example.com", "password": "short", "name": "Test"},
+        )
+        assert resp.status_code == 422
+
+    def test_register_empty_name_422(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/auth/register",
+            json={"email": "test@example.com", "password": "securepass123", "name": "   "},
+        )
+        assert resp.status_code == 422
+
+    def test_register_unicode_name(self, client: TestClient) -> None:
+        mock_user = _make_email_user(name="عبد الله محمد")
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.passwords.PasswordHasher.hash", return_value="$argon2id$hashed"),
+            patch("src.auth.pg_users.create_email_user", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+        ):
+            resp = client.post(
+                "/api/v1/auth/register",
+                json={
+                    "email": "arabic@example.com",
+                    "password": "securepass123",
+                    "name": "عبد الله محمد",
+                },
+            )
+
+        assert resp.status_code == 201
+
+    def test_register_rate_limit_429(self, client: TestClient) -> None:
+        with patch("src.api.routes.auth.check_rate_limit", return_value=False):
+            resp = client.post(
+                "/api/v1/auth/register",
+                json={"email": "test@example.com", "password": "securepass123", "name": "Test"},
+            )
+
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+
+
+class TestEmailLogin:
+    """Tests for POST /api/v1/auth/login/email."""
+
+    def test_login_success(self, client: TestClient) -> None:
+        mock_user = _make_email_user()
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.pg_users.get_user_by_email", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+            patch("src.auth.passwords.PasswordHasher.verify", return_value=True),
+        ):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "test@example.com", "password": "securepass123"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "bearer"
+        assert "access_token" in resp.cookies
+
+    def test_login_wrong_password_401(self, client: TestClient) -> None:
+        mock_user = _make_email_user()
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.pg_users.get_user_by_email", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+            patch("src.auth.passwords.verify_password", return_value=False),
+        ):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "test@example.com", "password": "wrongpassword"},
+            )
+
+        assert resp.status_code == 401
+        assert "Invalid email or password" in resp.json()["detail"]
+
+    def test_login_nonexistent_user_401(self, client: TestClient) -> None:
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.pg_users.get_user_by_email", return_value=None),
+            patch("src.auth.pg_users.ensure_users_table"),
+        ):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "noone@example.com", "password": "securepass123"},
+            )
+
+        assert resp.status_code == 401
+
+    def test_login_oauth_user_cannot_use_email_login(self, client: TestClient) -> None:
+        """Users who registered via OAuth cannot login with email/password."""
+        oauth_user = User(
+            id="uuid-456",
+            email="oauth@example.com",
+            name="OAuth User",
+            provider="google",
+            provider_user_id="google-123",
+            password_hash=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.pg_users.get_user_by_email", return_value=oauth_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+        ):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "oauth@example.com", "password": "anypassword"},
+            )
+
+        assert resp.status_code == 401
+
+    def test_login_suspended_user_403(self, client: TestClient) -> None:
+        mock_user = User(
+            id="uuid-789",
+            email="suspended@example.com",
+            name="Suspended",
+            provider="email",
+            provider_user_id="suspended@example.com",
+            password_hash="$argon2id$v=19$m=19456,t=2,p=1$salt$hash",
+            is_suspended=True,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.pg_users.get_user_by_email", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+            patch("src.auth.passwords.PasswordHasher.verify", return_value=True),
+        ):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "suspended@example.com", "password": "securepass123"},
+            )
+
+        assert resp.status_code == 403
+
+    def test_login_rate_limit_429(self, client: TestClient) -> None:
+        with patch("src.api.routes.auth.check_rate_limit", return_value=False):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "test@example.com", "password": "securepass123"},
+            )
+
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+
+    def test_login_password_hash_not_in_response(self, client: TestClient) -> None:
+        mock_user = _make_email_user()
+        with (
+            patch("src.api.routes.auth.check_rate_limit", return_value=True),
+            patch("src.auth.pg_users.get_user_by_email", return_value=mock_user),
+            patch("src.auth.pg_users.ensure_users_table"),
+            patch("src.auth.passwords.PasswordHasher.verify", return_value=True),
+        ):
+            resp = client.post(
+                "/api/v1/auth/login/email",
+                json={"email": "test@example.com", "password": "securepass123"},
+            )
+
+        assert resp.status_code == 200
+        assert "password_hash" not in resp.text
+        assert "$argon2id" not in resp.text
+
+
+class TestMeEndpointPasswordExclusion:
+    """Test that /auth/me never returns password_hash."""
+
+    def test_me_excludes_password_hash(self, client: TestClient) -> None:
+        from src.auth.tokens import create_access_token
+
+        token = create_access_token("uuid-123")
+        mock_user = _make_email_user()
+        with patch("src.auth.pg_users.get_user_by_id", return_value=mock_user):
+            resp = client.get(
+                "/api/v1/auth/me",
+                cookies={"access_token": token},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "password_hash" not in data
+        assert "$argon2id" not in resp.text
+
+
+class TestPasswordHashing:
+    """Unit tests for argon2id password hashing."""
+
+    def test_hash_and_verify(self) -> None:
+        from src.auth.passwords import hash_password, verify_password
+
+        password = "my-secure-password-123"
+        hashed = hash_password(password)
+        assert hashed.startswith("$argon2id$")
+        assert verify_password(password, hashed) is True
+
+    def test_wrong_password_fails(self) -> None:
+        from src.auth.passwords import hash_password, verify_password
+
+        hashed = hash_password("correct-password")
+        assert verify_password("wrong-password", hashed) is False
+
+    def test_unicode_password(self) -> None:
+        from src.auth.passwords import hash_password, verify_password
+
+        password = "كلمة_المرور_العربية_123"
+        hashed = hash_password(password)
+        assert verify_password(password, hashed) is True
+
+
+class TestRateLimit:
+    """Unit tests for per-endpoint rate limiting."""
+
+    def test_rate_limit_allows_under_threshold(self) -> None:
+        from src.auth.rate_limit import check_rate_limit
+
+        with patch("src.auth.rate_limit.get_redis_client", return_value=None):
+            for _ in range(3):
+                assert check_rate_limit("test:127.0.0.1", max_requests=3) is True
+
+    def test_rate_limit_blocks_over_threshold(self) -> None:
+        from src.auth.rate_limit import check_rate_limit
+
+        with patch("src.auth.rate_limit.get_redis_client", return_value=None):
+            for _ in range(5):
+                check_rate_limit("test2:127.0.0.1", max_requests=5)
+            assert check_rate_limit("test2:127.0.0.1", max_requests=5) is False
+
+
+class TestRegisterRequestValidation:
+    """Unit tests for RegisterRequest model validation."""
+
+    def test_valid_request(self) -> None:
+        from src.auth.models import RegisterRequest
+
+        req = RegisterRequest(email="user@example.com", password="12345678", name="Test")
+        assert req.email == "user@example.com"
+
+    def test_email_normalized_lowercase(self) -> None:
+        from src.auth.models import RegisterRequest
+
+        req = RegisterRequest(email="User@Example.COM", password="12345678", name="Test")
+        assert req.email == "user@example.com"
+
+    def test_invalid_email_rejected(self) -> None:
+        from src.auth.models import RegisterRequest
+
+        with pytest.raises(Exception):
+            RegisterRequest(email="not-email", password="12345678", name="Test")
+
+    def test_short_password_rejected(self) -> None:
+        from src.auth.models import RegisterRequest
+
+        with pytest.raises(Exception):
+            RegisterRequest(email="user@example.com", password="short", name="Test")
+
+    def test_empty_name_rejected(self) -> None:
+        from src.auth.models import RegisterRequest
+
+        with pytest.raises(Exception):
+            RegisterRequest(email="user@example.com", password="12345678", name="   ")


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/auth/register` endpoint for email/password user creation with argon2id hashing
- Add `POST /api/v1/auth/login/email` endpoint for email/password authentication
- Add per-endpoint Redis-backed rate limiting (3/min register, 5/min login per IP, applied before hash computation)
- Add `UserPublic` response model that excludes `password_hash` from all API responses
- 26 new tests covering registration, login, rate limiting, password hashing, and security invariants

## Implementation Details
- `src/auth/passwords.py` — argon2id hashing with OWASP-recommended parameters (time_cost=2, memory_cost=19456)
- `src/auth/rate_limit.py` — sliding-window rate limiter with Redis backend and in-memory fallback
- `src/auth/models.py` — `RegisterRequest`, `EmailLoginRequest`, `UserPublic` models with validation
- `src/auth/pg_users.py` — `create_email_user()` and `get_user_by_email()` functions
- `src/api/routes/auth.py` — registration and login endpoints with httpOnly cookies
- `pyproject.toml` — `argon2-cffi>=23.1` dependency added

## Related Issues
Closes #425

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Kwame Asante <parametrization+Kwame.Asante@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>