### PR TITLE
fix(auth): LIKE injection + password_hash lifecycle (#443, #449)

### DIFF
--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class User(BaseModel):
@@ -13,12 +14,106 @@ class User(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     id: str
-    email: str
+    email: str | None = None
     name: str
     provider: str
     provider_user_id: str
     created_at: datetime
+    updated_at: datetime | None = None
     is_admin: bool = False
+    is_suspended: bool = False
+    role: str | None = None
+    password_hash: str | None = None
+
+
+class UserPublic(BaseModel):
+    """User response model that excludes password_hash."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    email: str | None = None
+    name: str
+    provider: str
+    provider_user_id: str
+    created_at: datetime
+    updated_at: datetime | None = None
+    is_admin: bool = False
+    is_suspended: bool = False
+    role: str | None = None
+
+    @staticmethod
+    def from_user(user: User) -> UserPublic:
+        """Create a UserPublic from a User, stripping password_hash."""
+        return UserPublic(
+            id=user.id,
+            email=user.email,
+            name=user.name,
+            provider=user.provider,
+            provider_user_id=user.provider_user_id,
+            created_at=user.created_at,
+            updated_at=user.updated_at,
+            is_admin=user.is_admin,
+            is_suspended=user.is_suspended,
+            role=user.role,
+        )
+
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+
+
+class RegisterRequest(BaseModel):
+    """Email/password registration request body."""
+
+    model_config = ConfigDict(frozen=True)
+
+    email: str
+    password: str
+    name: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        v = v.strip().lower()
+        if not _EMAIL_RE.match(v):
+            msg = "Invalid email format"
+            raise ValueError(msg)
+        if len(v) > 320:
+            msg = "Email must not exceed 320 characters"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            msg = "Password must be at least 8 characters"
+            raise ValueError(msg)
+        if len(v) > 128:
+            msg = "Password must not exceed 128 characters"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            msg = "Name must not be empty"
+            raise ValueError(msg)
+        if len(v) > 255:
+            msg = "Name must not exceed 255 characters"
+            raise ValueError(msg)
+        return v
+
+
+class EmailLoginRequest(BaseModel):
+    """Email/password login request body."""
+
+    model_config = ConfigDict(frozen=True)
+
+    email: str
+    password: str
 
 
 class TokenResponse(BaseModel):

--- a/src/auth/pg_users.py
+++ b/src/auth/pg_users.py
@@ -1,0 +1,208 @@
+"""PostgreSQL user storage — CRUD operations for the users table."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from src.auth.models import User
+from src.utils.pg_client import PgClient
+
+
+def _escape_like(s: str) -> str:
+    """Escape LIKE special characters (%, _, \\) in a search string."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def ensure_users_table(pg: PgClient) -> None:
+    """Create the users table and indexes (idempotent)."""
+    pg.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            email           VARCHAR(320),
+            name            VARCHAR(255) NOT NULL,
+            provider        VARCHAR(50) NOT NULL,
+            provider_user_id VARCHAR(255) NOT NULL,
+            password_hash   VARCHAR(255),
+            is_admin        BOOLEAN NOT NULL DEFAULT FALSE,
+            is_suspended    BOOLEAN NOT NULL DEFAULT FALSE,
+            role            VARCHAR(100),
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (provider, provider_user_id)
+        )
+    """)
+    pg.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_users_email ON users (email) WHERE email IS NOT NULL"
+    )
+
+
+def upsert_user(
+    pg: PgClient,
+    *,
+    provider: str,
+    provider_user_id: str,
+    email: str | None,
+    name: str,
+) -> User:
+    """Insert a new user or update name/email on conflict. Returns the user."""
+    rows = pg.execute(
+        """
+        INSERT INTO users (id, email, name, provider, provider_user_id)
+        VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT (provider, provider_user_id) DO UPDATE
+            SET email = COALESCE(EXCLUDED.email, users.email),
+                name = EXCLUDED.name,
+                updated_at = now()
+        RETURNING id, email, name, provider, provider_user_id,
+                  is_admin, is_suspended, role, created_at, updated_at
+        """,
+        (str(uuid.uuid4()), email, name, provider, provider_user_id),
+    )
+    return _row_to_user(rows[0])
+
+
+def get_user_by_id(pg: PgClient, user_id: str) -> User | None:
+    """Fetch a single user by UUID (excludes password_hash)."""
+    rows = pg.execute(
+        """
+        SELECT id, email, name, provider, provider_user_id,
+               is_admin, is_suspended, role, created_at, updated_at
+        FROM users WHERE id = %s
+        """,
+        (user_id,),
+    )
+    return _row_to_user(rows[0]) if rows else None
+
+
+def list_users(
+    pg: PgClient,
+    *,
+    page: int = 1,
+    limit: int = 20,
+    search: str | None = None,
+    role: str | None = None,
+) -> tuple[list[User], int]:
+    """Return a paginated list of users with optional filters."""
+    where_parts: list[str] = []
+    params: list[Any] = []
+
+    if search:
+        where_parts.append("(name ILIKE %s OR email ILIKE %s)")
+        like = f"%{_escape_like(search)}%"
+        params.extend([like, like])
+    if role:
+        where_parts.append("role = %s")
+        params.append(role)
+
+    where = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
+
+    count_rows = pg.execute(f"SELECT count(*) AS total FROM users {where}", tuple(params))
+    total: int = count_rows[0]["total"] if count_rows else 0
+
+    offset = (page - 1) * limit
+    rows = pg.execute(
+        f"""
+        SELECT id, email, name, provider, provider_user_id,
+               is_admin, is_suspended, role, created_at, updated_at
+        FROM users {where}
+        ORDER BY created_at DESC
+        OFFSET %s LIMIT %s
+        """,
+        (*params, offset, limit),
+    )
+    return [_row_to_user(r) for r in rows], total
+
+
+def update_user(
+    pg: PgClient,
+    user_id: str,
+    *,
+    is_admin: bool | None = None,
+    is_suspended: bool | None = None,
+    role: str | None = None,
+) -> User | None:
+    """Partial update of user fields. Returns updated user or None if not found."""
+    set_parts: list[str] = []
+    params: list[Any] = []
+
+    if is_admin is not None:
+        set_parts.append("is_admin = %s")
+        params.append(is_admin)
+    if is_suspended is not None:
+        set_parts.append("is_suspended = %s")
+        params.append(is_suspended)
+    if role is not None:
+        set_parts.append("role = %s")
+        params.append(role)
+
+    if not set_parts:
+        return get_user_by_id(pg, user_id)
+
+    set_parts.append("updated_at = now()")
+    params.append(user_id)
+
+    rows = pg.execute(
+        f"""
+        UPDATE users SET {", ".join(set_parts)}
+        WHERE id = %s
+        RETURNING id, email, name, provider, provider_user_id,
+                  is_admin, is_suspended, role, created_at, updated_at
+        """,
+        tuple(params),
+    )
+    return _row_to_user(rows[0]) if rows else None
+
+
+def create_email_user(
+    pg: PgClient,
+    *,
+    email: str,
+    name: str,
+    password_hash: str,
+) -> User:
+    """Create a new user with email/password provider. Returns the user.
+
+    Raises a duplicate-key error if the email already exists (caller should
+    catch and return 409).
+    """
+    rows = pg.execute(
+        """
+        INSERT INTO users (id, email, name, provider, provider_user_id, password_hash)
+        VALUES (%s, %s, %s, 'email', %s, %s)
+        RETURNING id, email, name, provider, provider_user_id,
+                  is_admin, is_suspended, role, created_at, updated_at
+        """,
+        (str(uuid.uuid4()), email, name, email, password_hash),
+    )
+    return _row_to_user(rows[0])
+
+
+def get_user_by_email(pg: PgClient, email: str) -> User | None:
+    """Fetch a user by email address (any provider)."""
+    rows = pg.execute(
+        """
+        SELECT id, email, name, provider, provider_user_id, password_hash,
+               is_admin, is_suspended, role, created_at, updated_at
+        FROM users WHERE email = %s
+        """,
+        (email,),
+    )
+    return _row_to_user(rows[0]) if rows else None
+
+
+def _row_to_user(row: dict[str, Any]) -> User:
+    """Convert a PG row dict to a User model."""
+    return User(
+        id=str(row["id"]),
+        email=row.get("email"),
+        name=row["name"],
+        provider=row["provider"],
+        provider_user_id=row["provider_user_id"],
+        password_hash=row.get("password_hash"),
+        is_admin=row.get("is_admin", False),
+        is_suspended=row.get("is_suspended", False),
+        role=row.get("role"),
+        created_at=row["created_at"],
+        updated_at=row.get("updated_at"),
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -69,7 +69,6 @@ class AuthSettings(BaseSettings):
     github_client_id: str = ""
     github_client_secret: str = ""
     oauth_redirect_base_url: str = "http://localhost:8000"
-    cookie_secure: bool = True
 
     model_config = SettingsConfigDict(env_prefix="AUTH_")
 
@@ -102,7 +101,7 @@ class AuthSettings(BaseSettings):
                 raise ValueError(
                     f"AUTH_JWT_SECRET must be at least 32 characters in production "
                     f"(got {len(self.jwt_secret)}). Generate one with: "
-                    f"python -c \"import secrets; print(secrets.token_urlsafe(32))\""
+                    f'python -c "import secrets; print(secrets.token_urlsafe(32))"'
                 )
         return self
 


### PR DESCRIPTION
## Summary

- **#443 — LIKE injection in admin user search:** Added `_escape_like()` helper that escapes `%`, `_`, and `\` in search strings before building ILIKE patterns in `list_users()`. Prevents wildcard-based enumeration or DoS via crafted search queries.
- **#449 — password_hash carried through request lifecycle:** Removed `password_hash` from all SELECT/RETURNING clauses except `get_user_by_email()` (the login path). Functions like `get_user_by_id()`, `list_users()`, `upsert_user()`, `update_user()`, and `create_email_user()` no longer fetch or return the hash. `_row_to_user()` gracefully handles the missing column via `row.get("password_hash")` returning `None`.
- **Prerequisite:** Brought `pg_users.py` and updated `models.py` (with `password_hash`, `UserPublic`, registration models) from `wave-2` since these files are required for the fixes.
- **Bonus:** Fixed duplicate `cookie_secure` field in `AuthSettings` that was causing mypy failures.

## Test plan

- [ ] Verify `list_users` with search containing `%` or `_` no longer matches as wildcards
- [ ] Verify `get_user_by_id` returns `User` with `password_hash=None`
- [ ] Verify `get_user_by_email` still returns `password_hash` for login verification
- [ ] Verify existing unit tests pass (`pytest-unit` hook passes)
- [ ] Verify mypy passes (duplicate `cookie_secure` fix)

Closes #443, Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)