### PR TITLE
fix(acquire): update broken Sanadset and Thaqalayn data sources

### DIFF
--- a/src/acquire/sanadset.py
+++ b/src/acquire/sanadset.py
@@ -1,11 +1,15 @@
-"""Download the Sanadset hadith dataset and narrators dataset from Kaggle.
+"""Download the Sanadset hadith dataset from Mendeley Data (primary) or Kaggle (fallback).
 
 Datasets:
-- ``fahd09/hadith-dataset`` — ~650K hadiths with XML-style SANAD/MATN/NAR tags
-- ``fahd09/hadith-narrators`` — narrator biographies
+- Mendeley Data ``5xth87zwb5`` v4 — sanadset.csv (~650K hadiths), books.csv
+- Kaggle ``fahd09/hadith-dataset`` — same data (removed/intermittent as of early 2026)
+- Kaggle ``fahd09/hadith-narrators`` — narrator biographies (24K+)
 
-Requires either ``KAGGLE_USERNAME`` + ``KAGGLE_KEY`` in settings/.env, or a
-valid ``~/.kaggle/kaggle.json`` file.
+The Kaggle datasets (``fahd09/hadith-dataset`` and ``fahd09/hadith-narrators``) were
+removed or made private circa early 2026. Mendeley Data hosts the same Sanadset
+corpus (DOI: 10.17632/5xth87zwb5.4) with stable public download URLs and is now
+the primary acquisition path. Kaggle is retained as a fallback for the narrators
+dataset, which is not available on Mendeley.
 """
 
 from __future__ import annotations
@@ -14,7 +18,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from src.acquire.base import ensure_dir, write_manifest
+from src.acquire.base import download_file, ensure_dir, write_manifest
 from src.config import get_settings
 from src.utils.logging import get_logger
 
@@ -22,7 +26,31 @@ logger = get_logger(__name__)
 
 __all__ = ["download_sanadset"]
 
-_HADITH_DATASET = "fahd09/hadith-dataset"
+# Mendeley Data — Sanadset 650K v4 (DOI: 10.17632/5xth87zwb5.4)
+_MENDELEY_DATASET_ID = "5xth87zwb5"
+_MENDELEY_FILES_API = (
+    f"https://data.mendeley.com/api/datasets/{_MENDELEY_DATASET_ID}/files?version=4"
+)
+_MENDELEY_FILES: dict[str, dict[str, str]] = {
+    "sanadset.csv": {
+        "id": "fe0857fa-73af-4873-b652-60eb7347b811",
+        "sha256": "bbe4fd3d9ef797a78c9ddfdc7d31a9d2185c2f7efa0ecee75c9fc46b6dcfb5b3",
+        "url": (
+            "https://data.mendeley.com/public-files/datasets/5xth87zwb5/files/"
+            "fe0857fa-73af-4873-b652-60eb7347b811/file_downloaded"
+        ),
+    },
+    "books.csv": {
+        "id": "a09faa74-5d63-4baf-82cf-6e139dcea579",
+        "sha256": "0e6d45ce409e8fb8d9a246f2ed3d773237a1acc779e9f55b0c026efe87757924",
+        "url": (
+            "https://data.mendeley.com/public-files/datasets/5xth87zwb5/files/"
+            "a09faa74-5d63-4baf-82cf-6e139dcea579/file_downloaded"
+        ),
+    },
+}
+
+# Kaggle fallback (narrators only — not available on Mendeley)
 _NARRATORS_DATASET = "fahd09/hadith-narrators"
 _SUBPROCESS_TIMEOUT = 600
 _MIN_EXPECTED_ROWS = 600_000
@@ -43,6 +71,23 @@ def _kaggle_credentials_available() -> bool:
             return False
 
     return False
+
+
+def _download_mendeley(dest: Path) -> list[Path]:
+    """Download Sanadset CSV files from Mendeley Data. Returns saved paths."""
+    saved: list[Path] = []
+    for filename, meta in _MENDELEY_FILES.items():
+        file_path = dest / filename
+        logger.info("mendeley_download_start", filename=filename)
+        download_file(
+            meta["url"],
+            file_path,
+            expected_sha256=meta["sha256"],
+            timeout=600.0,
+        )
+        saved.append(file_path)
+        logger.info("mendeley_download_complete", filename=filename, size=file_path.stat().st_size)
+    return saved
 
 
 def _run_kaggle_download(dataset: str, dest: Path) -> None:
@@ -85,7 +130,10 @@ def _count_csv_rows(directory: Path) -> int:
 
 
 def download_sanadset(dest: Path | None = None) -> Path:
-    """Download Sanadset hadith + narrators datasets from Kaggle.
+    """Download Sanadset hadith + narrators datasets.
+
+    Primary source is Mendeley Data (public, no credentials required).
+    Narrator biographies are downloaded from Kaggle if credentials are available.
 
     Parameters
     ----------
@@ -100,44 +148,45 @@ def download_sanadset(dest: Path | None = None) -> Path:
     Raises
     ------
     RuntimeError
-        If Kaggle credentials are not available or validation fails.
+        If Mendeley download fails and no fallback succeeds.
     """
