### PR TITLE
fix(test): fix pre-commit hooks blocking all engineers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,7 @@
 #   3. gitleaks (secret detection)
 #   4. pip-audit (CVE scan)
 #   5. mypy type checking
-#   6. Unit tests
-#   7. Integration tests
+#   6. Unit tests (integration/e2e excluded — require Docker)
 #
 # Prerequisites:
 #   - Python 3.14+ with uv
@@ -72,14 +71,10 @@ repos:
 
       - id: pytest-unit
         name: pytest-unit
-        entry: uv run pytest tests/ -x --tb=short -q -m "not integration and not e2e"
+        entry: bash -c 'ENVIRONMENT=test uv run pytest tests/ -x --tb=short -q -m "not integration and not e2e"'
         language: system
         pass_filenames: false
         stages: [pre-commit]
 
-      - id: pytest-integration
-        name: pytest-integration
-        entry: uv run pytest tests/integration/ -x --tb=short -q -m integration
-        language: system
-        pass_filenames: false
-        stages: [pre-commit]
+      # Integration tests require Docker (Neo4j, PostgreSQL) — run in CI only.
+      # To run locally: make infra && ENVIRONMENT=test uv run pytest tests/integration/ -m integration


### PR DESCRIPTION
## Summary
- Add `ENVIRONMENT=test` to pre-commit `pytest-unit` hook entry so settings initialize correctly
- Remove `pytest-integration` from pre-commit — integration tests require Docker (Neo4j, PostgreSQL) and should only run in CI
- All 642 unit tests pass cleanly via pre-commit

## Test plan
- [x] `uv run pytest tests/ -m "not integration and not e2e"` — 642 passed
- [x] Pre-commit hooks pass on this very PR
- [ ] CI passes

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
