### PR TITLE
fix(auth): read refresh token from httpOnly cookie (#455)

### DIFF
--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
 from src.api.middleware import require_auth
-from src.auth.models import RefreshRequest, User
+from src.auth.models import User
 from src.auth.providers import PROVIDERS, get_provider, retrieve_pkce_verifier, store_pkce_verifier
 from src.auth.tokens import create_access_token, create_refresh_token, revoke_token, verify_token
 from src.config import get_settings
@@ -117,10 +117,14 @@ async def callback(provider: str, code: str, state: str, request: Request) -> JS
 
 
 @router.post("/auth/refresh")
-def refresh(body: RefreshRequest) -> JSONResponse:
-    """Refresh an access token using a valid refresh token (with rotation)."""
+def refresh(request: Request) -> JSONResponse:
+    """Refresh an access token using the httpOnly refresh_token cookie (with rotation)."""
+    raw_token = request.cookies.get("refresh_token")
+    if not raw_token:
+        raise HTTPException(status_code=401, detail="Missing refresh token cookie")
+
     try:
-        payload = verify_token(body.refresh_token)
+        payload = verify_token(raw_token)
     except ValueError:
         raise HTTPException(status_code=401, detail="Invalid or expired refresh token")  # noqa: B904
 
@@ -132,7 +136,7 @@ def refresh(body: RefreshRequest) -> JSONResponse:
         raise HTTPException(status_code=401, detail="Invalid token payload")
 
     # Revoke the old refresh token (rotation)
-    revoked_ok = revoke_token(body.refresh_token)
+    revoked_ok = revoke_token(raw_token)
     if not revoked_ok:
         raise HTTPException(
             status_code=503,

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -133,11 +133,3 @@ class AuthorizationUrlResponse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     authorization_url: str
-
-
-class RefreshRequest(BaseModel):
-    """Refresh token request body."""
-
-    model_config = ConfigDict(frozen=True)
-
-    refresh_token: str

--- a/tests/test_auth/test_middleware.py
+++ b/tests/test_auth/test_middleware.py
@@ -75,10 +75,8 @@ class TestAuthMeEndpoint:
 class TestRefreshEndpoint:
     def test_refresh_returns_new_tokens(self, client: TestClient) -> None:
         refresh = create_refresh_token("my-user-id")
-        resp = client.post(
-            "/api/v1/auth/refresh",
-            json={"refresh_token": refresh},
-        )
+        client.cookies.set("refresh_token", refresh)
+        resp = client.post("/api/v1/auth/refresh")
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "ok"
@@ -88,17 +86,17 @@ class TestRefreshEndpoint:
         assert "access_token" in resp.cookies
         assert "refresh_token" in resp.cookies
 
+    def test_refresh_with_no_cookie(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/auth/refresh")
+        assert resp.status_code == 401
+
     def test_refresh_with_invalid_token(self, client: TestClient) -> None:
-        resp = client.post(
-            "/api/v1/auth/refresh",
-            json={"refresh_token": "garbage"},
-        )
+        client.cookies.set("refresh_token", "garbage")
+        resp = client.post("/api/v1/auth/refresh")
         assert resp.status_code == 401
 
     def test_refresh_with_access_token_rejected(self, client: TestClient) -> None:
         access = create_access_token("my-user-id")
-        resp = client.post(
-            "/api/v1/auth/refresh",
-            json={"refresh_token": access},
-        )
+        client.cookies.set("refresh_token", access)
+        resp = client.post("/api/v1/auth/refresh")
         assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Changed `/auth/refresh` endpoint to read the refresh token from the `refresh_token` httpOnly cookie instead of the JSON request body
- Removed `RefreshRequest` body model (no longer needed since JS can't access httpOnly cookies)
- Deleted unused `RefreshRequest` class from `src/auth/models.py`
- Updated all refresh endpoint tests to send tokens via cookies
- Added new test for missing cookie case (401)

Closes #455

## Test plan
- [x] `test_refresh_returns_new_tokens` — sends refresh token via cookie, expects 200 with new tokens in cookies
- [x] `test_refresh_with_no_cookie` — no cookie sent, expects 401
- [x] `test_refresh_with_invalid_token` — garbage cookie, expects 401
- [x] `test_refresh_with_access_token_rejected` — access token in refresh cookie, expects 401
- [x] All 638 unit tests pass
- [x] Lint (ruff), typecheck (mypy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)