-    if not _kaggle_credentials_available():
-        msg = (
-            "Kaggle credentials not found. Set KAGGLE_USERNAME + KAGGLE_KEY in .env "
-            "or create ~/.kaggle/kaggle.json"
-        )
-        raise RuntimeError(msg)
-
     settings = get_settings()
     if dest is None:
         dest = settings.data_raw_dir / "sanadset"
     dest = ensure_dir(dest)
 
-    # Download hadith dataset (idempotent: skip if CSV files already present)
+    # Step 1: Download hadith data from Mendeley (primary source)
     hadith_csvs = list(dest.glob("*.csv"))
     if hadith_csvs:
-        logger.info("download_skipped", dataset=_HADITH_DATASET, reason="csv_files_exist")
+        logger.info("download_skipped", source="mendeley", reason="csv_files_exist")
     else:
-        _run_kaggle_download(_HADITH_DATASET, dest)
+        _download_mendeley(dest)
 
-    # Download narrators dataset to subdirectory
+    # Step 2: Download narrators from Kaggle (if credentials available)
     narrators_dir = ensure_dir(dest / "narrators")
     narrators_csvs = list(narrators_dir.glob("*.csv"))
     if narrators_csvs:
         logger.info("download_skipped", dataset=_NARRATORS_DATASET, reason="csv_files_exist")
+    elif _kaggle_credentials_available():
+        try:
+            _run_kaggle_download(_NARRATORS_DATASET, narrators_dir)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            logger.warning(
+                "narrators_download_failed",
+                dataset=_NARRATORS_DATASET,
+                note="Kaggle dataset may be unavailable; narrator biographies will be missing",
+            )
     else:
-        _run_kaggle_download(_NARRATORS_DATASET, narrators_dir)
+        logger.warning(
+            "narrators_skipped",
+            reason="no_kaggle_credentials",
+            note="Narrator biographies require Kaggle credentials; skipping",
+        )
 
-    # Validate: CSV files exist
+    # Validate: hadith CSV files exist
     hadith_csvs = list(dest.glob("*.csv"))
     if not hadith_csvs:
-        msg = f"No CSV files found in {dest} after downloading {_HADITH_DATASET}"
-        raise RuntimeError(msg)
-
-    narrators_csvs = list(narrators_dir.glob("*.csv"))
-    if not narrators_csvs:
-        msg = f"No CSV files found in {narrators_dir} after downloading {_NARRATORS_DATASET}"
+        msg = f"No CSV files found in {dest} after Mendeley download"
         raise RuntimeError(msg)
 
     # Validate: minimum row count for hadith data
@@ -148,6 +197,8 @@ def download_sanadset(dest: Path | None = None) -> Path:
             total_rows=total_rows,
             expected_min=_MIN_EXPECTED_ROWS,
         )
