### PR TITLE
feat(data): pipeline smoke test for 3 healthy sources

### DIFF
--- a/docs/data/pipeline-smoke-results.md
+++ b/docs/data/pipeline-smoke-results.md
@@ -1,0 +1,69 @@
+# Pipeline Smoke Test Results
+
+**Date:** 2026-03-29
+**Runner:** Rashid Osei-Mensah
+**Script:** `scripts/pipeline_smoke.py`
+**Sources tested:** open_hadith, lk_corpus, muhaddithat
+
+## Summary
+
+| Source | Acquire | Parse | Validate | Notes |
+|--------|---------|-------|----------|-------|
+| open_hadith | PASS | PASS | PASS | 124,320 hadiths parsed, schema valid |
+| lk_corpus | PASS | FAIL | -- | Per-chapter CSV structure not matched by parser |
+| muhaddithat | PASS | FAIL | -- | Narrator CSV filename (`variousnarrators.csv`) not matched by parser |
+
+**Overall: 1/3 sources fully passing end-to-end.**
+
+## Detailed Results
+
+### open_hadith (PASS)
+
+- **Acquire:** 0.47s -- shallow-cloned 18 CSV files from `mhashim6/Open-Hadith-Data`
+- **Parse:** 0.84s -- produced `hadiths_open_hadith.parquet` with 124,320 rows
+- **Validate:** Schema conforms to `HADITH_SCHEMA` (16 columns, all types correct)
+- **Warning:** No diacritics-specific CSVs detected (filenames lack "tashkeel"/"diacritics"); parser fell back to all 18 CSVs. `text_col` resolved to `None` for all files, meaning text is stored in `full_text_ar` via fallback rather than `matn_ar`.
+
+### lk_corpus (FAIL at parse)
+
+- **Acquire:** Succeeded (initial attempt timed out at 120s default; manual retry with longer timeout succeeded). Repository contains per-book directories (`Bukhari/`, `Muslim/`, `AbuDaud/`, `Tirmizi/`, `Nesai/`, `IbnMaja/`) with per-chapter CSVs (e.g., `Chapter1.csv`, `Chapter2.csv`).
+- **Parse failure:** The parser's `_derive_collection_name()` function maps filenames like `albukhari.csv` to canonical names. Per-chapter filenames like `Chapter1.csv` do not match any entry in `FILENAME_TO_COLLECTION`, so all CSVs are skipped with `lk_unknown_csv` warnings. The parser then finds 0 hadiths and raises `FileNotFoundError`.
+- **Root cause:** The LK corpus repository structure changed from single-file-per-book to per-chapter files. The parser needs to derive the collection name from the **parent directory** (e.g., `Bukhari/Chapter1.csv` -> `bukhari`) rather than the filename alone.
+- **Recommended fix:** Update `_derive_collection_name()` to check `csv_path.parent.name` against a directory-to-collection mapping when the filename does not match.
+
+### muhaddithat (FAIL at parse)
+
+- **Acquire:** 0.55s -- shallow-cloned `muhaddithat/isnad-datasets`. Found 2 data CSV files: `data/hadiths.csv` and `data/variousnarrators.csv`.
+- **Parse failure:** The parser searches for narrator CSVs matching `narrators.csv`, `scholars.csv`, or `narrator*.csv` (glob). The actual file is named `variousnarrators.csv`, which does not match `narrator*.csv` because glob requires the pattern to match from the start of the filename.
+- **Root cause:** The glob pattern `narrator*.csv` matches `narrator_foo.csv` but not `variousnarrators.csv`. The pattern needs to be `*narrator*.csv` to match embedded occurrences.
+- **Recommended fix:** Add `*narrator*.csv` or `variousnarrators.csv` to the search patterns in `muhaddithat.py:247-249`.
+
+## Timing
+
+| Stage | open_hadith | lk_corpus | muhaddithat |
+|-------|-------------|-----------|-------------|
+| Acquire | 0.47s (cached) | ~5s (cached) | 0.55s (cached) |
+| Parse | 0.84s | N/A | N/A |
+| Validate | 0.01s | N/A | N/A |
+| **Total** | **1.32s** | -- | -- |
+
+Note: First-run acquire times are significantly longer due to git clone operations. The LK corpus clone timed out at the default 120s timeout on first attempt.
+
+## Data Quality Observations
+
+1. **open_hadith text column detection:** The parser's diacritics filename filter (`tashkeel`/`diacritics`) found zero matches, suggesting the upstream repo may have changed its naming conventions. All 18 CSVs were parsed via the fallback path.
+
+2. **open_hadith column mapping:** `text_col` resolved to `None` for all parsed CSVs, meaning hadith text was stored in `full_text_ar` rather than `matn_ar`. This may affect downstream consumers that expect `matn_ar` to be populated.
+
+3. **LK corpus clone timeout:** The default 120s clone timeout is insufficient for the LK Hadith Corpus repository. Consider increasing the timeout or implementing partial/sparse checkout for large repos.
+
+4. **LK corpus structure change:** The repository now uses per-chapter CSVs within book directories instead of single files per book. This is a breaking change for the parser.
+
+5. **muhaddithat narrator file naming:** The narrator file is named `variousnarrators.csv` instead of the expected `narrators.csv`. The glob patterns in the parser are too restrictive.
+
+## Recommendations
+
+1. **P0 -- Fix LK parser:** Update `_derive_collection_name()` to handle per-chapter CSV structures by mapping parent directory names to collection names.
+2. **P0 -- Fix muhaddithat parser:** Add `*narrator*.csv` to the search patterns for narrator CSV files.
+3. **P1 -- Fix open_hadith text mapping:** Investigate CSV column headers and update `_TEXT_COLUMNS` candidates if needed so that `matn_ar` is populated instead of `full_text_ar`.
+4. **P2 -- Increase clone timeout:** Make the git clone timeout configurable or increase the default for large repositories like LK.

