### PR TITLE
fix(parse): lk_corpus dir-based CSVs + muhaddithat narrator glob

### DIFF
--- a/src/parse/lk_corpus.py
+++ b/src/parse/lk_corpus.py
@@ -76,10 +76,29 @@ def _strip_html(text: str | None) -> str | None:
     return text.strip() or None
 
 
-def _derive_collection_name(filename: str) -> str | None:
-    """Derive canonical collection name from CSV filename."""
-    stem = filename.rsplit(".", maxsplit=1)[0].lower()
-    return FILENAME_TO_COLLECTION.get(stem)
+# Parent directory -> canonical collection name mapping (new per-chapter layout).
+DIRNAME_TO_COLLECTION: dict[str, str] = {
+    "bukhari": "bukhari",
+    "muslim": "muslim",
+    "abudaud": "abu_dawud",
+    "tirmizi": "tirmidhi",
+    "nesai": "nasai",
+    "ibnmaja": "ibn_majah",
+}
+
+
+def _derive_collection_name(csv_path: Path) -> str | None:
+    """Derive canonical collection name from CSV path.
+
+    Checks the filename first (old flat-file layout), then falls back to
+    the parent directory name (new per-chapter layout).
+    """
+    stem = csv_path.stem.lower()
+    result = FILENAME_TO_COLLECTION.get(stem)
+    if result is not None:
+        return result
+    # Fall back to parent directory name.
+    return DIRNAME_TO_COLLECTION.get(csv_path.parent.name.lower())
 
 
 def _invalid_row_handler(row: pcsv.InvalidRow) -> str:
@@ -223,7 +242,7 @@ def run(raw_dir: Path, staging_dir: Path) -> list[Path]:
     collection_rows: list[dict[str, object]] = []
 
     for csv_path in csv_files:
-        collection_name = _derive_collection_name(csv_path.name)
+        collection_name = _derive_collection_name(csv_path)
         if collection_name is None:
             logger.warning("lk_unknown_csv", path=str(csv_path))
             continue

--- a/src/parse/muhaddithat.py
+++ b/src/parse/muhaddithat.py
@@ -243,7 +243,7 @@ def run(raw_dir: Path, staging_dir: Path) -> tuple[Path, Path]:
     hadiths_path = _find_csv(source_dir, "hadiths.csv")
 
     # Try to find a narrator/scholars CSV.
-    narrator_csv_names = ["narrators.csv", "scholars.csv", "narrator*.csv"]
+    narrator_csv_names = ["narrators.csv", "scholars.csv", "narrator*.csv", "*narrator*.csv"]
     narrators_path: Path | None = None
     for pattern in narrator_csv_names:
         matches = list(source_dir.rglob(pattern))

--- a/tests/test_parse/test_lk_parser.py
+++ b/tests/test_parse/test_lk_parser.py
@@ -80,6 +80,46 @@ def _sample_rows() -> list[list[str]]:
     ]
 
 