+
+    narrators_csvs = list(narrators_dir.glob("*.csv"))
 
     logger.info(
         "sanadset_download_complete",

--- a/src/acquire/thaqalayn.py
+++ b/src/acquire/thaqalayn.py
@@ -1,157 +1,61 @@
-"""Acquire hadith data from the Thaqalayn API.
+"""Acquire hadith data from the Thaqalayn GitHub repository.
 
-Fetches Shia hadith collections via the Thaqalayn REST API (v2).
-Falls back to cloning the ThaqalaynAPI GitHub repository if the API
-returns too many consecutive server errors.
+Fetches Shia hadith collections by cloning the MohammedArab1/ThaqalaynAPI
+GitHub repository. The Thaqalayn REST API v2 was removed circa early 2026
+when the website was rebuilt with Next.js — the GitHub repo is now the
+primary acquisition method.
 """
 
 from __future__ import annotations
 
-import json
-import time
 from pathlib import Path
-from typing import Any
-
-import httpx
-from tenacity import retry, stop_after_attempt, wait_exponential
 
 from src.acquire.base import clone_repo, ensure_dir, write_manifest
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-THAQALAYN_API_BASE = "https://thaqalayn.net/api/v2"
 THAQALAYN_GITHUB_URL = "https://github.com/MohammedArab1/ThaqalaynAPI.git"
-REQUEST_DELAY_S = 0.5
-MAX_CONSECUTIVE_5XX = 5
 MIN_EXPECTED_BOOKS = 15
 
 
-@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=30))
-def _fetch_json(url: str, client: httpx.Client) -> dict[str, Any] | list[Any]:
-    """Fetch JSON with retry. Raises on HTTP error so tenacity can retry."""
-    response = client.get(url)
-    response.raise_for_status()
-    result: dict[str, Any] | list[Any] = response.json()
-    return result
-
-
-def _download_via_api(dest: Path, client: httpx.Client) -> list[Path]:
-    """Download all books via the Thaqalayn API. Returns list of saved files."""
-    allbooks_url = f"{THAQALAYN_API_BASE}/allbooks"
-    logger.info("thaqalayn_fetching_allbooks", url=allbooks_url)
-    allbooks = _fetch_json(allbooks_url, client)
-
-    allbooks_path = dest / "allbooks.json"
-    allbooks_path.write_text(json.dumps(allbooks, ensure_ascii=False, indent=2), encoding="utf-8")
-    saved: list[Path] = [allbooks_path]
-
-    books: list[Any]
-    if isinstance(allbooks, dict):
-        books = allbooks.get("data", allbooks.get("books", [])) or []
-    elif isinstance(allbooks, list):
-        books = allbooks
-    else:
-        books = []
-
-    logger.info("thaqalayn_books_found", count=len(books))
-    consecutive_5xx = 0
-
-    for book in books:
-        book_id = book.get("id") or book.get("bookId") or book.get("_id")
-        if book_id is None:
-            logger.warning("thaqalayn_book_no_id", book=book)
-            continue
-
-        book_path = dest / f"book_{book_id}.json"
-        if book_path.exists() and book_path.stat().st_size > 0:
-            saved.append(book_path)
-            consecutive_5xx = 0
-            continue
-
-        time.sleep(REQUEST_DELAY_S)
-
-        try:
-            url = f"{THAQALAYN_API_BASE}/hadith/{book_id}"
-            data = _fetch_json(url, client)
-            book_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-            saved.append(book_path)
-            consecutive_5xx = 0
-            logger.info("thaqalayn_book_downloaded", book_id=book_id)
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code >= 500:
-                consecutive_5xx += 1
-                logger.warning(
-                    "thaqalayn_5xx",
-                    book_id=book_id,
-                    status=exc.response.status_code,
-                    consecutive=consecutive_5xx,
-                )
-                if consecutive_5xx >= MAX_CONSECUTIVE_5XX:
-                    logger.error("thaqalayn_circuit_breaker_tripped")
-                    raise
-            else:
-                logger.warning(
-                    "thaqalayn_http_error",
-                    book_id=book_id,
-                    status=exc.response.status_code,
-                )
-
-    return saved
-
-
 def _download_via_github(dest: Path) -> list[Path]:
-    """Clone the ThaqalaynAPI repo as fallback. Returns JSON files found."""
+    """Clone the ThaqalaynAPI repo. Returns JSON files found."""
     github_dest = dest / "github_clone"
     clone_repo(THAQALAYN_GITHUB_URL, github_dest)
     json_files = list(github_dest.rglob("*.json"))
-    logger.info("thaqalayn_github_fallback", file_count=len(json_files))
+    logger.info("thaqalayn_github_clone", file_count=len(json_files))
     return json_files
 
 
 def run(raw_dir: Path) -> Path:
-    """Download Thaqalayn data. Uses API first, falls back to GitHub clone."""
+    """Download Thaqalayn data via GitHub clone."""
     dest = ensure_dir(raw_dir / "thaqalayn")
 
     # Check for idempotent skip: already have enough book JSONs
     existing_books = list(dest.glob("book_*.json"))
-    if len(existing_books) >= MIN_EXPECTED_BOOKS:
+    github_clone = dest / "github_clone"
+    github_jsons = list(github_clone.rglob("*.json")) if github_clone.exists() else []
+    if len(existing_books) >= MIN_EXPECTED_BOOKS or len(github_jsons) >= MIN_EXPECTED_BOOKS:
+        all_files = existing_books or github_jsons
         logger.info(
             "thaqalayn_skipped",
             reason="already_acquired",
-            book_count=len(existing_books),
+            file_count=len(all_files),
         )
-        write_manifest(dest, existing_books)
+        write_manifest(dest, all_files)
         return dest
 
-    client = httpx.Client(
-        headers={"User-Agent": "isnad-graph/1.0 (hadith-research)"},
-        timeout=60.0,
-        follow_redirects=True,
-    )
+    saved = _download_via_github(dest)
 
-    try:
-        saved = _download_via_api(dest, client)
-    except Exception:
-        logger.warning("thaqalayn_api_failed_falling_back_to_github")
-        saved = _download_via_github(dest)
-    finally:
-        client.close()
-
-    book_files = [f for f in saved if f.name.startswith("book_")]
-    if len(book_files) < MIN_EXPECTED_BOOKS:
-        # API may have partially succeeded; try GitHub fallback
-        if not (dest / "github_clone").exists():
-            logger.warning("thaqalayn_insufficient_books_trying_github", count=len(book_files))
-            github_files = _download_via_github(dest)
-            saved.extend(github_files)
-            book_files = [f for f in saved if f.name.startswith("book_")]
-
-    all_json = [f for f in saved if f.suffix == ".json"]
-    if len(book_files) < MIN_EXPECTED_BOOKS:
-        msg = f"Expected >= {MIN_EXPECTED_BOOKS} book JSONs, found {len(book_files)}"
+    json_files = [f for f in saved if f.suffix == ".json"]
+    if len(json_files) < MIN_EXPECTED_BOOKS:
+        msg = (
+            f"Expected >= {MIN_EXPECTED_BOOKS} JSON files from GitHub clone, "
+            f"found {len(json_files)}"
+        )
         raise AssertionError(msg)
 
-    write_manifest(dest, all_json)
-    logger.info("thaqalayn_acquired", book_count=len(book_files), total_files=len(all_json))
+    write_manifest(dest, json_files)
+    logger.info("thaqalayn_acquired", total_files=len(json_files))
     return dest


### PR DESCRIPTION
## Summary

- **Sanadset (#557):** Kaggle datasets `fahd09/hadith-dataset` and `fahd09/hadith-narrators` were removed/made private. Switched primary download to Mendeley Data (DOI: 10.17632/5xth87zwb5.4) which hosts the same 650K CSV corpus with stable public URLs and SHA-256 integrity checks. Kaggle retained as optional fallback for narrators only.
- **Thaqalayn (#558):** REST API v2 (`thaqalayn.net/api/v2`) removed when site was rebuilt with Next.js. Removed dead API code and made GitHub clone (`MohammedArab1/ThaqalaynAPI`) the sole acquisition method, eliminating unnecessary latency from failed API attempts.

Closes #557
Closes #558

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `mypy` strict mode passes
- [x] `pytest` unit tests pass
- [ ] Integration: run `isnad acquire thaqalayn` — should clone from GitHub directly without API attempt
- [ ] Integration: run `isnad acquire sanadset` — should download from Mendeley Data without Kaggle credentials
- [ ] Verify SHA-256 checksums match for downloaded Mendeley files

🤖 Generated with [Claude Code](https://claude.com/claude-code)