--- a/scripts/pipeline_smoke.py
+++ b/scripts/pipeline_smoke.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Pipeline smoke test: acquire, parse, and validate 3 healthy data sources.
+
+Sources tested (no API keys required):
+  - open_hadith  (GitHub clone, CSV)
+  - lk_corpus    (GitHub clone, CSV)
+  - muhaddithat  (GitHub clone, CSV)
+
+Usage:
+    uv run python scripts/pipeline_smoke.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+
+# ---------------------------------------------------------------------------
+# Schemas for validation
+# ---------------------------------------------------------------------------
+from src.parse.schemas import (
+    COLLECTION_SCHEMA,
+    HADITH_SCHEMA,
+    NARRATOR_BIO_SCHEMA,
+    NARRATOR_MENTION_SCHEMA,
+    NETWORK_EDGE_SCHEMA,
+)
+
+EXPECTED_SCHEMAS: dict[str, Any] = {
+    "hadiths_": HADITH_SCHEMA,
+    "narrator_mentions_": NARRATOR_MENTION_SCHEMA,
+    "narrators_bio_": NARRATOR_BIO_SCHEMA,
+    "collections_": COLLECTION_SCHEMA,
+    "network_edges_": NETWORK_EDGE_SCHEMA,
+}
+
+SOURCES = ["open_hadith", "lk", "muhaddithat"]
+
+# Mapping from source name to acquire module attribute name
+SOURCE_MODULE_MAP = {
+    "open_hadith": "open_hadith",
+    "lk": "lk_corpus",
+    "muhaddithat": "muhaddithat",
+}
+
+
+@dataclass
+class StageResult:
+    """Result of a single pipeline stage for a single source."""
+
+    source: str
+    stage: str
+    success: bool
+    duration_s: float = 0.0
+    error: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def _match_schema(filename: str) -> tuple[str, Any] | None:
+    for prefix, schema in EXPECTED_SCHEMAS.items():
+        if filename.startswith(prefix):
+            return prefix, schema
+    return None
+
+
+def _check_schema(table_schema: Any, expected_schema: Any) -> list[str]:
+    issues: list[str] = []
+    expected_names = {f.name for f in expected_schema}
+    actual_names = {f.name for f in table_schema}
+    missing = expected_names - actual_names
+    extra = actual_names - expected_names
+    if missing:
+        issues.append(f"Missing columns: {sorted(missing)}")
+    if extra:
+        issues.append(f"Extra columns: {sorted(extra)}")
+    for fld in expected_schema:
+        if fld.name in actual_names:
+            actual_field = table_schema.field(fld.name)
+            if actual_field.type != fld.type:
+                issues.append(
+                    f"Column '{fld.name}' type mismatch: "
+                    f"expected {fld.type}, got {actual_field.type}"
+                )
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Acquire stage
+# ---------------------------------------------------------------------------
+def acquire_source(source: str, raw_dir: Path) -> StageResult:
+    """Download a single source into raw_dir."""
+    mod_name = SOURCE_MODULE_MAP[source]
+    module = __import__(f"src.acquire.{mod_name}", fromlist=[mod_name])
+
+    t0 = time.monotonic()
+    try:
+        dest = module.run(raw_dir)
+        elapsed = time.monotonic() - t0
+        file_count = len(list(dest.rglob("*"))) if dest and dest.exists() else 0
+        return StageResult(
+            source=source,
+            stage="acquire",
+            success=True,
+            duration_s=round(elapsed, 2),
+            details={"output_dir": str(dest), "file_count": file_count},
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        return StageResult(
+            source=source,
+            stage="acquire",
+            success=False,
+            duration_s=round(elapsed, 2),
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parse stage
+# ---------------------------------------------------------------------------
+def parse_source(source: str, raw_dir: Path, staging_dir: Path) -> StageResult:
+    """Parse a single source from raw_dir into staging_dir."""
+    mod_name = SOURCE_MODULE_MAP[source]
+    module = __import__(f"src.parse.{mod_name}", fromlist=[mod_name])
+
+    t0 = time.monotonic()
+    try:
+        result = module.run(raw_dir, staging_dir)
+        elapsed = time.monotonic() - t0
+
+        # Normalize result to list of paths
+        if isinstance(result, list | tuple):
+            paths = list(result)
+        elif isinstance(result, dict):
+            paths = list(result.values())
+        else:
+            paths = [result]
+
+        file_details: list[dict[str, Any]] = []
+        for p in paths:
+            if p and p.exists():
+                meta = pq.read_metadata(p)
+                file_details.append({"file": p.name, "rows": meta.num_rows})
+
+        return StageResult(
+            source=source,
+            stage="parse",
+            success=True,
+            duration_s=round(elapsed, 2),
+            details={"files": file_details, "file_count": len(paths)},
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        return StageResult(
+            source=source,
+            stage="parse",
+            success=False,
+            duration_s=round(elapsed, 2),
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Validate stage (schema conformance on produced Parquet files)
+# ---------------------------------------------------------------------------
+def validate_source(source: str, staging_dir: Path) -> StageResult:
+    """Validate Parquet outputs for a source against expected PyArrow schemas."""
+    t0 = time.monotonic()
+    try:
+        # Find parquet files belonging to this source
+        suffix = source
+        parquet_files = [f for f in sorted(staging_dir.glob("*.parquet")) if suffix in f.name]
+        if not parquet_files:
+            elapsed = time.monotonic() - t0
+            return StageResult(
+                source=source,
+                stage="validate",
+                success=False,
+                duration_s=round(elapsed, 2),
+                error="No Parquet files found for source",
+            )
+
+        all_issues: dict[str, list[str]] = {}
+        file_summaries: list[dict[str, Any]] = []
+
+        for pf in parquet_files:
+            table = pq.read_table(pf)
+            match = _match_schema(pf.name)
+            issues: list[str] = []
+            if match:
+                _, expected = match
+                issues = _check_schema(table.schema, expected)
+            else:
+                issues = ["No matching expected schema"]
+
+            all_issues[pf.name] = issues
+            file_summaries.append(
+                {
+                    "file": pf.name,
+                    "rows": table.num_rows,
+                    "columns": len(table.column_names),
+                    "schema_ok": len(issues) == 0,
+                    "issues": issues,
+                }
+            )
+
+        all_ok = all(len(v) == 0 for v in all_issues.values())
+        elapsed = time.monotonic() - t0
+        return StageResult(
+            source=source,
+            stage="validate",
+            success=all_ok,
+            duration_s=round(elapsed, 2),
+            details={"files": file_summaries},
+            error=None if all_ok else "Schema validation issues found",
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        return StageResult(
+            source=source,
+            stage="validate",
+            success=False,
+            duration_s=round(elapsed, 2),
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    project_root = Path(__file__).resolve().parent.parent
+    raw_dir = project_root / "data" / "raw"
+    staging_dir = project_root / "data" / "staging"
+
+    # Create dirs
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[StageResult] = []
+    overall_start = time.monotonic()
+
+    print("=" * 70)
+    print("PIPELINE SMOKE TEST")
+    print(f"Sources: {', '.join(SOURCES)}")
+    print(f"Raw dir: {raw_dir}")
+    print(f"Staging dir: {staging_dir}")
+    print("=" * 70)
+
+    for source in SOURCES:
+        print(f"\n{'---' * 17}")
+        print(f"Source: {source}")
+        print(f"{'---' * 17}")
+
+        # Acquire
+        print(f"  [acquire] downloading {source}...")
+        acq = acquire_source(source, raw_dir)
+        results.append(acq)
+        status = "OK" if acq.success else "FAIL"
+        print(f"  [acquire] {status} ({acq.duration_s}s)")
+        if not acq.success:
+            print(f"  [acquire] Error: {acq.error}")
+            continue
+
+        # Parse
+        print(f"  [parse]   parsing {source}...")
+        par = parse_source(source, raw_dir, staging_dir)
+        results.append(par)
+        status = "OK" if par.success else "FAIL"
+        print(f"  [parse]   {status} ({par.duration_s}s)")
+        if par.success and par.details.get("files"):
+            for fd in par.details["files"]:
+                print(f"            {fd['file']}: {fd['rows']:,} rows")
+        if not par.success:
+            print(f"  [parse]   Error: {par.error}")
+            continue
+
+        # Validate
+        print(f"  [validate] checking schemas for {source}...")
+        val = validate_source(source, staging_dir)
+        results.append(val)
+        status = "OK" if val.success else "FAIL"
+        print(f"  [validate] {status} ({val.duration_s}s)")
+        if val.details.get("files"):
+            for fs in val.details["files"]:
+                schema_status = "OK" if fs["schema_ok"] else "ISSUES"
+                print(
+                    f"             {fs['file']}: {fs['rows']:,} rows, "
+                    f"{fs['columns']} cols, schema={schema_status}"
+                )
+                for issue in fs.get("issues", []):
+                    print(f"               - {issue}")
+
+    # Summary
+    overall_elapsed = round(time.monotonic() - overall_start, 2)
+    print(f"\n{'=' * 70}")
+    print("SUMMARY")
+    print(f"{'=' * 70}")
+    print(f"Total time: {overall_elapsed}s\n")
+
+    # Group by source
+    for source in SOURCES:
+        source_results = [r for r in results if r.source == source]
+        statuses = []
+        for r in source_results:
+            mark = "PASS" if r.success else "FAIL"
+            statuses.append(f"{r.stage}={mark}")
+        print(f"  {source:15s}  {', '.join(statuses)}")
+
+    failures = [r for r in results if not r.success]
+    print()
+    if failures:
+        print(f"RESULT: {len(failures)} failure(s)")
+        return 1
+    print("RESULT: All stages passed for all sources")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `scripts/pipeline_smoke.py` to run acquire-parse-validate against 3 no-API-key sources (open_hadith, lk_corpus, muhaddithat)
- Document smoke test findings in `docs/data/pipeline-smoke-results.md`
- Surfaced 2 parser bugs: LK per-chapter CSV structure mismatch and muhaddithat narrator filename glob mismatch

## Test plan

- [x] Run `uv run python scripts/pipeline_smoke.py` -- open_hadith passes all 3 stages; lk and muhaddithat acquire successfully but fail at parse due to upstream data structure changes
- [x] Verify `ruff check` and `ruff format` pass on `scripts/pipeline_smoke.py`
- [x] All pre-commit hooks pass

Closes #533

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
