### PR TITLE
fix(tech-debt): cookie helper, cached proxy CIDRs, narrow gitleaks, remove dead model

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,12 @@
-# Gitleaks configuration — allowlist for test fixtures
+# Gitleaks configuration — allowlist for test fixtures containing dummy secrets
 [allowlist]
   paths = [
-    '''tests/.*''',
+    '''tests/conftest\.py''',
+    '''tests/test_auth/conftest\.py''',
+    '''tests/test_auth/test_providers\.py''',
+    '''tests/test_config\.py''',
+    '''tests/test_api/test_admin_config\.py''',
+    '''tests/test_api/test_admin\.py''',
+    '''tests/test_parse/test_sunnah_parser\.py''',
+    '''tests/integration/conftest\.py''',
   ]

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -6,6 +6,7 @@ import ipaddress
 import time
 import uuid
 from datetime import UTC, datetime
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import structlog
@@ -83,20 +84,24 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-def _parse_trusted_proxies(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
-    """Parse a comma-separated list of trusted proxy CIDRs/IPs into network objects."""
+@lru_cache(maxsize=4)
+def _parse_trusted_proxies(raw: str) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    """Parse a comma-separated list of trusted proxy CIDRs/IPs into network objects.
+
+    Results are cached since the trusted_proxies setting is immutable at runtime.
+    """
     networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
     for entry in raw.split(","):
         entry = entry.strip()
         if not entry:
             continue
         networks.append(ipaddress.ip_network(entry, strict=False))
-    return networks
+    return tuple(networks)
 
 
 def _is_trusted_proxy(
     client_host: str,
-    trusted: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+    trusted: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...],
 ) -> bool:
     """Return True if *client_host* falls within any trusted proxy network."""
     try:

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -21,6 +21,31 @@ router = APIRouter()
 _OAUTH_STATE_COOKIE = "oauth_state"
 
 
+def _set_token_cookies(
+    response: Response, access_token: str, refresh_token: str
+) -> None:
+    """Set httpOnly access and refresh token cookies on a response."""
+    settings = get_settings().auth
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+        max_age=settings.access_token_expire_minutes * 60,
+        path="/",
+    )
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+        max_age=settings.refresh_token_expire_days * 86400,
+        path="/",
+    )
+
+
 def _build_redirect_uri(provider: str) -> str:
     """Build the OAuth callback redirect URI from settings."""
     base = get_settings().auth.oauth_redirect_base_url.rstrip("/")
@@ -87,30 +112,12 @@ async def callback(provider: str, code: str, state: str, request: Request) -> JS
 
     # Use provider + provider_user_id as the internal user ID
     user_id = f"{user_info.provider}:{user_info.provider_user_id}"
-    settings = get_settings().auth
 
     access_token = create_access_token(user_id)
     refresh_token = create_refresh_token(user_id)
 
     response = JSONResponse(content={"status": "ok"})
-    response.set_cookie(
-        key="access_token",
-        value=access_token,
-        httponly=True,
-        secure=settings.cookie_secure,
-        samesite="lax",
-        max_age=settings.access_token_expire_minutes * 60,
-        path="/",
-    )
-    response.set_cookie(
-        key="refresh_token",
-        value=refresh_token,
-        httponly=True,
-        secure=settings.cookie_secure,
-        samesite="lax",
-        max_age=settings.refresh_token_expire_days * 86400,
-        path="/",
-    )
+    _set_token_cookies(response, access_token, refresh_token)
     # Clear the one-time-use oauth_state cookie
     response.delete_cookie(_OAUTH_STATE_COOKIE, path="/")
     return response
@@ -143,29 +150,11 @@ def refresh(request: Request) -> JSONResponse:
             detail="Token revocation service unavailable — refresh rejected for safety",
         )
 
-    settings = get_settings().auth
     new_access = create_access_token(user_id)
     new_refresh = create_refresh_token(user_id)
 
     response = JSONResponse(content={"status": "ok"})
-    response.set_cookie(
-        key="access_token",
-        value=new_access,
-        httponly=True,
-        secure=settings.cookie_secure,
-        samesite="lax",
-        max_age=settings.access_token_expire_minutes * 60,
-        path="/",
-    )
-    response.set_cookie(
-        key="refresh_token",
-        value=new_refresh,
-        httponly=True,
-        secure=settings.cookie_secure,
-        samesite="lax",
-        max_age=settings.refresh_token_expire_days * 86400,
-        path="/",
-    )
+    _set_token_cookies(response, new_access, new_refresh)
     return response
 
 

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -125,11 +125,3 @@ class TokenResponse(BaseModel):
     refresh_token: str
     token_type: str = "bearer"
     expires_in: int
-
-
-class AuthorizationUrlResponse(BaseModel):
-    """Authorization URL for OAuth redirect."""
-
-    model_config = ConfigDict(frozen=True)
-
-    authorization_url: str


### PR DESCRIPTION
## Summary

- **#456**: Remove unused `AuthorizationUrlResponse` model from `src/auth/models.py`
- **#457**: Extract `_set_token_cookies()` helper in `src/api/routes/auth.py` — cookie attributes (httpOnly, secure, samesite, path, max_age) now defined in one place, used by both callback and refresh endpoints
- **#458**: Add `@lru_cache(maxsize=4)` to `_parse_trusted_proxies()` in `src/api/middleware.py` — CIDR parsing now happens once per unique config string instead of per-request; return type changed to tuple for cache safety
- **#459**: Narrow `.gitleaks.toml` allowlist from `tests/.*` to 8 specific fixture files that contain dummy secrets

Closes #456, #457, #458, #459

## Test plan

- [ ] Verify `_set_token_cookies` is called in both callback and refresh endpoints
- [ ] Confirm `_parse_trusted_proxies` caching works (same input returns cached result)
- [ ] Run gitleaks to confirm allowlist still passes on real test files
- [ ] Verify `AuthorizationUrlResponse` has no remaining consumers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)