### PR TITLE
feat(validate): data quality validation framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
 
       - id: pytest-unit
         name: pytest-unit
-        entry: bash -c 'ENVIRONMENT=test uv run pytest tests/ -x --tb=short -q -m "not integration and not e2e"'
+        entry: bash -c 'ENVIRONMENT=test uv run pytest tests/ -x --tb=short -q -m "not integration and not e2e and not ml"'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-hooks hooks infra infra-down infra-reset acquire parse resolve load enrich test test-integration sample-data lint typecheck format clean clean-worktrees pipeline validate-staging validate-pipeline profile-data test-e2e test-e2e-headed check backup restore
+.PHONY: help setup setup-hooks hooks infra infra-down infra-reset acquire parse resolve load enrich test test-integration sample-data lint typecheck format clean clean-worktrees pipeline validate validate-staging validate-pipeline profile-data test-e2e test-e2e-headed check backup restore
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -64,7 +64,10 @@ clean: ## Remove staging data and caches
 	find . -type d -name .mypy_cache -exec rm -rf {} +
 	find . -type d -name .ruff_cache -exec rm -rf {} +
 
-validate-staging: ## Validate staging Parquet files
+validate: ## Run data quality validation (strict mode, JSON report)
+	uv run isnad validate-staging --strict --output-json data/reports/validation_report.json
+
+validate-staging: ## Validate staging Parquet files (warn mode)
 	uv run isnad validate-staging
 
 validate-pipeline: ## Run full pipeline validation against real data

--- a/src/api/routes/admin/reports.py
+++ b/src/api/routes/admin/reports.py
@@ -32,11 +32,11 @@ def _pipeline_metrics() -> PipelineMetrics | None:
     try:
         from src.parse.validate import validate_staging
 
-        summary = validate_staging(staging_dir)
+        report = validate_staging(staging_dir)
         return PipelineMetrics(
-            total_files=summary.get("total_files", 0),
-            total_rows=summary.get("total_rows", 0),
-            files=summary.get("files", []),
+            total_files=report.total_files,
+            total_rows=report.total_rows,
+            files=[fr.model_dump(mode="json") for fr in report.files],
         )
     except Exception:  # noqa: BLE001
         return None

--- a/src/cli.py
+++ b/src/cli.py
@@ -285,7 +285,24 @@ def main() -> None:
         help="Skip these enrichment steps",
     )
     subparsers.add_parser("validate", help="Run graph validation queries")
-    subparsers.add_parser("validate-staging", help="Validate staging Parquet files")
+    vs_parser = subparsers.add_parser("validate-staging", help="Validate staging Parquet files")
+    vs_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Halt on any validation failure (default: warn mode)",
+    )
+    vs_parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Write JSON validation report to this path",
+    )
+    vs_parser.add_argument(
+        "--drift-tolerance",
+        type=float,
+        default=30.0,
+        help="Maximum drift percentage from baseline (default: 30.0)",
+    )
 
     args = parser.parse_args()
 
@@ -303,10 +320,20 @@ def main() -> None:
         from pathlib import Path
 
         from src.config import get_settings
-        from src.parse.validate import validate_staging
+        from src.parse.validate import Strictness, validate_staging
 
         settings = get_settings()
-        validate_staging(Path(settings.data_staging_dir))
+        strictness = Strictness.STRICT if args.strict else Strictness.WARN
+        output_json = Path(args.output_json) if args.output_json else None
+        report = validate_staging(
+            Path(settings.data_staging_dir),
+            strictness=strictness,
+            drift_tolerance_pct=args.drift_tolerance,
+            output_json=output_json,
+        )
+        if not report.passed and strictness == Strictness.STRICT:
+            print("\nValidation FAILED in strict mode. Pipeline halted.")
+            sys.exit(1)
     elif args.command == "resolve":
         _cmd_resolve()
     elif args.command == "load":

--- a/src/parse/validate.py
+++ b/src/parse/validate.py
@@ -1,14 +1,22 @@
-"""Staging data validation and reporting."""
+"""Data quality validation framework for staging Parquet files.
+
+Provides per-source validation with schema conformance, null rate analysis,
+duplicate detection, Arabic text encoding checks, and drift detection against
+expected baselines. Produces structured Pydantic-based JSON reports.
+"""
 
 from __future__ import annotations
 
+import json
 import re
