### PR TITLE
feat(skills): /wave-kickoff, /wave-retro, /team-reset, /wave-audit

### DIFF
--- a/.claude/skills/team-reset.md
+++ b/.claude/skills/team-reset.md
@@ -1,0 +1,107 @@
+---
+name: team-reset
+description: Transparent team teardown and recreation — handles unresponsive agents, reports roster changes
+---
+
+Handle the team teardown/create lifecycle for the isnad-graph project.
+
+## Instructions
+
+### 1. Report current team state
+
+Read the current team roster from `.claude/team/roster/` and report to the user:
+
+```
+**Current team: isnad-graph**
+| Role | Name | Status |
+|------|------|--------|
+| Manager | Fatima Okonkwo | Active |
+| ... | ... | ... |
+```
+
+List all active roster members with their roles and status.
+
+### 2. Send shutdown requests
+
+Send a `shutdown_request` message to ALL active agents:
+
+```json
+{"type": "shutdown_request", "reason": "Team reset initiated"}
+```
+
+Wait 5 seconds for agents to acknowledge.
+
+### 3. Force teardown if needed
+
+If `TeamDelete` fails with "Cannot cleanup team with N active members":
+
+1. Report to user: "Force teardown required — {N} agents unresponsive"
+2. Manually edit the config file to remove stale members:
+   ```bash
+   # Read current config
+   cat ~/.claude/teams/isnad-graph/config.json
+   # Keep only team-lead entry, remove all others
+   ```
+3. Retry `TeamDelete`
+
+### 4. Delete the team
+
+Call `TeamDelete` for team `isnad-graph`. Report success or failure to user.
+
+```
+**Team deleted:** isnad-graph
+- Agents terminated: {count}
+- Force removal required: {yes/no}
+```
+
+### 5. Create new team
+
+Read all roster files in `.claude/team/roster/` to build the new roster. Call `TeamCreate` for team `isnad-graph`.
+
+Report to user:
+
+```
+**Team created:** isnad-graph
+| Role | Name | Status |
+|------|------|--------|
+| Manager | Fatima Okonkwo | Active |
+| ... | ... | ... |
+```
+
+### 6. Highlight roster changes
+
+If there are differences between the old and new team (hires, departures, role changes), explicitly report them:
+
+```
+**Roster changes:**
+- DEPARTED: {name} ({role}) — {reason}
+- HIRED: {name} ({role}) — replacing {departed name}
+- ROLE CHANGE: {name} — {old role} → {new role}
+```
+
+If no changes: "Roster unchanged from previous team."
+
+### 7. Ready confirmation
+
+Confirm the team is ready for work:
+
+```
+Team `isnad-graph` is ready. {N} members active.
+Proceed with agent spawning when ready.
+```
+
+## What remains manual
+
+- The orchestrating Claude instance must still spawn individual agents (agents cannot self-spawn)
+- Roster file changes (hires/fires) must be committed separately
+- The user may override the roster before TeamCreate if desired
+
+## Emergency override
+
+If the skill fails entirely, the manual fallback is:
+
+```bash
+# Remove stale config
+rm ~/.claude/teams/isnad-graph/config.json
+# Recreate via TeamCreate
+```

