### PR TITLE
feat(security): harden security headers and CORS (#492)

### DIFF
--- a/docs/security/security-headers-cors-audit.md
+++ b/docs/security/security-headers-cors-audit.md
@@ -1,0 +1,100 @@
+# Security Headers & CORS Audit Report
+
+**Date:** 2026-03-29
+**Auditor:** Yara Hadid, Senior Security Engineer
+**Issue:** #492
+**Scope:** All HTTP responses from the isnad-graph FastAPI application
+**Reference:** OWASP Secure Headers Project, MDN Web Security Guidelines
+
+---
+
+## 1. Executive Summary
+
+This audit reviewed the security headers and CORS configuration on the isnad-graph API.
+Seven findings were identified (3 High, 3 Medium, 1 Low). All have been remediated in this PR.
+
+---
+
+## 2. CORS Configuration
+
+### 2.1 Findings
+
+| Setting | Before | After | Severity |
+|---------|--------|-------|----------|
+| `allow_origins` | `settings.cors_origins` (default `["http://localhost:3000"]`) | Unchanged | OK -- no wildcard |
+| `allow_credentials` | `True` | Unchanged | OK -- required for cookie-based refresh tokens |
+| `allow_methods` | `["GET", "POST"]` | `["GET", "POST", "PATCH", "OPTIONS"]` | **Medium** -- missing PATCH for admin routes |
+| `allow_headers` | `["*"]` | `["Authorization", "Content-Type", "Accept", "X-Request-ID"]` | **Medium** -- wildcard weakens CORS |
+
+### 2.2 Verification Checklist
+
+- [x] No wildcard `*` in `allow_origins` (uses explicit list from `Settings.cors_origins`)
+- [x] Preflight OPTIONS from allowed origin returns correct `Access-Control-Allow-Origin`
+- [x] Preflight from disallowed origin receives no ACAO header
+- [x] `Access-Control-Allow-Credentials: true` is present
+- [x] PATCH method is allowed in preflight response (required by admin config endpoint)
+- [x] Authorization header is explicitly allowed
+- [x] No wildcard in `allow_headers`
+
+---
+
+## 3. Security Response Headers
+
+### 3.1 Audit Matrix
+
+| Header | Before | After | Severity | Rationale |
+|--------|--------|-------|----------|-----------|
+| `X-Content-Type-Options` | `nosniff` | `nosniff` | OK | Prevents MIME-type sniffing |
+| `X-Frame-Options` | `DENY` | `DENY` | OK | Prevents clickjacking |
+| `X-XSS-Protection` | `1; mode=block` | `0` | **High** | Legacy XSS Auditor introduces cross-site leak vectors (OWASP recommends `0`; CSP provides real protection) |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` | `max-age=63072000; includeSubDomains; preload` | **Medium** | Added `preload` directive for HSTS preload list eligibility |
+| `Content-Security-Policy` | `default-src 'self'` | `default-src 'self'; frame-ancestors 'none'` | **Medium** | `frame-ancestors 'none'` provides defense-in-depth with X-Frame-Options |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | `strict-origin-when-cross-origin` | OK | Appropriate for API |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | `camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()` | **Low** | Extended to cover Payment, USB, and FLoC |
+| `Cross-Origin-Opener-Policy` | **Missing** | `same-origin` | **High** | Spectre mitigation -- prevents cross-origin window references |
+| `Cross-Origin-Resource-Policy` | **Missing** | `same-origin` | **High** | Spectre mitigation -- prevents cross-origin resource loading |
+
+### 3.2 Headers Not Added (Intentional)
+
+| Header | Reason |
+|--------|--------|
+| `Cross-Origin-Embedder-Policy` | Would break cross-origin API consumption from the React SPA |
+| `Expect-CT` | Deprecated; Certificate Transparency is enforced by browsers by default |
+
+---
+
+## 4. Configuration
+
+All security headers are configurable via the `SECURITY_` environment variable prefix
+(see `SecurityHeaderSettings` in `src/config.py`). This allows per-environment tuning
+(e.g., relaxing CSP in development).
+
+New configurable fields added:
+- `SECURITY_X_XSS_PROTECTION` (default `0`)
+- `SECURITY_HSTS_PRELOAD` (default `True`)
+- `SECURITY_CROSS_ORIGIN_OPENER_POLICY` (default `same-origin`)
+- `SECURITY_CROSS_ORIGIN_RESOURCE_POLICY` (default `same-origin`)
+
+---
+
+## 5. Test Coverage
+
+| Test Class | Count | Description |
+|------------|-------|-------------|
+| `TestSecurityHeaders` | 11 | All OWASP headers including COOP, CORP, extended Permissions-Policy |
+| `TestCORSConfiguration` | 6 | Origin allowlisting, credentials, PATCH method, explicit headers |
+| `TestRateLimiting` | 1 | 429 response on exceeded limit |
+| `TestRequestSizeLimits` | 1 | 413 response on oversized body |
+
+All tests pass.
+
+---
+
+## 6. Risk Summary
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| Critical | 0 | -- |
+| High | 3 | Remediated |
+| Medium | 3 | Remediated |
+| Low | 1 | Remediated |

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -142,8 +142,8 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=settings.cors_origins,
         allow_credentials=True,
-        allow_methods=["GET", "POST"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "Accept", "X-Request-ID"],
     )
     from src.api.routes import (
         auth,

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -47,14 +47,18 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = self._cfg.x_frame_options
-        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["X-XSS-Protection"] = self._cfg.x_xss_protection
         hsts = f"max-age={self._cfg.hsts_max_age}"
         if self._cfg.hsts_include_subdomains:
             hsts += "; includeSubDomains"
+        if self._cfg.hsts_preload:
+            hsts += "; preload"
         response.headers["Strict-Transport-Security"] = hsts
         response.headers["Content-Security-Policy"] = self._cfg.content_security_policy
         response.headers["Referrer-Policy"] = self._cfg.referrer_policy
         response.headers["Permissions-Policy"] = self._cfg.permissions_policy
+        response.headers["Cross-Origin-Opener-Policy"] = self._cfg.cross_origin_opener_policy
+        response.headers["Cross-Origin-Resource-Policy"] = self._cfg.cross_origin_resource_policy
         return response
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -66,12 +66,18 @@ class AuthSettings(BaseSettings):
 class SecurityHeaderSettings(BaseSettings):
     """Configurable security headers. Production defaults; override for dev."""
 
-    content_security_policy: str = "default-src 'self'"
+    content_security_policy: str = "default-src 'self'; frame-ancestors 'none'"
     hsts_max_age: int = 63072000
     hsts_include_subdomains: bool = True
+    hsts_preload: bool = True
     x_frame_options: str = "DENY"
+    x_xss_protection: str = "0"
     referrer_policy: str = "strict-origin-when-cross-origin"
-    permissions_policy: str = "camera=(), microphone=(), geolocation=()"
+    permissions_policy: str = (
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
+    )
+    cross_origin_opener_policy: str = "same-origin"
+    cross_origin_resource_policy: str = "same-origin"
 
     model_config = SettingsConfigDict(env_prefix="SECURITY_")
 

--- a/tests/test_auth/test_security.py
+++ b/tests/test_auth/test_security.py
@@ -90,17 +90,20 @@ class TestSecurityHeaders:
 
     def test_x_xss_protection(self, client: TestClient) -> None:
         resp = client.get("/health")
-        assert resp.headers.get("x-xss-protection") == "1; mode=block"
+        assert resp.headers.get("x-xss-protection") == "0"
 
     def test_strict_transport_security(self, client: TestClient) -> None:
         resp = client.get("/health")
         hsts = resp.headers.get("strict-transport-security", "")
         assert "max-age=" in hsts
         assert "includeSubDomains" in hsts
+        assert "preload" in hsts
 
     def test_content_security_policy(self, client: TestClient) -> None:
         resp = client.get("/health")
-        assert resp.headers.get("content-security-policy") == "default-src 'self'"
+        csp = resp.headers.get("content-security-policy", "")
+        assert "default-src 'self'" in csp
+        assert "frame-ancestors 'none'" in csp
 
     def test_referrer_policy(self, client: TestClient) -> None:
         resp = client.get("/health")
@@ -108,13 +111,96 @@ class TestSecurityHeaders:
 
     def test_permissions_policy(self, client: TestClient) -> None:
         resp = client.get("/health")
-        assert "camera=()" in resp.headers.get("permissions-policy", "")
+        pp = resp.headers.get("permissions-policy", "")
+        assert "camera=()" in pp
+        assert "microphone=()" in pp
+        assert "geolocation=()" in pp
+        assert "payment=()" in pp
+
+    def test_cross_origin_opener_policy(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.headers.get("cross-origin-opener-policy") == "same-origin"
+
+    def test_cross_origin_resource_policy(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.headers.get("cross-origin-resource-policy") == "same-origin"
 
     def test_headers_on_api_endpoint(self, client: TestClient) -> None:
         """Security headers should be present on API routes too."""
         resp = client.get("/api/v1/narrators")
         assert resp.headers.get("x-content-type-options") == "nosniff"
         assert resp.headers.get("x-frame-options") == "DENY"
+        assert resp.headers.get("cross-origin-opener-policy") == "same-origin"
+
+
+# --- CORS Configuration ---
+
+
+class TestCORSConfiguration:
+    """Verify CORS middleware is configured securely."""
+
+    def test_allowed_origin_reflected(self, client: TestClient) -> None:
+        """Allowed origin gets reflected in Access-Control-Allow-Origin."""
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    def test_disallowed_origin_rejected(self, client: TestClient) -> None:
+        """Disallowed origin does not get an Access-Control-Allow-Origin header."""
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") is None
+
+    def test_credentials_allowed(self, client: TestClient) -> None:
+        """Access-Control-Allow-Credentials is true for allowed origins."""
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-credentials") == "true"
+
+    def test_no_wildcard_origin(self, client: TestClient) -> None:
+        """CORS must never reflect a wildcard origin."""
+        resp = client.get("/health", headers={"Origin": "http://localhost:3000"})
+        assert resp.headers.get("access-control-allow-origin") != "*"
+
+    def test_patch_method_allowed(self, client: TestClient) -> None:
+        """PATCH method should be allowed for admin endpoints."""
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "PATCH",
+            },
+        )
+        allowed = resp.headers.get("access-control-allow-methods", "")
+        assert "PATCH" in allowed
+
+    def test_explicit_allow_headers(self, client: TestClient) -> None:
+        """Allow-Headers should list specific headers, not wildcard."""
+        resp = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "Authorization",
+            },
+        )
+        allowed = resp.headers.get("access-control-allow-headers", "")
+        assert "authorization" in allowed.lower()
 
 
 # --- Rate Limiting ---


### PR DESCRIPTION
## Summary

- **X-XSS-Protection** changed from `1; mode=block` to `0` per OWASP recommendation (legacy XSS Auditor introduces cross-site leak vectors; CSP provides the actual protection)
- **HSTS** extended with `preload` directive for HSTS preload list eligibility
- **CSP** extended with `frame-ancestors 'none'` for defense-in-depth alongside X-Frame-Options
- **Cross-Origin-Opener-Policy** (`same-origin`) and **Cross-Origin-Resource-Policy** (`same-origin`) added as Spectre mitigations -- these were completely missing
- **Permissions-Policy** extended to also restrict `payment`, `usb`, and `interest-cohort`
- **CORS `allow_headers`** changed from wildcard `["*"]` to explicit allowlist `["Authorization", "Content-Type", "Accept", "X-Request-ID"]`
- **CORS `allow_methods`** extended with `PATCH` and `OPTIONS` (PATCH is needed by admin config endpoint)
- All new header values are configurable via `SECURITY_` env prefix
- Audit report at `docs/security/security-headers-cors-audit.md`

Closes #492

## Test plan

- [x] 801 unit tests pass (8 new: 2 COOP/CORP header tests, 6 CORS tests)
- [x] Existing security header tests updated for new values
- [x] CORS tests verify: allowed/disallowed origins, credentials, PATCH method, explicit headers, no wildcard
- [x] Ruff lint and format pass
- [x] mypy passes
- [ ] Verify headers with `curl -I` against staging deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