+from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
-from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
+from pydantic import BaseModel, ConfigDict
 
 from src.parse.schemas import (
     COLLECTION_SCHEMA,
@@ -21,6 +29,10 @@ from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Schema mapping
+# ---------------------------------------------------------------------------
+
 EXPECTED_SCHEMAS: dict[str, pa.Schema] = {
     "hadiths_": HADITH_SCHEMA,
     "narrator_mentions_": NARRATOR_MENTION_SCHEMA,
@@ -29,7 +41,131 @@ EXPECTED_SCHEMAS: dict[str, pa.Schema] = {
     "network_edges_": NETWORK_EDGE_SCHEMA,
 }
 
-_ARABIC_RE = re.compile(r"[\u0600-\u06FF]")
+_ARABIC_RE = re.compile("[\u0600-\u06ff]")
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class Strictness(StrEnum):
+    """Gate strictness level."""
+
+    STRICT = "strict"
+    WARN = "warn"
+
+
+class CheckStatus(StrEnum):
+    """Result status for a single validation check."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    WARN = "warn"
+    SKIP = "skip"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic report models (frozen for immutability per project convention)
+# ---------------------------------------------------------------------------
+
+
+class CheckResult(BaseModel):
+    """Result of a single validation check."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    status: CheckStatus
+    message: str
+    value: float | int | str | None = None
+    threshold: float | int | str | None = None
+
+
+class DriftResult(BaseModel):
+    """Drift detection result comparing current metrics against a baseline."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metric: str
+    baseline_value: float | int
+    current_value: float | int
+    drift_pct: float
+    within_tolerance: bool
+    tolerance_pct: float
+
+
+class FileReport(BaseModel):
+    """Validation report for a single Parquet file."""
+
+    model_config = ConfigDict(frozen=True)
+
+    file: str
+    source: str
+    rows: int
+    columns: int
+    null_percentages: dict[str, float]
+    checks: list[CheckResult]
+    drift: list[DriftResult]
+    passed: bool
+
+
+class ValidationReport(BaseModel):
+    """Top-level validation report for all staging files."""
+
+    model_config = ConfigDict(frozen=True)
+
+    timestamp: str
+    staging_dir: str
+    strictness: Strictness
+    total_files: int
+    total_rows: int
+    files: list[FileReport]
+    passed: bool
+
+
+# ---------------------------------------------------------------------------
+# Default baselines for drift detection
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASELINES: dict[str, dict[str, float | int]] = {
+    "hadiths_sunnah_api": {"row_count": 30000, "arabic_coverage_pct": 90.0},
+    "hadiths_open_hadith": {"row_count": 50000, "arabic_coverage_pct": 95.0},
+    "hadiths_thaqalayn": {"row_count": 15000, "arabic_coverage_pct": 95.0},
+    "hadiths_lk_corpus": {"row_count": 60000, "arabic_coverage_pct": 99.0},
+    "hadiths_fawaz": {"row_count": 5000, "arabic_coverage_pct": 80.0},
+    "hadiths_sanadset": {"row_count": 10000, "arabic_coverage_pct": 90.0},
+    "hadiths_sunnah_scraped": {"row_count": 40000, "arabic_coverage_pct": 90.0},
+    "hadiths_muhaddithat": {"row_count": 1000, "arabic_coverage_pct": 50.0},
+    "narrator_mentions_sunnah_api": {"row_count": 100000},
+    "narrator_mentions_thaqalayn": {"row_count": 50000},
+    "narrator_mentions_lk_corpus": {"row_count": 200000},
+    "narrators_bio_lk_corpus": {"row_count": 10000},
+    "narrators_bio_muhaddithat": {"row_count": 500},
+    "collections_sunnah_api": {"row_count": 15},
+    "collections_thaqalayn": {"row_count": 5},
+    "network_edges_sanadset": {"row_count": 30000},
+}
+
+DEFAULT_DRIFT_TOLERANCE_PCT = 30.0
+
+# Null-rate thresholds: columns that should never be null
+REQUIRED_COLUMNS: dict[str, set[str]] = {
+    "hadiths_": {"source_id", "source_corpus", "collection_name", "sect"},
+    "narrator_mentions_": {
+        "mention_id",
+        "source_hadith_id",
+        "source_corpus",
+        "position_in_chain",
+    },
+    "narrators_bio_": {"bio_id", "source"},
+    "collections_": {"collection_id", "name_en", "sect", "source_corpus"},
+    "network_edges_": {"from_narrator_name", "to_narrator_name", "source"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 
 def _has_arabic(text: str) -> bool:
@@ -83,178 +219,402 @@ def _check_schema_conformance(table_schema: pa.Schema, expected_schema: pa.Schem
     return issues
 
 
-def validate_staging(staging_dir: Path) -> dict[str, Any]:
-    """Read all Parquet files in staging_dir and validate them.
+def _extract_source(filename: str) -> str:
+    """Extract source name from filename, e.g. 'hadiths_sunnah_api.parquet' -> 'sunnah_api'."""
+    stem = Path(filename).stem
+    for prefix in EXPECTED_SCHEMAS:
+        if stem.startswith(prefix):
+            return stem[len(prefix) :]
+    return stem
 
-    For each file:
-    - Report row count, column count, null % per column
-    - Verify schema matches expected staging schema
-    - For hadith files: check duplicate source_ids, empty matn, Arabic/English coverage
 
-    Returns a summary dict with all findings. Also prints a formatted report.
+def _baseline_key(filename: str) -> str:
+    """Build a key for baseline lookup from filename."""
+    return Path(filename).stem
+
+
+# ---------------------------------------------------------------------------
+# Per-file validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_file(
+    pf_path: Path,
+    strictness: Strictness,
+    baselines: dict[str, dict[str, float | int]],
+    drift_tolerance_pct: float,
+) -> FileReport:
+    """Run all validation checks on a single Parquet file."""
+    table = pq.read_table(pf_path)
+    filename = pf_path.name
+    source = _extract_source(filename)
+    num_rows = len(table)
+    num_cols = len(table.column_names)
+    null_pcts = _null_percentages(table)
+
+    checks: list[CheckResult] = []
+    drift_results: list[DriftResult] = []
+
+    # -- Row count check --
+    checks.append(
+        CheckResult(
+            name="row_count",
+            status=CheckStatus.PASS if num_rows > 0 else CheckStatus.FAIL,
+            message=f"{num_rows} rows" if num_rows > 0 else "File is empty",
+            value=num_rows,
+        )
+    )
+
+    # -- Schema conformance --
+    match = _match_schema(filename)
+    if match is not None:
+        _prefix, expected = match
+        issues = _check_schema_conformance(table.schema, expected)
+        if issues:
+            checks.append(
+                CheckResult(
+                    name="schema_conformance",
+                    status=CheckStatus.FAIL,
+                    message="; ".join(issues),
+                )
+            )
+        else:
+            checks.append(
+                CheckResult(
+                    name="schema_conformance",
+                    status=CheckStatus.PASS,
+                    message="Schema matches expected",
+                )
+            )
+    else:
+        checks.append(
+            CheckResult(
+                name="schema_conformance",
+                status=CheckStatus.WARN,
+                message="No matching expected schema found",
+            )
+        )
+
+    # -- Required column null checks --
+    for prefix, required_cols in REQUIRED_COLUMNS.items():
+        if filename.startswith(prefix):
+            for col in required_cols:
+                if col in table.column_names:
+                    pct = null_pcts.get(col, 0.0)
+                    checks.append(
+                        CheckResult(
+                            name=f"null_check_{col}",
+                            status=CheckStatus.PASS if pct == 0.0 else CheckStatus.FAIL,
+                            message=f"{col} null rate: {pct}%",
+                            value=pct,
+                            threshold=0.0,
+                        )
+                    )
+            break
+
+    # -- Duplicate detection --
+    id_col = _get_id_column(filename)
+    if id_col and id_col in table.column_names and num_rows > 0:
+        id_array = table.column(id_col)
+        total = len(id_array)
+        unique = pc.count(pc.unique(id_array)).as_py()
+        dupes = total - unique
+        dupe_pct = round(100.0 * dupes / total, 2) if total > 0 else 0.0
+        checks.append(
+            CheckResult(
+                name="duplicate_ids",
+                status=CheckStatus.PASS if dupes == 0 else CheckStatus.WARN,
+                message=f"{dupes} duplicate {id_col} values ({dupe_pct}%)",
+                value=dupes,
+            )
+        )
+
+    # -- Arabic text encoding --
+    if num_rows > 0:
+        for ar_col in ("name_ar", "matn_ar"):
+            if ar_col in table.column_names:
+                col = table.column(ar_col)
+                non_null = col.drop_null()
+                non_null_count = len(non_null)
+                if non_null_count > 0:
+                    has_arabic = pc.sum(
+                        pc.match_substring_regex(non_null, "[\u0600-\u06ff]")
+                    ).as_py()
+                    ar_pct = round(100.0 * has_arabic / non_null_count, 2)
+                    checks.append(
+                        CheckResult(
+                            name=f"arabic_encoding_{ar_col}",
+                            status=CheckStatus.PASS if ar_pct > 50.0 else CheckStatus.WARN,
+                            message=f"{ar_pct}% of non-null {ar_col} contain Arabic chars",
+                            value=ar_pct,
+                            threshold=50.0,
+                        )
+                    )
+
+    # -- Hadith-specific checks --
+    if filename.startswith("hadiths_") and num_rows > 0:
+        checks.extend(_hadith_checks(table, num_rows))
+
+    # -- Drift detection --
+    bkey = _baseline_key(filename)
+    if bkey in baselines:
+        baseline = baselines[bkey]
+        current_metrics = _current_metrics(table, filename, num_rows)
+        for metric, baseline_val in baseline.items():
+            if metric in current_metrics:
+                current_val = current_metrics[metric]
+                if baseline_val != 0:
+                    drift_pct = round(
+                        100.0 * abs(current_val - baseline_val) / abs(baseline_val), 2
+                    )
+                else:
+                    drift_pct = 0.0 if current_val == 0 else 100.0
+                within = drift_pct <= drift_tolerance_pct
+                drift_results.append(
+                    DriftResult(
+                        metric=metric,
+                        baseline_value=baseline_val,
+                        current_value=current_val,
+                        drift_pct=drift_pct,
+                        within_tolerance=within,
+                        tolerance_pct=drift_tolerance_pct,
+                    )
+                )
+
+    # Determine pass/fail
+    has_failure = any(c.status == CheckStatus.FAIL for c in checks)
+    drift_failure = any(not d.within_tolerance for d in drift_results)
+
+    if strictness == Strictness.STRICT:
+        passed = not has_failure and not drift_failure
+    else:
+        passed = not has_failure
+
+    return FileReport(
+        file=filename,
+        source=source,
+        rows=num_rows,
+        columns=num_cols,
+        null_percentages=null_pcts,
+        checks=checks,
+        drift=drift_results,
+        passed=passed,
+    )
+
+
+def _get_id_column(filename: str) -> str | None:
+    """Return the primary ID column for a file type."""
+    if filename.startswith("hadiths_"):
+        return "source_id"
+    if filename.startswith("narrator_mentions_"):
+        return "mention_id"
+    if filename.startswith("narrators_bio_"):
+        return "bio_id"
+    if filename.startswith("collections_"):
+        return "collection_id"
+    return None
+
+
+def _hadith_checks(table: pa.Table, num_rows: int) -> list[CheckResult]:
+    """Run hadith-specific validation checks."""
+    checks: list[CheckResult] = []
+
+    # Empty matn_ar
+    if "matn_ar" in table.column_names:
+        col = table.column("matn_ar")
+        null_count = col.null_count
+        stripped = pc.utf8_trim(col.drop_null(), " \t\n\r")
+        blank_count = pc.sum(pc.equal(stripped, "")).as_py()
+        empty = null_count + blank_count
+        empty_pct = round(100.0 * empty / num_rows, 2)
+        checks.append(
+            CheckResult(
+                name="empty_matn_ar",
+                status=CheckStatus.PASS if empty_pct < 50.0 else CheckStatus.WARN,
+                message=f"{empty} empty matn_ar ({empty_pct}%)",
+                value=empty,
+            )
+        )
+
+    # Empty matn_en
+    if "matn_en" in table.column_names:
+        col = table.column("matn_en")
+        null_count = col.null_count
+        stripped = pc.utf8_trim(col.drop_null(), " \t\n\r")
+        blank_count = pc.sum(pc.equal(stripped, "")).as_py()
+        empty = null_count + blank_count
+        empty_pct = round(100.0 * empty / num_rows, 2)
+        checks.append(
+            CheckResult(
+                name="empty_matn_en",
+                status=CheckStatus.PASS if empty_pct < 50.0 else CheckStatus.WARN,
+                message=f"{empty} empty matn_en ({empty_pct}%)",
+                value=empty,
+            )
+        )
+
+    # Book/chapter coverage
+    for col_name, label in [("book_number", "book"), ("chapter_number", "chapter")]:
+        if col_name in table.column_names:
+            filled = num_rows - table.column(col_name).null_count
+            pct = round(100.0 * filled / num_rows, 2)
+            checks.append(
+                CheckResult(
+                    name=f"{label}_coverage",
+                    status=CheckStatus.PASS,
+                    message=f"{label} coverage: {pct}%",
+                    value=pct,
+                )
+            )
+
+    return checks
+
+
+def _current_metrics(table: pa.Table, filename: str, num_rows: int) -> dict[str, float | int]:
+    """Extract metrics from current data for drift comparison."""
+    metrics: dict[str, float | int] = {"row_count": num_rows}
+    if filename.startswith("hadiths_") and "matn_ar" in table.column_names and num_rows > 0:
+        col = table.column("matn_ar")
+        non_null = col.drop_null()
+        if len(non_null) > 0:
+            has_arabic = pc.sum(pc.match_substring_regex(non_null, "[\u0600-\u06ff]")).as_py()
+            metrics["arabic_coverage_pct"] = round(100.0 * has_arabic / num_rows, 2)
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_staging(
+    staging_dir: Path,
+    *,
+    strictness: Strictness = Strictness.WARN,
+    baselines: dict[str, dict[str, float | int]] | None = None,
+    drift_tolerance_pct: float = DEFAULT_DRIFT_TOLERANCE_PCT,
+    output_json: Path | None = None,
+) -> ValidationReport:
+    """Validate all Parquet files in staging_dir.
+
+    Args:
+        staging_dir: Directory containing staging Parquet files.
+        strictness: STRICT halts on any failure; WARN logs failures but passes.
+        baselines: Per-source expected metrics for drift detection.
+            Defaults to DEFAULT_BASELINES.
+        drift_tolerance_pct: Maximum allowed drift percentage from baseline.
+        output_json: If provided, write JSON report to this path.
+
+    Returns:
+        A ValidationReport with per-file results.
     """
+    if baselines is None:
+        baselines = DEFAULT_BASELINES
+
     parquet_files = sorted(staging_dir.glob("*.parquet"))
     if not parquet_files:
-        print(f"No Parquet files found in {staging_dir}")
         logger.warning("no_parquet_files", staging_dir=str(staging_dir))
-        return {"files": [], "total_files": 0}
+        report = ValidationReport(
+            timestamp=datetime.now(UTC).isoformat(),
+            staging_dir=str(staging_dir),
+            strictness=strictness,
+            total_files=0,
+            total_rows=0,
+            files=[],
+            passed=True,
+        )
+        if output_json:
+            _write_json(report, output_json)
+        return report
 
-    results: list[dict[str, Any]] = []
-
+    file_reports: list[FileReport] = []
     for pf_path in parquet_files:
-        table = pq.read_table(pf_path)
-        filename = pf_path.name
-        num_rows = len(table)
-        num_cols = len(table.column_names)
-        null_pcts = _null_percentages(table)
+        fr = _validate_file(pf_path, strictness, baselines, drift_tolerance_pct)
+        file_reports.append(fr)
+        logger.info(
+            "file_validated",
+            file=fr.file,
+            rows=fr.rows,
+            passed=fr.passed,
+            checks_failed=sum(1 for c in fr.checks if c.status == CheckStatus.FAIL),
+        )
 
-        file_result: dict[str, Any] = {
-            "file": filename,
-            "rows": num_rows,
-            "columns": num_cols,
-            "null_percentages": null_pcts,
-            "schema_issues": [],
-            "is_hadith": False,
-        }
+    all_passed = all(fr.passed for fr in file_reports)
 
-        # Schema conformance
-        match = _match_schema(filename)
-        if match is not None:
-            _prefix, expected = match
-            issues = _check_schema_conformance(table.schema, expected)
-            file_result["schema_issues"] = issues
-        else:
-            file_result["schema_issues"] = ["No matching expected schema found"]
+    report = ValidationReport(
+        timestamp=datetime.now(UTC).isoformat(),
+        staging_dir=str(staging_dir),
+        strictness=strictness,
+        total_files=len(file_reports),
+        total_rows=sum(fr.rows for fr in file_reports),
+        files=file_reports,
+        passed=all_passed,
+    )
 
-        # Hadith-specific checks
-        if filename.startswith("hadiths_"):
-            file_result["is_hadith"] = True
-            hadith_checks: dict[str, Any] = {}
+    _print_report(report)
 
-            # Duplicate source_ids
-            if "source_id" in table.column_names:
-                source_col = table.column("source_id")
-                total = len(source_col)
-                unique = pc.count(pc.unique(source_col)).as_py()
-                dupes = total - unique
-                hadith_checks["duplicate_source_ids"] = dupes
-            else:
-                hadith_checks["duplicate_source_ids"] = None
+    if output_json:
+        _write_json(report, output_json)
 
-            # Empty matn fields — count nulls + empty/whitespace-only strings
-            empty_matn_ar = 0
-            empty_matn_en = 0
-            if "matn_ar" in table.column_names:
-                col = table.column("matn_ar")
-                null_count = col.null_count
-                stripped = pc.utf8_trim(col.drop_null(), " \t\n\r")
-                blank_count = pc.sum(pc.equal(stripped, "")).as_py()
-                empty_matn_ar = null_count + blank_count
-            if "matn_en" in table.column_names:
-                col = table.column("matn_en")
-                null_count = col.null_count
-                stripped = pc.utf8_trim(col.drop_null(), " \t\n\r")
-                blank_count = pc.sum(pc.equal(stripped, "")).as_py()
-                empty_matn_en = null_count + blank_count
-            hadith_checks["empty_matn_ar"] = empty_matn_ar
-            hadith_checks["empty_matn_en"] = empty_matn_en
-
-            # Arabic vs English coverage
-            ar_count = 0
-            en_count = 0
-            if "matn_ar" in table.column_names:
-                col = table.column("matn_ar")
-                non_null = col.drop_null()
-                ar_count = pc.sum(pc.match_substring_regex(non_null, r"[\u0600-\u06FF]")).as_py()
-            if "matn_en" in table.column_names:
-                col = table.column("matn_en")
-                non_null = col.drop_null()
-                stripped = pc.utf8_trim(non_null, " \t\n\r")
-                en_count = pc.sum(pc.not_equal(stripped, "")).as_py()
-            if num_rows > 0:
-                hadith_checks["arabic_coverage_pct"] = round(100.0 * ar_count / num_rows, 2)
-                hadith_checks["english_coverage_pct"] = round(100.0 * en_count / num_rows, 2)
-            else:
-                hadith_checks["arabic_coverage_pct"] = 0.0
-                hadith_checks["english_coverage_pct"] = 0.0
-
-            # Book/chapter metadata coverage
-            book_filled = 0
-            chapter_filled = 0
-            if "book_number" in table.column_names:
-                book_filled = num_rows - table.column("book_number").null_count
-            if "chapter_number" in table.column_names:
-                chapter_filled = num_rows - table.column("chapter_number").null_count
-            if num_rows > 0:
-                hadith_checks["book_coverage_pct"] = round(100.0 * book_filled / num_rows, 2)
-                hadith_checks["chapter_coverage_pct"] = round(100.0 * chapter_filled / num_rows, 2)
-            else:
-                hadith_checks["book_coverage_pct"] = 0.0
-                hadith_checks["chapter_coverage_pct"] = 0.0
-
-            file_result["hadith_checks"] = hadith_checks
-
-        results.append(file_result)
-
-    summary: dict[str, Any] = {
-        "total_files": len(results),
-        "files": results,
-        "total_rows": sum(r["rows"] for r in results),
-    }
-
-    # Print formatted report
-    _print_report(summary)
-
-    return summary
+    return report
 
 
-def _print_report(summary: dict[str, Any]) -> None:
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def _write_json(report: ValidationReport, path: Path) -> None:
+    """Write validation report as JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report.model_dump(mode="json"), indent=2))
+    logger.info("report_written", path=str(path))
+
+
+def _print_report(report: ValidationReport) -> None:
     """Print a formatted validation report to stdout."""
     print("=" * 70)
     print("STAGING DATA VALIDATION REPORT")
+    print(f"  Timestamp:  {report.timestamp}")
+    print(f"  Strictness: {report.strictness.value}")
     print("=" * 70)
-    print(f"Total files: {summary['total_files']}")
-    print(f"Total rows:  {summary['total_rows']}")
+    print(f"Total files: {report.total_files}")
+    print(f"Total rows:  {report.total_rows}")
+    print(f"Overall:     {'PASSED' if report.passed else 'FAILED'}")
     print()
 
-    for file_info in summary["files"]:
+    for fr in report.files:
+        status = "PASS" if fr.passed else "FAIL"
         print("-" * 70)
-        print(f"File: {file_info['file']}")
-        print(f"  Rows: {file_info['rows']:,}  |  Columns: {file_info['columns']}")
+        print(f"[{status}] {fr.file}  (source: {fr.source})")
+        print(f"  Rows: {fr.rows:,}  |  Columns: {fr.columns}")
 
-        # Schema issues
-        issues = file_info["schema_issues"]
-        if issues:
-            print("  Schema issues:")
-            for issue in issues:
-                print(f"    - {issue}")
-        else:
-            print("  Schema: OK")
+        # Checks
+        failed = [c for c in fr.checks if c.status in (CheckStatus.FAIL, CheckStatus.WARN)]
+        passed = [c for c in fr.checks if c.status == CheckStatus.PASS]
+        if failed:
+            print("  Issues:")
+            for c in failed:
+                print(f"    [{c.status.value.upper()}] {c.name}: {c.message}")
+        print(f"  Checks: {len(passed)} passed, {len(failed)} issues")
 
-        # Null percentages
-        null_pcts = file_info["null_percentages"]
-        cols_with_nulls = {k: v for k, v in null_pcts.items() if v > 0}
+        # Drift
+        if fr.drift:
+            print("  Drift:")
+            for d in fr.drift:
+                marker = "OK" if d.within_tolerance else "DRIFT"
+                print(
+                    f"    [{marker}] {d.metric}: "
+                    f"baseline={d.baseline_value}, current={d.current_value}, "
+                    f"drift={d.drift_pct}% (tolerance={d.tolerance_pct}%)"
+                )
+
+        # Null rates (only show columns with nulls)
+        cols_with_nulls = {k: v for k, v in fr.null_percentages.items() if v > 0}
         if cols_with_nulls:
             print("  Null % (columns with nulls):")
             for col, pct in sorted(cols_with_nulls.items()):
                 print(f"    {col}: {pct}%")
-        else:
-            print("  Null %: no nulls")
-
-        # Hadith-specific
-        if file_info["is_hadith"] and "hadith_checks" in file_info:
-            hc = file_info["hadith_checks"]
-            print("  Hadith checks:")
-            if hc.get("duplicate_source_ids") is not None:
-                print(f"    Duplicate source_ids: {hc['duplicate_source_ids']}")
-            print(f"    Empty matn_ar: {hc['empty_matn_ar']}")
-            print(f"    Empty matn_en: {hc['empty_matn_en']}")
-            print(f"    Arabic coverage: {hc['arabic_coverage_pct']}%")
-            print(f"    English coverage: {hc['english_coverage_pct']}%")
-            if "book_coverage_pct" in hc:
-                print(f"    Book coverage: {hc['book_coverage_pct']}%")
-            if "chapter_coverage_pct" in hc:
-                print(f"    Chapter coverage: {hc['chapter_coverage_pct']}%")
 
         print()
 

--- a/tests/test_parse/test_validate.py
+++ b/tests/test_parse/test_validate.py
@@ -1,0 +1,385 @@
+"""Tests for the data quality validation framework."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.parse.schemas import COLLECTION_SCHEMA, HADITH_SCHEMA, NARRATOR_MENTION_SCHEMA
+from src.parse.validate import (
+    CheckStatus,
+    DriftResult,
+    FileReport,
+    Strictness,
+    ValidationReport,
+    validate_staging,
+)
+
+
+@pytest.fixture
+def staging_dir(tmp_path: Path) -> Path:
+    """Create a temporary staging directory."""
+    return tmp_path
+
+
+def _write_hadith_parquet(path: Path, rows: list[dict]) -> None:
+    """Write a hadith Parquet file with the correct schema."""
+    arrays = {}
+    for field in HADITH_SCHEMA:
+        values = [r.get(field.name) for r in rows]
+        arrays[field.name] = pa.array(values, type=field.type)
+    table = pa.table(arrays, schema=HADITH_SCHEMA)
+    pq.write_table(table, path)
+
+
+def _write_collection_parquet(path: Path, rows: list[dict]) -> None:
+    """Write a collection Parquet file."""
+    arrays = {}
+    for field in COLLECTION_SCHEMA:
+        values = [r.get(field.name) for r in rows]
+        arrays[field.name] = pa.array(values, type=field.type)
+    table = pa.table(arrays, schema=COLLECTION_SCHEMA)
+    pq.write_table(table, path)
+
+
+def _write_narrator_mention_parquet(path: Path, rows: list[dict]) -> None:
+    """Write a narrator mentions Parquet file."""
+    arrays = {}
+    for field in NARRATOR_MENTION_SCHEMA:
+        values = [r.get(field.name) for r in rows]
+        arrays[field.name] = pa.array(values, type=field.type)
+    table = pa.table(arrays, schema=NARRATOR_MENTION_SCHEMA)
+    pq.write_table(table, path)
+
+
+def _make_hadith_row(
+    source_id: str = "h1",
+    source_corpus: str = "test",
+    collection_name: str = "bukhari",
+    sect: str = "sunni",
+    matn_ar: str | None = "\u0628\u0633\u0645 \u0627\u0644\u0644\u0647",
+    matn_en: str | None = "In the name of God",
+    **kwargs,
+) -> dict:
+    return {
+        "source_id": source_id,
+        "source_corpus": source_corpus,
+        "collection_name": collection_name,
+        "book_number": kwargs.get("book_number", 1),
+        "chapter_number": kwargs.get("chapter_number", 1),
+        "hadith_number": kwargs.get("hadith_number", 1),
+        "matn_ar": matn_ar,
+        "matn_en": matn_en,
+        "isnad_raw_ar": kwargs.get("isnad_raw_ar"),
+        "isnad_raw_en": kwargs.get("isnad_raw_en"),
+        "full_text_ar": kwargs.get("full_text_ar"),
+        "full_text_en": kwargs.get("full_text_en"),
+        "grade": kwargs.get("grade"),
+        "chapter_name_ar": kwargs.get("chapter_name_ar"),
+        "chapter_name_en": kwargs.get("chapter_name_en"),
+        "sect": sect,
+    }
+
+
+class TestValidationReportModels:
+    """Test Pydantic report model structure."""
+
+    def test_check_result_frozen(self):
+        from src.parse.validate import CheckResult
+
+        cr = CheckResult(name="test", status=CheckStatus.PASS, message="ok")
+        with pytest.raises(Exception):
+            cr.name = "changed"  # type: ignore[misc]
+
+    def test_file_report_frozen(self):
+        fr = FileReport(
+            file="test.parquet",
+            source="test",
+            rows=0,
+            columns=0,
+            null_percentages={},
+            checks=[],
+            drift=[],
+            passed=True,
+        )
+        with pytest.raises(Exception):
+            fr.passed = False  # type: ignore[misc]
+
+    def test_validation_report_serialization(self):
+        report = ValidationReport(
+            timestamp="2026-01-01T00:00:00Z",
+            staging_dir="/tmp/test",
+            strictness=Strictness.WARN,
+            total_files=0,
+            total_rows=0,
+            files=[],
+            passed=True,
+        )
+        data = report.model_dump(mode="json")
+        assert data["strictness"] == "warn"
+        assert data["passed"] is True
+
+    def test_drift_result_model(self):
+        dr = DriftResult(
+            metric="row_count",
+            baseline_value=100,
+            current_value=80,
+            drift_pct=20.0,
+            within_tolerance=True,
+            tolerance_pct=30.0,
+        )
+        assert dr.within_tolerance is True
+        assert dr.drift_pct == 20.0
+
+
+class TestValidateStaging:
+    """Test the main validate_staging function."""
+
+    def test_empty_directory(self, staging_dir: Path):
+        report = validate_staging(staging_dir)
+        assert report.total_files == 0
+        assert report.passed is True
+
+    def test_valid_hadith_file(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(5)]
+        _write_hadith_parquet(staging_dir / "hadiths_test_source.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        assert report.total_files == 1
+        assert report.total_rows == 5
+        assert report.files[0].passed is True
+        assert report.files[0].source == "test_source"
+
+    def test_schema_conformance_pass(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(3)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        schema_checks = [c for c in report.files[0].checks if c.name == "schema_conformance"]
+        assert len(schema_checks) == 1
+        assert schema_checks[0].status == CheckStatus.PASS
+
+    def test_duplicate_detection(self, staging_dir: Path):
+        rows = [
+            _make_hadith_row(source_id="h1"),
+            _make_hadith_row(source_id="h1"),
+            _make_hadith_row(source_id="h2"),
+        ]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        dupe_checks = [c for c in report.files[0].checks if c.name == "duplicate_ids"]
+        assert len(dupe_checks) == 1
+        assert dupe_checks[0].value == 1
+        assert dupe_checks[0].status == CheckStatus.WARN
+
+    def test_arabic_encoding_check(self, staging_dir: Path):
+        rows = [
+            _make_hadith_row(source_id="h1", matn_ar="\u0628\u0633\u0645"),
+            _make_hadith_row(source_id="h2", matn_ar="\u0627\u0644\u0644\u0647"),
+            _make_hadith_row(source_id="h3", matn_ar="no arabic here"),
+        ]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        ar_checks = [c for c in report.files[0].checks if c.name == "arabic_encoding_matn_ar"]
+        assert len(ar_checks) == 1
+        assert ar_checks[0].value == pytest.approx(66.67, abs=0.01)
+
+    def test_null_check_required_columns(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(3)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        null_checks = [c for c in report.files[0].checks if c.name.startswith("null_check_")]
+        assert len(null_checks) > 0
+        for nc in null_checks:
+            assert nc.status == CheckStatus.PASS
+
+    def test_empty_matn_checks(self, staging_dir: Path):
+        rows = [
+            _make_hadith_row(source_id="h1", matn_ar=None, matn_en=None),
+            _make_hadith_row(source_id="h2", matn_ar="", matn_en="  "),
+            _make_hadith_row(source_id="h3"),
+        ]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        empty_ar = [c for c in report.files[0].checks if c.name == "empty_matn_ar"]
+        assert len(empty_ar) == 1
+        assert empty_ar[0].value == 2  # 1 null + 1 empty string
+
+    def test_collection_file(self, staging_dir: Path):
+        rows = [
+            {
+                "collection_id": "c1",
+                "name_ar": "\u0635\u062d\u064a\u062d",
+                "name_en": "Sahih Bukhari",
+                "compiler_name": "Bukhari",
+                "compilation_year_ah": 256,
+                "sect": "sunni",
+                "total_hadiths": 7563,
+                "source_corpus": "test",
+            }
+        ]
+        _write_collection_parquet(staging_dir / "collections_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        assert report.total_files == 1
+        assert report.files[0].passed is True
+        assert report.files[0].source == "test"
+
+
+class TestStrictnessLevels:
+    """Test strict vs warn mode behavior."""
+
+    def test_warn_mode_passes_with_warnings(self, staging_dir: Path):
+        rows = [
+            _make_hadith_row(source_id="h1"),
+            _make_hadith_row(source_id="h1"),  # duplicate
+        ]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir, strictness=Strictness.WARN)
+        assert report.passed is True
+        assert report.strictness == Strictness.WARN
+
+    def test_strict_mode_fails_on_schema_mismatch(self, staging_dir: Path):
+        # Write a file with wrong schema (missing required columns)
+        table = pa.table({"wrong_col": pa.array(["a", "b"])})
+        pq.write_table(table, staging_dir / "hadiths_test.parquet")
+
+        report = validate_staging(staging_dir, strictness=Strictness.STRICT)
+        assert report.passed is False
+
+
+class TestDriftDetection:
+    """Test drift detection against baselines."""
+
+    def test_drift_within_tolerance(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(90)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        baselines = {"hadiths_test": {"row_count": 100}}
+        report = validate_staging(staging_dir, baselines=baselines, drift_tolerance_pct=20.0)
+        assert len(report.files[0].drift) == 1
+        assert report.files[0].drift[0].within_tolerance is True
+        assert report.files[0].drift[0].drift_pct == 10.0
+
+    def test_drift_exceeds_tolerance(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(50)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        baselines = {"hadiths_test": {"row_count": 100}}
+        report = validate_staging(
+            staging_dir,
+            baselines=baselines,
+            drift_tolerance_pct=10.0,
+            strictness=Strictness.STRICT,
+        )
+        assert len(report.files[0].drift) == 1
+        assert report.files[0].drift[0].within_tolerance is False
+        assert report.files[0].drift[0].drift_pct == 50.0
+        assert report.passed is False
+
+    def test_drift_warn_mode_doesnt_fail(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(10)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        baselines = {"hadiths_test": {"row_count": 100}}
+        report = validate_staging(
+            staging_dir,
+            baselines=baselines,
+            drift_tolerance_pct=5.0,
+            strictness=Strictness.WARN,
+        )
+        # Drift exceeds tolerance but warn mode doesn't fail on drift
+        assert report.files[0].drift[0].within_tolerance is False
+        assert report.passed is True
+
+    def test_no_baseline_no_drift(self, staging_dir: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(5)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        report = validate_staging(staging_dir, baselines={})
+        assert len(report.files[0].drift) == 0
+
+
+class TestJSONOutput:
+    """Test JSON report generation."""
+
+    def test_json_report_written(self, staging_dir: Path, tmp_path: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(3)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        json_path = tmp_path / "reports" / "report.json"
+        validate_staging(staging_dir, output_json=json_path)
+
+        assert json_path.exists()
+        data = json.loads(json_path.read_text())
+        assert data["total_files"] == 1
+        assert data["total_rows"] == 3
+        assert data["passed"] is True
+        assert len(data["files"]) == 1
+        assert data["files"][0]["source"] == "test"
+
+    def test_json_roundtrip(self, staging_dir: Path, tmp_path: Path):
+        rows = [_make_hadith_row(source_id=f"h{i}") for i in range(3)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", rows)
+
+        json_path = tmp_path / "report.json"
+        report = validate_staging(staging_dir, output_json=json_path)
+
+        data = json.loads(json_path.read_text())
+        roundtrip = ValidationReport(**data)
+        assert roundtrip.total_files == report.total_files
+        assert roundtrip.passed == report.passed
+
+
+class TestMultipleFileTypes:
+    """Test validation across different file types."""
+
+    def test_mixed_file_types(self, staging_dir: Path):
+        hadith_rows = [_make_hadith_row(source_id=f"h{i}") for i in range(5)]
+        _write_hadith_parquet(staging_dir / "hadiths_test.parquet", hadith_rows)
+
+        collection_rows = [
+            {
+                "collection_id": "c1",
+                "name_ar": None,
+                "name_en": "Test Collection",
+                "compiler_name": None,
+                "compilation_year_ah": None,
+                "sect": "sunni",
+                "total_hadiths": None,
+                "source_corpus": "test",
+            }
+        ]
+        _write_collection_parquet(staging_dir / "collections_test.parquet", collection_rows)
+
+        report = validate_staging(staging_dir)
+        assert report.total_files == 2
+        assert report.total_rows == 6
+
+    def test_narrator_mentions(self, staging_dir: Path):
+        rows = [
+            {
+                "mention_id": "m1",
+                "source_hadith_id": "h1",
+                "source_corpus": "test",
+                "position_in_chain": 1,
+                "name_ar": "\u0639\u0644\u064a",
+                "name_en": "Ali",
+                "name_ar_normalized": None,
+                "transmission_method": None,
+            }
+        ]
+        _write_narrator_mention_parquet(staging_dir / "narrator_mentions_test.parquet", rows)
+
+        report = validate_staging(staging_dir)
+        assert report.total_files == 1
+        assert report.files[0].passed is True


### PR DESCRIPTION
## Summary

- Add structured data quality validation framework with Pydantic report models (`ValidationReport`, `FileReport`, `CheckResult`, `DriftResult`)
- Per-source validation: schema conformance, null rate analysis on required columns, duplicate ID detection, Arabic text encoding checks, hadith-specific content coverage
- Drift detection: compare current parse output metrics against configurable baselines with tolerance thresholds
- Configurable strictness levels: `strict` (halt pipeline on failure) and `warn` (log and continue)
- CLI options: `--strict`, `--output-json <path>`, `--drift-tolerance <pct>`
- `make validate` target for strict-mode validation with JSON report output
- Fix admin reports endpoint to use new `ValidationReport` model attributes
- Fix pre-commit pytest hook to exclude `ml`-marked tests

## Test plan

- [x] 22 unit tests covering report models, schema validation, null checks, duplicate detection, Arabic encoding, drift detection, strictness levels, JSON output, and multi-file-type validation
- [x] All 819 existing tests pass (excluding integration/e2e/ml)
- [x] Ruff lint + format pass
- [x] mypy strict mode passes

Closes #534

Generated with [Claude Code](https://claude.com/claude-code)