--- a/.claude/skills/wave-audit.md
+++ b/.claude/skills/wave-audit.md
@@ -1,0 +1,98 @@
+---
+name: wave-audit
+description: Audit open issues against merged PRs — find and close orphaned issues with proper comments
+args: Phase number, Wave number
+---
+
+Audit open issues for a wave and close any that were resolved but not auto-closed.
+
+## Instructions
+
+### 1. List merged PRs for the wave
+
+```bash
+gh pr list --state merged --base "deployments/phase{N}/wave-{M}" --json number,title,body,headRefName
+```
+
+### 2. Extract issue references from PRs
+
+For each merged PR, parse the body for:
+- `Closes #N`
+- `Fixes #N`
+- `Resolves #N`
+
+Build a map: `{issue_number → [PR_number, PR_title]}`.
+
+### 3. List open issues for the wave
+
+```bash
+gh issue list --state open --label "p{N}-wave-{M}" --json number,title,labels
+```
+
+### 4. Identify orphans
+
+An orphan is an open issue that:
+- Is labeled with the wave label (`p{N}-wave-{M}`)
+- Was referenced by a merged PR's `Closes`/`Fixes`/`Resolves` but was not auto-closed
+
+Cross-reference the two lists. Also check for issues that may have been implemented but the PR forgot to include the `Closes` reference — match by branch name pattern:
+
+```
+{FirstInitial}.{LastName}/{ISSUE_NUMBER}-*
+```
+
+### 5. Report findings to user
+
+Present a table before taking action:
+
+```
+**Wave Audit: Phase {N} Wave {M}**
+
+| Issue | Title | Status | Implementing PR | Action |
+|-------|-------|--------|-----------------|--------|
+| #123  | ...   | Open   | PR #456         | Close  |
+| #789  | ...   | Open   | (none found)    | Keep   |
+
+**Orphans found:** {count}
+**Issues with no implementing PR:** {count}
+```
+
+**Do NOT close any issues until the user confirms.** Present the list and wait for approval.
+
+### 6. Close confirmed orphans
+
+For each confirmed orphan, close with a comment:
+
+```bash
+gh issue close {NUMBER} --comment "$(cat <<'EOF'
+Requestor: Fatima.Okonkwo
+Requestee: N/A
+RequestOrReplied: Request
+
+Closed by wave audit. This issue was resolved by PR #{PR_NUMBER} ({PR_TITLE}) which merged to `deployments/phase{N}/wave-{M}`.
+
+Added label: `fixed-in-phase{N}-wave{M}`
+EOF
+)"
+```
+
+Add the `fixed-in-phase{N}-wave{M}` label:
+
+```bash
+gh issue edit {NUMBER} --add-label "fixed-in-phase{N}-wave-{M}"
+```
+
+### 7. Report summary
+
+```
+**Audit complete:**
+- Issues closed: {count}
+- Issues remaining open: {count} (no implementing PR found)
+- Issues already closed: {count} (correctly auto-closed)
+```
+
+## What remains manual
+
+- User must approve all closures before they execute
+- Issues with no implementing PR require manual triage (defer, reassign, or close as won't-fix)
+- The skill does not verify that the PR actually implemented the issue — it relies on `Closes #N` references and branch naming conventions

--- a/.claude/skills/wave-kickoff.md
+++ b/.claude/skills/wave-kickoff.md
@@ -1,0 +1,95 @@
+---
+name: wave-kickoff
+description: Automated wave planning — branch creation, label management, issue labeling, kickoff comments, and execution plan
+args: Phase number, Wave number
+---
+
+Automate the wave kickoff process for the isnad-graph project.
+
+## Instructions
+
+### 1. Create the deployments branch
+
+```bash
+git fetch origin
+git checkout main && git pull origin main
+git checkout -b deployments/phase{N}/wave-{M}
+git push -u origin deployments/phase{N}/wave-{M}
+```
+
+If the branch already exists, check it out and pull latest instead.
+
+### 2. Create wave label
+
+Check if label `p{N}-wave-{M}` exists:
+
+```bash
+gh label list --search "p{N}-wave-{M}"
+```
+
+If missing, create it:
+
+```bash
+gh label create "p{N}-wave-{M}" --description "Phase {N} Wave {M}" --color "8B5CF6"
+```
+
+### 3. Collect issue list and assignments
+
+Prompt the user for:
+- List of issue numbers for this wave
+- Assignee for each issue (FIRSTNAME_LASTNAME label)
+- Peer review pairings (reviewer for each engineer)
+
+Validate all assignee labels exist before proceeding:
+
+```bash
+gh label list --search "FIRSTNAME"
+```
+
+Create any missing labels before applying.
+
+### 4. Label all issues
+
+For each issue, apply the wave label and assignee label:
+
+```bash
+gh issue edit {NUMBER} --add-label "p{N}-wave-{M}" --add-label "{FIRSTNAME_LASTNAME}"
+```
+
+### 5. Post kickoff comments
+
+Post a kickoff comment on each issue using charter format:
+
+```
+Requestor: Fatima.Okonkwo
+Requestee: {Assignee.Name}
+RequestOrReplied: Request
+
+**Wave {M} Kickoff — Phase {N}**
+
+This issue is assigned to you for p{N}-wave-{M}.
+- Peer reviewer: {reviewer name}
+- Branch from: `deployments/phase{N}/wave-{M}`
+- Branch naming: `{FirstInitial}.{LastName}/{IIII}-{issue-slug}`
+- Priority: {hotfix|security|bug|feature} (per charter § Wave Planning & Priority)
+
+Please begin implementation.
+```
+
+### 6. Output execution plan
+
+Generate and display a structured execution plan with:
+- **Priority ordering:** hotfixes first, then security fixes, then bugs, then features (per charter § Wave Planning & Priority)
+- **Issue table:** number, title, assignee, reviewer, priority tier
+- **Dependencies:** any cross-PR dependencies identified
+- **Estimated parallelism:** which issues can run concurrently
+
+### 7. Report
+
+Present the full plan to the user. Do NOT begin implementation until the user approves.
+
+## What remains manual
+
+- User must approve the execution plan before implementation starts
+- User decides which issues to include in the wave
+- Cross-team dependency resolution still requires lead coordination

--- a/.claude/skills/wave-retro.md
+++ b/.claude/skills/wave-retro.md
@@ -1,0 +1,115 @@
+---
+name: wave-retro
+description: Automated wave retrospective — PR analysis, assessments, trust matrix updates, feedback log, charter change proposals
+args: Phase number, Wave number
+---
+
+Run a retrospective for a completed wave of the isnad-graph project.
+
+## Instructions
+
+### 1. Gather merged PRs
+
+List all PRs merged to the wave's deployments branch:
+
+```bash
+gh pr list --state merged --base "deployments/phase{N}/wave-{M}" --json number,title,author,body,mergedAt,reviews
+```
+
+### 2. Gather review comments and CI data
+
+For each merged PR:
+
+```bash
+gh pr view {NUMBER} --json reviews,comments
+gh run list --branch {PR_BRANCH} --json conclusion,name
+```
+
+Collect:
+- Review comments (must-fix items, tech-debt items)
+- CI pass/fail counts per PR
+- Time from PR creation to merge
+
+### 3. Per-engineer assessment
+
+For each engineer who had PRs in this wave, assess:
+
+- **Positive findings:** clean PRs, fast turnaround, good reviews given, helpful collaboration
+- **Negative findings:** CI failures, must-fix items from reviews, late delivery, missing tests
+- **Severity:** minor / moderate / severe (per charter § Feedback System)
+
+Structure as:
+
+```
+### {Engineer Name}
+- PRs: #{N1}, #{N2}
+- CI failures: {count}
+- Must-fix items received: {count}
+- Tech-debt items created: {count}
+- Assessment: {positive/negative findings}
+- Severity: {minor|moderate|severe|none}
+```
+
+### 4. Update trust matrix
+
+Checkout the trust matrix branch and update:
+
+```bash
+git fetch origin CEO/0000-Trust_Matrix
+git checkout CEO/0000-Trust_Matrix
+```
+
+Update `.claude/team/trust_matrix.md` with directional trust changes based on wave performance:
+- Reliable delivery, clean reviews → increase trust (+1, max 5)
+- CI failures, must-fix items, broken commitments → decrease trust (-1, min 1)
+- No significant signal → no change
+
+Add change log entries with date and reason. Commit as Fatima Okonkwo, push, then return to the working branch.
+
+### 5. Append to feedback log
+
+Append a retro entry to `.claude/team/feedback_log.md`:
+
+```markdown
+## Retrospective: Phase {N} Wave {M} — {DATE}
+
+### Team Performance
+{summary of wave metrics: PRs merged, issues closed, CI health}
+
+### Per-Engineer Assessments
+{from step 3}
+
+### Top 3 Going Well
+1. {finding}
+2. {finding}
+3. {finding}
+
+### Top 3 Pain Points
+1. {finding}
+2. {finding}
+3. {finding}
+
+### Proposed Process Changes
+1. {change} — Rationale: {why}
+2. {change} — Rationale: {why}
+```
+
+### 6. Propose charter changes
+
+Based on pain points and findings, propose specific charter amendments. Present each as:
+
+```
+**Proposed change:** {what to change in charter}
+**Section:** {which charter section}
+**Rationale:** {why, based on retro findings}
+```
+
+### 7. Present to user for approval
+
+Display all proposed changes. **Do NOT apply any charter changes without explicit user approval.** The user decides which proposals to adopt, modify, or reject.
+
+## What remains manual
+
+- User must approve all charter changes before they are applied
+- Subjective assessment calibration (severity levels) may need user override
+- Trust matrix changes are proposed — user can veto specific adjustments

--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -669,3 +669,86 @@ After every wave completes and the deployments branch is PR'd to main:
 1. Scan `docs/`, `docs/diagrams/`, and `README.md` against the changes in the PR.
 2. Update any stale diagrams or documentation.
 3. The System Architect (Renaud) owns diagram accuracy; the Manager owns doc accuracy.
+
+## Automated Skills (Claude Code)
+
+The following Claude Code skills automate recurring team processes. Each skill is a markdown file in `.claude/skills/` and is invoked via `/skill-name` in Claude Code.
+
+### `/wave-kickoff` — Automated Wave Planning
+
+**Skill file:** `.claude/skills/wave-kickoff.md`
+
+**Replaces manual steps in:** § Branching Rules (deployments branch creation), § Wave Planning & Priority (priority ordering), § GitHub Label Hygiene (label creation/validation), § Implementation Kickoff & Issue Assignment (labeling and kickoff comments).
+
+**What is automated:**
+- Deployments branch creation from main
+- Wave label creation and validation
+- Issue labeling (wave label + assignee label)
+- Kickoff comments on each issue with reviewer assignments
+- Execution plan generation with priority ordering (hotfixes → security → bugs → features)
+
+**What remains manual:**
+- User must approve the execution plan before implementation starts
+- User decides which issues to include in the wave
+- Cross-team dependency resolution still requires lead coordination
+
+**Emergency override:** Skip the skill and perform each step manually using `gh` CLI commands per § Branching Rules and § Implementation Kickoff & Issue Assignment.
+
+### `/wave-retro` — Automated Wave Retrospective
+
+**Skill file:** `.claude/skills/wave-retro.md`
+
+**Replaces manual steps in:** § Wave Retrospectives (retro conversations, consolidation, process change proposals), § Feedback System (trust matrix updates, feedback logging), § Trust Identity Matrix (directional score adjustments).
+
+**What is automated:**
+- Merged PR and review comment collection
+- Per-engineer performance assessment (CI failures, must-fix counts, delivery quality)
+- Trust matrix updates on `CEO/0000-Trust_Matrix` branch
+- Feedback log append to `.claude/team/feedback_log.md`
+- Charter change proposals based on retro findings
+
+**What remains manual:**
+- User must approve all charter changes before they are applied
+- Subjective severity calibration may need user override
+- User can veto specific trust matrix adjustments
+
+**Emergency override:** Run the retro manually per § Wave Retrospectives — Manager spawns retro conversations with leads, consolidates findings, presents to user.
+
+### `/team-reset` — Transparent Team Lifecycle Management
+
+**Skill file:** `.claude/skills/team-reset.md`
+
+**Replaces manual steps in:** § Team Lifecycle (TeamCreate / TeamDelete) (teardown transparency, force teardown, roster change reporting).
+
+**What is automated:**
+- Current team roster reporting to user
+- Shutdown requests to all active agents
+- Force teardown of unresponsive agents (config file cleanup)
+- TeamDelete and TeamCreate calls
+- Roster change highlighting (departures, hires, role changes)
+
+**What remains manual:**
+- The orchestrating Claude instance must still spawn individual agents after team creation
+- Roster file changes (hires/fires) must be committed separately
+- User may override the roster before TeamCreate
+
+**Emergency override:** Manually remove the config file (`~/.claude/teams/isnad-graph/config.json`) and recreate via TeamCreate.
+
+### `/wave-audit` — Close Orphaned Issues After Wave
+
+**Skill file:** `.claude/skills/wave-audit.md`
+
+**Replaces manual steps in:** § Issue Hygiene (close condition enforcement), § Bug Closure (closing issues when fix PRs merge).
+
+**What is automated:**
+- Cross-referencing merged PRs against open issues for the wave
+- Identifying orphans (implemented but not auto-closed) via `Closes #N` references and branch naming
+- Closing orphans with proper comments and `fixed-in-phase{N}-wave{M}` labels
+- Summary reporting of audit results
+
+**What remains manual:**
+- User must approve all closures before they execute
+- Issues with no implementing PR require manual triage
+- The skill relies on `Closes #N` references and branch naming — it does not verify implementation content
+
+**Emergency override:** Run `gh issue list --state open --label "p{N}-wave-{M}"` and close issues manually with `gh issue close`.


### PR DESCRIPTION
## Summary

- Add four Claude Code skills automating recurring team processes: `/wave-kickoff` (wave planning), `/wave-retro` (retrospectives), `/team-reset` (team lifecycle), `/wave-audit` (orphan issue closure)
- Update charter with new § Automated Skills section documenting what each skill replaces, what remains manual, and emergency override procedures

## Related Issues

Closes #497
Closes #498
Closes #499
Closes #500

## Details

| Skill | File | Replaces |
|-------|------|----------|
| `/wave-kickoff` | `.claude/skills/wave-kickoff.md` | Manual branch creation, label management, issue labeling, kickoff comments |
| `/wave-retro` | `.claude/skills/wave-retro.md` | Manual retro conversations, trust matrix updates, feedback logging |
| `/team-reset` | `.claude/skills/team-reset.md` | Manual TeamDelete/TeamCreate with force-teardown |
| `/wave-audit` | `.claude/skills/wave-audit.md` | Manual cross-referencing of merged PRs against open issues |

All four skills preserve user approval gates — no destructive actions without confirmation.

## Review Checklist

- [x] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Hiro Tanaka <parametrization+Hiro.Tanaka@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>