+class TestDeriveCollectionName:
+    """Tests for directory-based and filename-based collection name derivation."""
+
+    def test_filename_mapping(self) -> None:
+        from src.parse.lk_corpus import _derive_collection_name
+
+        assert _derive_collection_name(Path("data/lk/albukhari.csv")) == "bukhari"
+        assert _derive_collection_name(Path("data/lk/altirmidhi.csv")) == "tirmidhi"
+
+    def test_directory_mapping(self) -> None:
+        from src.parse.lk_corpus import _derive_collection_name
+
+        assert _derive_collection_name(Path("data/lk/Bukhari/Chapter1.csv")) == "bukhari"
+        assert _derive_collection_name(Path("data/lk/Muslim/Chapter3.csv")) == "muslim"
+        assert _derive_collection_name(Path("data/lk/AbuDaud/Chapter1.csv")) == "abu_dawud"
+        assert _derive_collection_name(Path("data/lk/Tirmizi/Chapter2.csv")) == "tirmidhi"
+        assert _derive_collection_name(Path("data/lk/Nesai/Chapter1.csv")) == "nasai"
+        assert _derive_collection_name(Path("data/lk/IbnMaja/Chapter5.csv")) == "ibn_majah"
+
+    def test_unknown_returns_none(self) -> None:
+        from src.parse.lk_corpus import _derive_collection_name
+
+        assert _derive_collection_name(Path("data/lk/unknown/foo.csv")) is None
+
+    def test_per_chapter_layout_parses(self, tmp_path: Path) -> None:
+        """Per-chapter CSVs in book directories should be parsed correctly."""
+        raw_dir = tmp_path / "raw"
+        lk_dir = raw_dir / "lk" / "Bukhari"
+        lk_dir.mkdir(parents=True)
+        staging_dir = tmp_path / "staging"
+
+        _make_lk_csv(lk_dir / "Chapter1.csv", _sample_rows())
+
+        run(raw_dir, staging_dir)
+
+        table = pq.read_table(staging_dir / "hadiths_lk.parquet")
+        assert table.num_rows == 3
+        assert all(v.as_py() == "bukhari" for v in table.column("collection_name"))
+
+
 class TestLkParser:
     def test_produces_parquet_files(self, tmp_path: Path) -> None:
         raw_dir = tmp_path / "raw"

--- a/tests/test_parse/test_muhaddithat_parser.py
+++ b/tests/test_parse/test_muhaddithat_parser.py
@@ -75,6 +75,27 @@ class TestMuhaddithatParser:
         # Hadith 3: N1->N2, N2->N3 (2 edges) => 4 total
         assert table.num_rows == 4
 
+    def test_variousnarrators_csv_found(self, tmp_path: Path) -> None:
+        """Parser should find variousnarrators.csv as the narrator file."""
+        raw_dir = tmp_path / "raw"
+        muh_dir = raw_dir / "muhaddithat"
+        muh_dir.mkdir(parents=True)
+        staging_dir = tmp_path / "staging"
+
+        narrators_csv = "id,name,gender,bio\n"
+        narrators_csv += "N1,فاطمة بنت الحسين,female,عالمة\n"
+        narrators_csv += "N2,عائشة بنت أبي بكر,female,أم المؤمنين\n"
+        (muh_dir / "variousnarrators.csv").write_text(narrators_csv, encoding="utf-8")
+
+        hadiths_csv = "id,narrator_ids,text\n"
+        hadiths_csv += '1,"N1,N2",متن الحديث\n'
+        (muh_dir / "hadiths.csv").write_text(hadiths_csv, encoding="utf-8")
+
+        bio_path, edge_path = run(raw_dir, staging_dir)
+        assert bio_path.exists()
+        table = pq.read_table(bio_path)
+        assert table.num_rows == 2
+
     def test_no_source_dir_raises(self, tmp_path: Path) -> None:
         raw_dir = tmp_path / "raw"
         raw_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- **#564 (lk_corpus):** `_derive_collection_name()` now checks the parent directory name (e.g. `Bukhari/`, `Muslim/`) when the CSV filename doesn't match `FILENAME_TO_COLLECTION`. This handles the upstream repo's new per-chapter directory layout while preserving backwards compatibility with the old flat-file format.
- **#565 (muhaddithat):** Added `*narrator*.csv` glob pattern to narrator CSV discovery so `variousnarrators.csv` is found.
- Added unit tests for both fixes: directory-based derivation (4 tests) and `variousnarrators.csv` discovery (1 test).

## Test plan

- [x] All 797 unit tests pass (`ENVIRONMENT=test uv run pytest tests/ -x -q -m "not integration and not e2e and not ml"`)
- [x] New `TestDeriveCollectionName` tests cover filename mapping, directory mapping, unknown paths, and full per-chapter parse
- [x] New `test_variousnarrators_csv_found` verifies the muhaddithat parser discovers `variousnarrators.csv`
- [x] Ruff lint + format pass
- [x] mypy passes
- [ ] Pipeline smoke test (`uv run python scripts/pipeline_smoke.py`) — requires raw data

Closes #564
Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)
