### PR TITLE
docs(ux): add 6 remaining wireframe specifications

### DIFF
--- a/docs/ux/wireframes/admin.md
+++ b/docs/ux/wireframes/admin.md
@@ -1,0 +1,552 @@
+# Admin Panel — Wireframe Specification
+
+**Author:** Sable Nakamura-Whitfield (Principal UX Designer)
+**Issue:** #542
+**Date:** 2026-03-29
+**Status:** Draft
+
+---
+
+## 1. Design Intent
+
+The admin panel is an internal operations dashboard for pipeline management, user administration, system health monitoring, and data quality oversight. Unlike the public-facing views, this page prioritizes information density and operational clarity over aesthetics. Every indicator must be glanceable — red/amber/green status at a glance, with drill-down for details.
+
+Design principle: this is a control room, not a marketing page. No chrome, no decoration — just the data operators need to keep the platform running.
+
+---
+
+## 2. Page Layout
+
+### 2.1 Desktop (>=1280px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Admin                           [user avatar]   |
++-------+---------------------------------------------------------------+
+| NAV   | ADMIN TABS                                                    |
+| SIDE  | [Dashboard] [Users] [Pipeline] [Moderation] [Config]          |
+| BAR   +---------------------------------------------------------------+
+| (220) |                                                               |
+|       |  +-------------------+  +-------------------+  +----------+  |
+|       |  | SYSTEM HEALTH     |  | PIPELINE STATUS   |  | API USAGE|  |
+|       |  | Neo4j: ● UP       |  | Last run: 2h ago  |  | Today:   |  |
+|       |  | PostgreSQL: ● UP  |  | Status: ✓ Success |  | 12,847   |  |
+|       |  | Redis: ● UP       |  | Duration: 4m 23s  |  | req/day  |  |
+|       |  | API: ● UP         |  | Next: in 22h      |  |          |  |
+|       |  +-------------------+  +-------------------+  +----------+  |
+|       |                                                               |
+|       |  +----------------------------------------------------------+ |
+|       |  | DATA QUALITY METRICS                                     | |
+|       |  | Narrators: 4,892  | Hadith: 38,421  | Chains: 52,103   | |
+|       |  | Validation pass: 99.2%  | Rejected: 312 (0.8%)          | |
+|       |  | Last validation: 2h ago | [View rejection log →]        | |
+|       |  +----------------------------------------------------------+ |
+|       |                                                               |
+|       |  +----------------------------------------------------------+ |
+|       |  | API USAGE (7-day)                                        | |
+|       |  |  1200 ┤                          ╭─╮                     | |
+|       |  |   800 ┤              ╭─╮   ╭─╮  │ │                     | |
+|       |  |   400 ┤  ╭─╮  ╭─╮  │ │  │ │  │ │  ╭─╮                 | |
+|       |  |     0 ┤──╯ ╰──╯ ╰──╯ ╰──╯ ╰──╯ ╰──╯ ╰──             | |
+|       |  |        Mon  Tue  Wed  Thu  Fri  Sat  Sun               | |
+|       |  +----------------------------------------------------------+ |
+|       |                                                               |
+|       |  +----------------------------------------------------------+ |
+|       |  | RECENT AUDIT LOG                                         | |
+|       |  | 14:23  admin@noorina  Pipeline triggered (manual)        | |
+|       |  | 14:20  system         Validation completed (99.2% pass)  | |
+|       |  | 12:01  admin@noorina  User role changed: tariq → editor  | |
+|       |  | 11:45  system         Redis cache cleared                 | |
+|       |  | [View full audit log →]                                  | |
+|       |  +----------------------------------------------------------+ |
+|       |                                                               |
++-------+---------------------------------------------------------------+
+```
+
+### 2.2 Tablet (768px–1279px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Admin                          [hamburger] [user avatar]      |
++-----------------------------------------------------------------------+
+| [Dashboard] [Users] [Pipeline] [Moderation] [Config]                  |
++-----------------------------------------------------------------------+
+| +-------------------+  +-------------------+                          |
+| | SYSTEM HEALTH     |  | PIPELINE STATUS   |                          |
+| +-------------------+  +-------------------+                          |
+| +-------------------+  +-------------------+                          |
+| | DATA QUALITY      |  | API USAGE         |                          |
+| +-------------------+  +-------------------+                          |
+| +----------------------------------------------------------+         |
+| | AUDIT LOG                                                 |         |
+| +----------------------------------------------------------+         |
++-----------------------------------------------------------------------+
+```
+
+- Cards arranged in 2-column grid
+- Charts compress to fit narrower viewport
+
+### 2.3 Mobile (<768px)
+
+```
++-----------------------------------+
+| HEADER          [ham] [avatar]    |
++-----------------------------------+
+| [Tab: Dash] [Users] [Pipeline]   |
++-----------------------------------+
+| SYSTEM HEALTH                     |
+| Neo4j: ● UP | PG: ● UP          |
+| Redis: ● UP | API: ● UP         |
++-----------------------------------+
+| PIPELINE: ✓ Success (2h ago)     |
++-----------------------------------+
+| DATA QUALITY: 99.2% pass         |
++-----------------------------------+
+| API: 12,847 req today            |
++-----------------------------------+
+| AUDIT LOG (last 5)               |
+| ...                               |
++-----------------------------------+
+```
+
+- Read-only on mobile — no pipeline triggers or user management actions
+- Cards stack vertically, compact summaries only
+- Tab navigation for admin sections
+
+---
+
+## 3. Dashboard Tab (Default)
+
+### 3.1 System Health Cards
+
+```
++-------------------------------------------+
+| SYSTEM HEALTH                              |
++-------------------------------------------+
+| Neo4j 5.x          ● UP    4,892 nodes    |
+| PostgreSQL 16       ● UP    38,421 rows    |
+| Redis 7.x          ● UP    1.2 GB used    |
+| API (FastAPI)       ● UP    23ms avg resp  |
++-------------------------------------------+
+```
+
+- Status indicators: green circle (UP), red circle (DOWN), amber circle (DEGRADED)
+- Each row shows: service name, version, status, key metric
+- Click a row for detailed health view (connection pool, memory, query latency)
+- Health checks poll every 30 seconds; last-checked timestamp in tooltip
+- Status text always accompanies the color indicator (never color-only)
+
+### 3.2 Pipeline Status Card
+
+```
++-------------------------------------------+
+| PIPELINE STATUS                            |
++-------------------------------------------+
+| Last run:     2026-03-29 12:00 UTC         |
+| Status:       ✓ Completed successfully     |
+| Duration:     4m 23s                       |
+| Next run:     2026-03-30 12:00 UTC (auto)  |
+|                                            |
+| Stage breakdown:                           |
+| [✓] Acquire    ██████████  1m 02s          |
+| [✓] Parse      ██████████  0m 48s          |
+| [✓] Resolve    ██████████  1m 35s          |
+| [✓] Load       ██████████  0m 38s          |
+| [✓] Enrich     ██████████  0m 20s          |
+|                                            |
+| [Trigger manual run ▶]  [View logs]       |
++-------------------------------------------+
+```
+
+- Stage progress bars show relative time per stage
+- Failed stages show [✗] in red with error message expandable
+- "Trigger manual run" requires confirmation dialog
+- "View logs" opens a scrollable log viewer (monospace, with timestamps)
+
+### 3.3 Data Quality Metrics
+
+```
++----------------------------------------------------------+
+| DATA QUALITY                                              |
++----------------------------------------------------------+
+| Entity counts:                                            |
+| Narrators:  4,892    Hadith: 38,421    Chains: 52,103   |
+| Collections: 14      Gradings: 87,204  Events: 234       |
+|                                                           |
+| Validation:                                               |
+| Pass rate:     99.2% (38,109 / 38,421)                   |
+| Rejected:      312 records (0.8%)                         |
+| Last run:      2026-03-29 12:04 UTC                      |
+|                                                           |
+| Top rejection reasons:                                    |
+| 1. Missing narrator ID (142)                              |
+| 2. Duplicate chain hash (89)                              |
+| 3. Invalid date range (54)                                |
+| 4. Other (27)                                             |
+|                                                           |
+| [View rejection log →]  [Re-validate →]                  |
++----------------------------------------------------------+
+```
+
+### 3.4 API Usage Chart
+
+```
++----------------------------------------------------------+
+| API USAGE                                    [7d|30d|90d] |
++----------------------------------------------------------+
+|                                                           |
+|  1200 ┤                          ╭─╮                      |
+|   800 ┤              ╭─╮   ╭─╮  │ │                      |
+|   400 ┤  ╭─╮  ╭─╮  │ │  │ │  │ │  ╭─╮                  |
+|     0 ┤──╯ ╰──╯ ╰──╯ ╰──╯ ╰──╯ ╰──╯ ╰──              |
+|        Mon  Tue  Wed  Thu  Fri  Sat  Sun                  |
+|                                                           |
+| Total today: 12,847 requests                              |
+| Top endpoints:                                            |
+|   /api/v1/narrators    (4,231)                           |
+|   /api/v1/hadith       (3,892)                           |
+|   /api/v1/search       (2,104)                           |
+|   /api/v1/graph        (1,820)                           |
++----------------------------------------------------------+
+```
+
+- Bar chart showing daily request volume
+- Time range toggle: 7 days, 30 days, 90 days
+- Top endpoints listed below chart
+- Hover on bar shows exact count for that day
+
+### 3.5 Audit Log
+
+```
++----------------------------------------------------------+
+| RECENT ACTIVITY                            [View full →] |
++----------------------------------------------------------+
+| 14:23  admin@noorina   Pipeline triggered (manual)       |
+| 14:20  system          Validation completed (99.2%)      |
+| 12:01  admin@noorina   User role changed: tariq → editor |
+| 11:45  system          Redis cache cleared               |
+| 09:30  api-key-4a2f    Rate limit triggered (150 req/s)  |
++----------------------------------------------------------+
+```
+
+- Most recent 5 entries shown on dashboard
+- Timestamp, actor, action description
+- "View full" navigates to dedicated audit log viewer with filtering and search
+
+---
+
+## 4. Users Tab
+
+```
++-----------------------------------------------------------------------+
+| USERS                                    [Invite user +] [Export CSV] |
++-----------------------------------------------------------------------+
+| [Search users...]                        [Role: All v] [Status: All v]|
++-----------------------------------------------------------------------+
+| +-----+--------------------+----------+----------+-------------------+ |
+| |     | Name               | Email    | Role     | Last active       | |
+| +-----+--------------------+----------+----------+-------------------+ |
+| | [✓] | Kwame Asante       | k@...    | Admin    | 2h ago            | |
+| | [ ] | Tariq Al-Rashidi   | t@...    | Editor   | 1d ago            | |
+| | [ ] | Mei-Lin Chang      | m@...    | Viewer   | 3d ago            | |
+| | [ ] | api-key-4a2f       | —        | API      | 12m ago           | |
+| +-----+--------------------+----------+----------+-------------------+ |
+|                                                                       |
+| Selected: 1                         [Edit role] [Disable] [Delete]   |
++-----------------------------------------------------------------------+
+| API KEYS                                            [Generate key +]  |
++-----------------------------------------------------------------------+
+| +--------------------+----------+-----------+------------------------+ |
+| | Key                | Owner    | Created   | Last used              | |
+| +--------------------+----------+-----------+------------------------+ |
+| | key-4a2f...8e91    | system   | 2026-03-01| 12m ago               | |
+| | key-7b3c...2d45    | tariq    | 2026-03-15| 1d ago                | |
+| +--------------------+----------+-----------+------------------------+ |
+| Selected: 0                                  [Revoke] [Regenerate]   |
++-----------------------------------------------------------------------+
+```
+
+- User table with sortable columns
+- Bulk actions via checkbox selection
+- Role options: Admin, Editor, Viewer, API
+- Status indicators: active (green), disabled (gray)
+- "Invite user" opens a modal with email input and role selector
+- API keys section below user table
+- Keys partially masked (first 8 + last 4 characters visible)
+- "Generate key" opens modal with scope and expiry settings
+- Destructive actions (Delete, Revoke) require confirmation dialog
+
+---
+
+## 5. Pipeline Tab
+
+```
++-----------------------------------------------------------------------+
+| PIPELINE MANAGEMENT                                                   |
++-----------------------------------------------------------------------+
+| [Trigger full pipeline ▶]  [Select stages...] [Trigger selected ▶]   |
++-----------------------------------------------------------------------+
+|                                                                       |
+| RUN HISTORY                                                           |
++-----------------------------------------------------------------------+
+| +----------+--------+----------+----------+--------------------------+ |
+| | Run ID   | Status | Started  | Duration | Stages                   | |
+| +----------+--------+----------+----------+--------------------------+ |
+| | run-047  | ✓ Pass | 12:00    | 4m 23s   | All 5 stages            | |
+| | run-046  | ✗ Fail | 00:00    | 2m 11s   | Failed at: Resolve      | |
+| | run-045  | ✓ Pass | 12:00 y. | 4m 18s   | All 5 stages            | |
+| +----------+--------+----------+----------+--------------------------+ |
+|                                                                       |
+| Expand run-046:                                                       |
+| +---------------------------------------------------------------+    |
+| | [✓] Acquire   1m 02s   12,847 records fetched                 |    |
+| | [✓] Parse     0m 48s   12,847 → 12,501 parsed (346 skipped)  |    |
+| | [✗] Resolve   0m 21s   ERROR: FAISS index corrupt             |    |
+| |     Stack trace:                                               |    |
+| |     > src/resolve/disambiguate.py:142                          |    |
+| |     > faiss.read_index("data/staging/narrator.faiss")          |    |
+| |     > RuntimeError: could not read index                       |    |
+| | [—] Load      skipped                                         |    |
+| | [—] Enrich    skipped                                         |    |
+| |                                                                |    |
+| | [Re-run from Resolve ▶]  [View full logs]                    |    |
+| +---------------------------------------------------------------+    |
+|                                                                       |
+| SOURCE CONFIGURATION                                                  |
+| +--------------------+----------+-----------------------------------+ |
+| | Source             | Enabled  | Last fetch                        | |
+| +--------------------+----------+-----------------------------------+ |
+| | Sunnah.com API     | [x]      | 2026-03-29 12:00                 | |
+| | Kaggle (Bukhari)   | [x]      | 2026-03-29 12:00                 | |
+| | IslamWeb           | [x]      | 2026-03-29 12:01                 | |
+| | al-Kafi (manual)   | [ ]      | 2026-03-15 (stale)               | |
+| +--------------------+----------+-----------------------------------+ |
++-----------------------------------------------------------------------+
+```
+
+- "Trigger full pipeline" runs all 5 stages sequentially
+- "Select stages" allows cherry-picking specific stages to run
+- Run history table with expandable rows for stage details
+- Failed runs show error details, stack trace, and "Re-run from [stage]" button
+- Source configuration table with enable/disable toggles
+
+---
+
+## 6. Moderation Tab
+
+```
++-----------------------------------------------------------------------+
+| MODERATION QUEUE (7 pending)                                          |
++-----------------------------------------------------------------------+
+| [All (7)] [Narrator edits (3)] [Hadith corrections (2)] [Reports (2)]|
++-----------------------------------------------------------------------+
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | NARRATOR EDIT REQUEST                      Submitted: 2h ago      | |
+| | User: tariq@noorina  |  Type: Name correction                    | |
+| |                                                                   | |
+| | Current:  Abu Hurairah (ابو هريرة)                                 | |
+| | Proposed: Abu Hurayra al-Dawsi (ابو هريرة الدوسي)                   | |
+| | Reason: "Adding full nisba for disambiguation"                     | |
+| |                                                                   | |
+| | [Approve ✓]  [Reject ✗]  [Edit & approve]                        | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | HADITH CORRECTION                          Submitted: 5h ago      | |
+| | User: mei@noorina  |  Type: Translation fix                      | |
+| |                                                                   | |
+| | Current:  "Deeds are by intentions..."                            | |
+| | Proposed: "Actions are judged by intentions..."                    | |
+| | Reason: "More accurate translation per Lane's Lexicon"             | |
+| |                                                                   | |
+| | [Approve ✓]  [Reject ✗]  [Edit & approve]                        | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Queue items categorized by type
+- Each item shows: current vs proposed state, submitter, reason
+- Three actions: Approve, Reject (with required reason), Edit & Approve
+- Rejected items notify the submitter with the rejection reason
+- Queue count shown in tab badge
+
+---
+
+## 7. Config Tab
+
+```
++-----------------------------------------------------------------------+
+| CONFIGURATION                                                         |
++-----------------------------------------------------------------------+
+|                                                                       |
+| GENERAL                                                               |
+| +-------------------------------------------------------------------+ |
+| | Site name:          [Isnad Graph                              ]   | |
+| | Default language:   [English v]                                   | |
+| | API rate limit:     [150    ] requests/second                     | |
+| | Session timeout:    [30     ] minutes                             | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| PIPELINE                                                              |
+| +-------------------------------------------------------------------+ |
+| | Auto-run schedule:  [Daily at 12:00 UTC v]                        | |
+| | Node count limit:   [5000   ] (max for graph explorer)            | |
+| | Similarity threshold: [0.80 ] (parallel detection cutoff)          | |
+| | Validation strictness: [Standard v]                                | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| CACHE                                                                 |
+| +-------------------------------------------------------------------+ |
+| | Redis TTL:          [3600   ] seconds                             | |
+| | Cache warming:      [x] Enabled                                   | |
+| | [Clear all cache]                                                  | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+|                                   [Save changes]  [Revert to saved]  |
++-----------------------------------------------------------------------+
+```
+
+- Form-based configuration with current values pre-filled
+- "Save changes" validates inputs and persists
+- "Revert to saved" resets form to last-saved state
+- Destructive actions (Clear cache) require confirmation
+- Changes to pipeline config take effect on next run
+
+---
+
+## 8. RTL and Bidirectional Text
+
+### 8.1 Admin Content
+
+- Arabic text in moderation queue items uses `dir="rtl"` blocks
+- Narrator names in user/audit tables show English only (admin context)
+- Moderation items show both Arabic and English with proper bidi isolation
+
+### 8.2 Layout Direction
+
+- Admin layout remains LTR throughout — this is an internal operations interface
+- Arabic content within moderation items and data quality examples uses inline RTL blocks
+
+### 8.3 Font Stack
+
+```css
+--font-arabic: 'Noto Naskh Arabic', 'Geeza Pro', 'Traditional Arabic', serif;
+--font-ui: system-ui, -apple-system, sans-serif;
+--font-mono: 'JetBrains Mono', 'Fira Code', monospace;  /* logs, stack traces */
+```
+
+---
+
+## 9. Accessibility
+
+### 9.1 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move through tab bar, then through cards/tables within active tab |
+| Arrow left/right | Switch between admin tabs |
+| Arrow up/down | Navigate table rows |
+| Enter | Expand table row, activate buttons |
+| Space | Toggle checkboxes |
+| Escape | Close modals, cancel actions |
+
+### 9.2 Screen Reader Support
+
+- Tab bar: `role="tablist"` with `aria-selected` on active tab
+- Status indicators: "Neo4j: status UP" (never just the color)
+- Pipeline stages: "Acquire: completed, duration 1 minute 2 seconds"
+- Moderation queue: `aria-label="Moderation queue, 7 pending items"`
+- Charts: accessible data table alternative below each chart
+- Audit log: `role="log"` with `aria-live="polite"` for new entries
+
+### 9.3 High Contrast Mode
+
+- Status indicator circles gain 2px black outlines
+- Chart bars gain 2px black outlines and pattern fills
+- Table row borders become 1px solid black
+- Focus ring: 3px solid with offset on all interactive elements
+
+### 9.4 Reduced Motion
+
+- Health check polling indicators are static (no pulse animation)
+- Chart transitions are instant
+- Log entries appear without slide-in animation
+
+---
+
+## 10. Responsive Breakpoint Summary
+
+| Feature | Desktop (>=1280) | Tablet (768-1279) | Mobile (<768) |
+|---------|:---:|:---:|:---:|
+| Nav sidebar | Visible (220px) | Hamburger overlay | Hamburger overlay |
+| Admin tabs | Horizontal tab bar | Horizontal tab bar | Scrollable tabs |
+| Dashboard cards | 3-column grid | 2-column grid | Single column |
+| User management | Full table + actions | Full table, actions in menu | Read-only list |
+| Pipeline controls | Full controls | Full controls | Read-only status |
+| Moderation queue | Full cards + actions | Full cards + actions | Read-only cards |
+| Charts | Full size | Compressed | Sparkline only |
+| Config panel | Full form | Full form | Read-only display |
+| Audit log | 5 entries + full view | 5 entries + full view | 3 entries |
+
+---
+
+## 11. Component Mapping
+
+| Wireframe element | Component | Notes |
+|-------------------|-----------|-------|
+| Page shell | `AdminPage.tsx` | New page, route: `/admin`, requires admin role |
+| Tab navigation | `AdminTabs` | Horizontal tab bar with badge counts |
+| System health | `SystemHealthCards` | Polling health check display |
+| Pipeline status | `PipelineStatus` | Stage breakdown, trigger controls |
+| Data quality | `DataQualityMetrics` | Entity counts, validation stats |
+| API usage chart | `ApiUsageChart` | Bar chart with time range toggle |
+| Audit log | `AuditLog` | Timestamped event list, filterable |
+| User table | `UserManagement` | CRUD table with role management |
+| API key manager | `ApiKeyManager` | Generate, revoke, list keys |
+| Moderation queue | `ModerationQueue` | Review cards with approve/reject |
+| Config form | `AdminConfig` | Form with validation and save |
+
+---
+
+## 12. Design Tokens
+
+```css
+/* Status indicators */
+--status-up: oklch(60% 0.15 150);        /* green */
+--status-down: oklch(55% 0.15 25);       /* red */
+--status-degraded: oklch(70% 0.15 60);   /* amber */
+--status-unknown: oklch(55% 0.05 0);     /* gray */
+
+/* Admin cards */
+--admin-card-bg: #ffffff;
+--admin-card-border: #e0e0e0;
+--admin-card-padding: 16px;
+--admin-card-radius: 6px;
+
+/* Charts */
+--chart-bar-fill: oklch(65% 0.15 250);   /* blue */
+--chart-bar-hover: oklch(55% 0.18 250);  /* darker blue */
+--chart-grid: #f0f0f0;
+--chart-axis: #333333;
+
+/* Log entries */
+--log-font: var(--font-mono);
+--log-font-size: 13px;
+--log-timestamp-color: #888888;
+--log-actor-color: #1a73e8;
+
+/* Moderation */
+--mod-approve: oklch(60% 0.15 150);
+--mod-reject: oklch(55% 0.15 25);
+--mod-pending-bg: oklch(95% 0.02 60);    /* light amber tint */
+```
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-29 | Sable Nakamura-Whitfield | Initial wireframe specification |

--- a/docs/ux/wireframes/comparative.md
+++ b/docs/ux/wireframes/comparative.md
@@ -1,0 +1,443 @@
+# Comparative View — Wireframe Specification
+
+**Author:** Sable Nakamura-Whitfield (Principal UX Designer)
+**Issue:** #541
+**Date:** 2026-03-29
+**Status:** Draft
+
+---
+
+## 1. Design Intent
+
+The comparative view enables side-by-side analysis of parallel hadith across Sunni and Shia collections. It answers the scholarly question: "How does the same tradition appear in different sources, what textual variations exist, and where do the isnad chains converge or diverge?"
+
+The design uses a split-panel layout inspired by textual criticism tools. Diff highlighting draws the eye to variation without obscuring the base text. Chain comparison reveals shared narrators as structural evidence of common transmission pathways.
+
+---
+
+## 2. Page Layout
+
+### 2.1 Desktop (>=1280px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Comparative Analysis            [user avatar]   |
++-------+---------------------------------------------------------------+
+| NAV   | SELECTOR BAR                                                  |
+| SIDE  | [Select hadith A...] [vs] [Select hadith B...]  [+ Add C]     |
+| BAR   | [Collection filter v] [Grade filter v]           [Reset]      |
+| (220) +-----------------------------------+---------------------------+
+|       | HADITH A                          | HADITH B                  |
+|       | Bukhari 1                         | Muslim 1907               |
+|       |                                   |                           |
+|       | إنما الأعمال بالنيات وإنما لكل     | إنما الأعمال بالنيات وإنما  |
+|       | امرئ ما نوى فمن كانت هجرته        | لكل امرئ ما نوى فمن كانت   |
+|       | إلى دنيا يصيبها أو إلى امرأة      | هجرته إلى الله ورسوله       |
+|       | ينكحها فهجرته إلى ما هاجر إليه    | فهجرته إلى الله ورسوله      |
+|       |                                   | ومن كانت هجرته لدنيا        |
+|       | ─────────────────────             | ─────────────────────     |
+|       | "Actions are judged by            | "Actions are judged by    |
+|       | intentions..."                    | intentions..."            |
+|       |                                   |                           |
+|       | Grade: Sahih                      | Grade: Sahih              |
+|       | Similarity: 0.96                                              |
+|       +-----------------------------------+---------------------------+
+|       | CHAIN COMPARISON                                              |
+|       |                                                               |
+|       | A: Prophet → Umar → Alqama → M.Ibrahim → Yahya → Sufyan → B. |
+|       | B: Prophet → Umar → Alqama → M.Ibrahim → Yahya → Malik → M.  |
+|       |    ●━━━━━━●━━━━━━●━━━━━━●━━━━━━━━●┐                           |
+|       |                                   ├→ ● Sufyan → ● Bukhari     |
+|       |                                   └→ ● Malik  → ● Muslim      |
+|       |    [shared]  [shared]  [shared]  [shared] [diverge]           |
+|       +---------------------------------------------------------------+
+|       | DIFF SUMMARY                                                  |
+|       +---------------------------------------------------------------+
+```
+
+### 2.2 Tablet (768px–1279px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER                                 [hamburger] [user avatar]      |
++-----------------------------------------------------------------------+
+| [Select hadith A...] [vs] [Select hadith B...]                        |
+| [Collection v] [Grade v]                              [Reset]         |
++-----------------------------------------------------------------------+
+| HADITH A (full width)                                                 |
+| Bukhari 1                                                             |
+| [Arabic text]                                                         |
+| [Translation]                                                         |
++-----------------------------------------------------------------------+
+| HADITH B (full width)                                                 |
+| Muslim 1907                                                           |
+| [Arabic text]          (diff highlights inline)                       |
+| [Translation]                                                         |
++-----------------------------------------------------------------------+
+| CHAIN COMPARISON (full width, horizontal scroll)                      |
++-----------------------------------------------------------------------+
+| DIFF SUMMARY                                                          |
++-----------------------------------------------------------------------+
+```
+
+- Hadith panels stack vertically instead of side-by-side
+- Diff highlights shown inline within the text
+
+### 2.3 Mobile (<768px)
+
+```
++-----------------------------------+
+| HEADER          [ham] [avatar]    |
++-----------------------------------+
+| [Select A...] [vs] [Select B...] |
++-----------------------------------+
+| [Tab: Hadith A] [Hadith B] [Diff]|
++-----------------------------------+
+| (tab content)                     |
+|                                   |
+| [Arabic text with diff marks]    |
+|                                   |
++-----------------------------------+
+| Similarity: 0.96    [Full diff]  |
++-----------------------------------+
+```
+
+- Tab interface to switch between hadith A, hadith B, and diff view
+- Chain comparison accessible via "Full diff" button (opens full-screen overlay)
+
+---
+
+## 3. Hadith Selector
+
+### 3.1 Selector Bar
+
+```
++-----------------------------------------------------------------------+
+| [Select hadith A...]  [vs]  [Select hadith B...]   [+ Add C]         |
++-----------------------------------------------------------------------+
+```
+
+- Two search inputs for selecting hadith to compare
+- Search accepts: hadith number (e.g., "Bukhari 1"), narrator name, or matn text
+- Typeahead dropdown grouped by collection
+- `[vs]` is a visual separator, not interactive
+- `[+ Add C]` adds a third comparison column (maximum 3)
+- Removing a hadith: [x] button within the selector input
+
+### 3.2 Pre-populated Entry
+
+When arriving from a hadith detail page's "Compare parallels" link:
+- Hadith A is pre-filled with the source hadith
+- Hadith B shows the top parallel by similarity score
+- User can change either selection
+
+### 3.3 Filter Controls
+
+```
+  [Collection filter v]              [Grade filter v]
+  +----------------------------+     +-------------------+
+  | [x] Bukhari               |     | [x] Sahih         |
+  | [x] Muslim                |     | [x] Hasan         |
+  | [x] Abu Dawud             |     | [ ] Da'if         |
+  | [x] Tirmidhi              |     | [ ] Mawdu'        |
+  | [x] al-Kafi (Shia)        |     +-------------------+
+  | ...                        |
+  +----------------------------+
+```
+
+- Filters apply to the typeahead search results, not to the displayed hadith
+- Useful for cross-sectarian comparison (selecting both Sunni and Shia collections)
+
+---
+
+## 4. Hadith Comparison Panels
+
+### 4.1 Side-by-Side Text
+
+```
++-----------------------------------+----------------------------------+
+| HADITH A: Bukhari 1              | HADITH B: Muslim 1907            |
++-----------------------------------+----------------------------------+
+|                                   |                                  |
+| إنما الأعمال بالنيات وإنما لكل    | إنما الأعمال بالنيات وإنما لكل   |
+| امرئ ما نوى فمن كانت هجرته       | امرئ ما نوى فمن كانت هجرته      |
+| [إلى دنيا يصيبها أو إلى امرأة]   | [إلى الله ورسوله فهجرته إلى]     |
+| [ينكحها فهجرته إلى ما هاجر إليه] | [الله ورسوله ومن كانت هجرته]     |
+|                                   | [لدنيا يصيبها أو إلى امرأة]     |
+|                                   | [ينكحها فهجرته إلى ما هاجر إليه]|
+| ─────────────────────             | ─────────────────────            |
+| "Actions are judged by            | "Actions are judged by           |
+| intentions, and each person       | intentions, and each person      |
+| will get the reward according     | will get the reward according    |
+| to what he intended.              | to what he intended.             |
+| [So whoever emigrated for         | [So whoever emigrated to         |
+| worldly benefits or for a woman]  | Allah and His Messenger, his     |
+| [to marry, his emigration was     | emigration is to Allah and       |
+| for what he emigrated for."]      | His Messenger. And whoever       |
+|                                   | emigrated for worldly benefits]  |
+|                                   | ..."                             |
++-----------------------------------+----------------------------------+
+| Similarity: 0.96    |  Textual overlap: 78%                        |
++-----------------------------------------------------------------------+
+```
+
+- Panels scroll in sync (scrolling one scrolls the other)
+- Diff-highlighted sections use background color:
+  - Text unique to A: `oklch(70% 0.08 25)` — light red background
+  - Text unique to B: `oklch(70% 0.08 150)` — light green background
+  - Shared text: no highlight
+- Diff operates at the word level for Arabic text, respecting word boundaries
+- Brackets in the ASCII art above represent highlighted diff regions
+- Both Arabic and English text are diff-highlighted
+
+### 4.2 Three-Way Comparison
+
+When a third hadith (C) is added:
+
+```
++-------------------------+-------------------------+-------------------------+
+| HADITH A: Bukhari 1    | HADITH B: Muslim 1907   | HADITH C: Tirmidhi 24  |
++-------------------------+-------------------------+-------------------------+
+| [Arabic text]           | [Arabic text]            | [Arabic text]           |
+| [Translation]           | [Translation]            | [Translation]           |
++-------------------------+-------------------------+-------------------------+
+```
+
+- Three equal-width columns
+- Diff highlighting uses three colors (one per source)
+- Similarity scores shown pairwise: A-B, A-C, B-C
+
+### 4.3 Metadata Row
+
+Below the text panels:
+
+```
++-----------------------------------+----------------------------------+
+| Collection: Sahih al-Bukhari      | Collection: Sahih Muslim         |
+| Book: كتاب بدء الوحي               | Book: كتاب الإيمان                |
+| Number: 1                         | Number: 1907                     |
+| Grade: Sahih                      | Grade: Sahih                     |
+| Chain length: 7                   | Chain length: 6                  |
++-----------------------------------+----------------------------------+
+```
+
+---
+
+## 5. Chain Comparison
+
+### 5.1 Merged Chain Graph
+
+```
++-----------------------------------------------------------------------+
+| CHAIN COMPARISON                              [Merged | Side-by-side] |
++-----------------------------------------------------------------------+
+|                                                                       |
+|  Prophet Muhammad                                                     |
+|       │                                                               |
+|       ▼                                                               |
+|  Umar ibn al-Khattab          ── SHARED (both chains)                 |
+|       │                                                               |
+|       ▼                                                               |
+|  Alqama ibn Waqqas            ── SHARED                               |
+|       │                                                               |
+|       ▼                                                               |
+|  Muhammad ibn Ibrahim         ── SHARED                               |
+|       │                                                               |
+|       ▼                                                               |
+|  Yahya ibn Sa'id              ── SHARED (divergence point)            |
+|       ├────────────┐                                                  |
+|       ▼            ▼                                                  |
+|  Sufyan ibn       Malik ibn                                           |
+|  'Uyayna          Anas                                                |
+|  (A only)         (B only)                                            |
+|       │            │                                                  |
+|       ▼            ▼                                                  |
+|  al-Bukhari       Muslim                                              |
+|  (Compiler A)     (Compiler B)                                        |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Merged view (default): shared narrators shown once, divergences branching
+- Color encoding:
+  - Shared nodes: neutral fill (#666)
+  - A-only nodes: oklch(65% 0.15 250) — blue
+  - B-only nodes: oklch(70% 0.15 60) — amber
+- Shared edges: solid line
+- Divergent edges: colored by source (A or B)
+- Each narrator node is clickable (navigates to narrator detail)
+
+### 5.2 Side-by-Side Chains
+
+```
++---------------------------------+---------------------------------+
+| CHAIN A (Bukhari 1)             | CHAIN B (Muslim 1907)           |
++---------------------------------+---------------------------------+
+| Prophet Muhammad    ────────── ●| Prophet Muhammad ●              |
+| Umar ibn al-Khattab ───────── ●| Umar ibn al-Khattab ●          |
+| Alqama ibn Waqqas   ───────── ●| Alqama ibn Waqqas ●            |
+| M. ibn Ibrahim      ───────── ●| M. ibn Ibrahim ●               |
+| Yahya ibn Sa'id     ───────── ●| Yahya ibn Sa'id ●              |
+| Sufyan ibn 'Uyayna            ●| Malik ibn Anas ●               |
+| al-Bukhari                    ●| Muslim ●                        |
++---------------------------------+---------------------------------+
+```
+
+- Parallel columns with shared narrators aligned horizontally
+- Connecting lines between shared narrators across columns
+- Unique narrators are visually distinct (colored, no connector)
+
+---
+
+## 6. Diff Summary
+
+```
++-----------------------------------------------------------------------+
+| DIFF SUMMARY                                                          |
++-----------------------------------------------------------------------+
+|                                                                       |
+| Textual overlap:     78%  (word-level comparison)                     |
+| Semantic similarity: 0.96 (CAMeLBERT cosine similarity)               |
+| Shared narrators:    5 of 7 (A) / 6 (B)                              |
+| Divergence point:    Yahya ibn Sa'id al-Ansari                        |
+|                                                                       |
+| Key textual differences:                                              |
+| 1. Hadith B includes additional clause about emigrating "to Allah     |
+|    and His Messenger" not present in A                                |
+| 2. Hadith A has shorter conclusion                                    |
+| 3. Wording of worldly emigration differs slightly                     |
+|                                                                       |
+| [Export comparison →]  [Citation →]                                   |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Summary statistics at a glance
+- Key differences enumerated
+- "Export comparison" generates a formatted PDF/text with both texts and analysis
+- "Citation" provides formatted academic citation for the comparison
+
+---
+
+## 7. RTL and Bidirectional Text
+
+### 7.1 Arabic Text in Comparison Panels
+
+- Each panel renders Arabic text in `dir="rtl"` blocks with `lang="ar"` and `--font-arabic`
+- Diff highlighting backgrounds apply to Arabic words without breaking ligatures or diacritics
+- Word-level diff algorithm respects Arabic word boundaries (space-delimited, with clitic awareness)
+
+### 7.2 Synchronized Scrolling
+
+- When panels are side-by-side, both scroll together vertically
+- Arabic text (RTL) and English text (LTR) maintain their respective directions within each panel
+- Horizontal scroll within a panel is independent (for long Arabic lines)
+
+### 7.3 Font Stack
+
+```css
+--font-arabic: 'Noto Naskh Arabic', 'Geeza Pro', 'Traditional Arabic', serif;
+--font-ui: system-ui, -apple-system, sans-serif;
+```
+
+---
+
+## 8. Accessibility
+
+### 8.1 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move through: selector A > selector B > filters > panel A > panel B > chain > diff summary |
+| Arrow left/right | Switch focus between comparison panels |
+| Arrow up/down | Scroll within focused panel |
+| Enter | Select hadith from dropdown, activate links in chain |
+| Escape | Close dropdowns, deselect |
+| d | Toggle diff highlighting on/off |
+
+### 8.2 Screen Reader Support
+
+- Page title: `<title>Compare Bukhari 1 vs Muslim 1907 — Isnad Graph</title>`
+- Comparison panels: `role="region"` with `aria-label="Hadith A: Bukhari 1"` and `aria-label="Hadith B: Muslim 1907"`
+- Diff highlights: inline `<mark>` elements with `aria-label="Text unique to Bukhari version"` / `aria-label="Text unique to Muslim version"`
+- Chain comparison: accessible as `<ol>` with shared/unique status announced per node
+- Diff summary: `aria-label="Comparison summary: 78% textual overlap, 0.96 semantic similarity, 5 shared narrators"`
+
+### 8.3 High Contrast Mode
+
+- Diff highlight colors become higher contrast (dark red/green backgrounds with white text)
+- Chain shared/unique distinction adds pattern fills
+- Panel borders become 2px solid black
+- Connecting lines in chain comparison become 2px solid
+
+### 8.4 Reduced Motion
+
+- Panel scroll synchronization is instant
+- Chain graph renders in final position without animation
+- Diff highlights appear instantly
+
+---
+
+## 9. Responsive Breakpoint Summary
+
+| Feature | Desktop (>=1280) | Tablet (768-1279) | Mobile (<768) |
+|---------|:---:|:---:|:---:|
+| Nav sidebar | Visible (220px) | Hamburger overlay | Hamburger overlay |
+| Comparison layout | Side-by-side | Stacked | Tab view |
+| Max hadith compared | 3 | 2 | 2 |
+| Chain comparison | Merged + side-by-side toggle | Merged only | Full-screen overlay |
+| Diff highlighting | Inline, synchronized | Inline, sequential | Inline per tab |
+| Synchronized scroll | Yes | n/a (stacked) | n/a (tabs) |
+| Export | PDF/text/citation | Text/citation | Citation only |
+| Selector | Two inline inputs | Two inline inputs | Stacked inputs |
+
+---
+
+## 10. Component Mapping
+
+| Wireframe element | Component | Notes |
+|-------------------|-----------|-------|
+| Page shell | `ComparativePage.tsx` | New page, route: `/compare/:idA/:idB` |
+| Hadith selector | `HadithSelector` | Typeahead search, pre-populated from navigation |
+| Comparison panel | `ComparisonPanel` | Renders text with diff highlighting |
+| Diff engine | `TextDiffEngine` | Word-level Arabic-aware diff algorithm |
+| Chain comparison | `ChainComparison` | Merged and side-by-side views |
+| Diff summary | `DiffSummary` | Statistics and key differences |
+| Export | `ComparisonExport` | PDF/text generation |
+
+---
+
+## 11. Design Tokens
+
+```css
+/* Comparison panels */
+--panel-bg: #ffffff;
+--panel-border: #e0e0e0;
+--panel-gap: 1px;
+--panel-divider: #d0d0d0;
+
+/* Diff highlighting */
+--diff-added-bg: oklch(92% 0.04 150);      /* light green */
+--diff-removed-bg: oklch(92% 0.04 25);     /* light red */
+--diff-added-bg-contrast: oklch(30% 0.08 150);  /* dark green (high contrast) */
+--diff-removed-bg-contrast: oklch(30% 0.08 25); /* dark red (high contrast) */
+
+/* Chain comparison */
+--chain-shared-color: #666666;
+--chain-a-color: oklch(65% 0.15 250);      /* blue */
+--chain-b-color: oklch(70% 0.15 60);       /* amber */
+--chain-c-color: oklch(60% 0.15 150);      /* green */
+
+/* Similarity badge */
+--similarity-high: oklch(60% 0.15 150);
+--similarity-mid: oklch(70% 0.15 60);
+--similarity-low: oklch(55% 0.10 0);
+```
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-29 | Sable Nakamura-Whitfield | Initial wireframe specification |

--- a/docs/ux/wireframes/hadith-detail.md
+++ b/docs/ux/wireframes/hadith-detail.md
@@ -1,0 +1,436 @@
+# Hadith Detail — Wireframe Specification
+
+**Author:** Sable Nakamura-Whitfield (Principal UX Designer)
+**Issue:** #539
+**Date:** 2026-03-29
+**Status:** Draft
+
+---
+
+## 1. Design Intent
+
+The hadith detail page presents a single hadith in full scholarly context: complete Arabic text with translation, the isnad chain rendered as a navigable visualization, grading assessments from multiple scholars, collection attribution, and parallel hadith across collections. The page should feel like a well-typeset critical edition — the text is primary, everything else supports close reading.
+
+---
+
+## 2. Page Layout
+
+### 2.1 Desktop (>=1280px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Bukhari > Book 1 > Hadith 1    [user avatar]   |
++-------+---------------------------------------------------------------+
+| NAV   | HADITH TEXT (Arabic + Translation)                             |
+| SIDE  +-------------------------------+-------------------------------+
+| BAR   | ISNAD CHAIN VISUALIZATION     | GRADING & METADATA            |
+| (220) | (flex: 1)                     | (360px)                       |
+|       |                               |                               |
+|       |  Prophet ──→ Umar ──→ ...     | Collection: Bukhari           |
+|       |                               | Book: بدء الوحي (Revelation)   |
+|       |                               | Number: 1                     |
+|       |                               | Grade: Sahih                  |
+|       |                               |                               |
+|       +-------------------------------+-------------------------------+
+|       | PARALLEL HADITH                                                |
+|       +---------------------------------------------------------------+
+|       | TOPICS & CLASSIFICATION                                        |
+|       +---------------------------------------------------------------+
+|       | CITATION & SHARE                                               |
+|       +---------------------------------------------------------------+
+```
+
+### 2.2 Tablet (768px–1279px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER                                 [hamburger] [user avatar]      |
++-----------------------------------------------------------------------+
+| HADITH TEXT (full width)                                              |
++-----------------------------------------------------------------------+
+| ISNAD CHAIN VISUALIZATION (full width)                                |
++-----------------------------------------------------------------------+
+| GRADING & METADATA (full width)                                       |
++-----------------------------------------------------------------------+
+| PARALLEL HADITH                                                       |
++-----------------------------------------------------------------------+
+| TOPICS | CITATION                                                     |
++-----------------------------------------------------------------------+
+```
+
+### 2.3 Mobile (<768px)
+
+```
++-----------------------------------+
+| HEADER          [ham] [avatar]    |
++-----------------------------------+
+| HADITH TEXT (compact)             |
++-----------------------------------+
+| [Tab: Chain] [Grading] [Parallel] |
++-----------------------------------+
+| (tab content)                     |
++-----------------------------------+
+| CITATION (sticky bottom bar)     |
++-----------------------------------+
+```
+
+- Sections below hadith text reorganized into tabs to reduce scroll
+- Citation/share as a sticky bottom bar for easy access
+
+---
+
+## 3. Hadith Text Section
+
+```
++-----------------------------------------------------------------------+
+|                                                                       |
+|  بسم الله الرحمن الرحيم                                                 |  <- dir="rtl"
+|                                                                       |
+|  حدثنا الحميدي عبد الله بن الزبير قال حدثنا سفيان قال حدثنا           |
+|  يحيى بن سعيد الأنصاري قال أخبرني محمد بن إبراهيم التيمي أنه          |
+|  سمع علقمة بن وقاص الليثي يقول سمعت عمر بن الخطاب رضي الله            |
+|  عنه على المنبر قال سمعت رسول الله صلى الله عليه وسلم يقول             |
+|  إنما الأعمال بالنيات وإنما لكل امرئ ما نوى فمن كانت هجرته إلى        |
+|  دنيا يصيبها أو إلى امرأة ينكحها فهجرته إلى ما هاجر إليه             |
+|                                                                       |
+|  ─────────────────────────────────────────────────────────────────     |
+|                                                                       |
+|  Narrated 'Umar bin Al-Khattab: I heard Allah's Messenger say,       |
+|  "The reward of deeds depends upon the intentions and every           |
+|  person will get the reward according to what he has intended.         |
+|  So whoever emigrated for worldly benefits or for a woman to          |
+|  marry, his emigration was for what he emigrated for."                |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Arabic matn displayed in full, `dir="rtl"`, `lang="ar"`, using `--font-arabic` at 18px
+- Horizontal divider separates Arabic from translation
+- English translation below in `--font-ui` at 16px
+- Isnad portion (chain of narration) visually distinguished from matn (text body) — the isnad text uses a slightly lighter color (#555) while the matn proper uses full black
+- No truncation — full text always visible
+
+---
+
+## 4. Isnad Chain Visualization
+
+### 4.1 Linear Chain View
+
+```
++-----------------------------------------------+
+| ISNAD CHAIN                    [Linear|Graph]  |
++-----------------------------------------------+
+|                                               |
+|  Prophet Muhammad                              |
+|       │                                       |
+|       ▼                                       |
+|  Umar ibn al-Khattab                          |
+|  Sahabi | Thiqah                ── click →     |
+|       │                                       |
+|       ▼                                       |
+|  Alqama ibn Waqqas al-Laythi                  |
+|  Tabi'i | Thiqah                              |
+|       │                                       |
+|       ▼                                       |
+|  Muhammad ibn Ibrahim al-Taymi                |
+|  Tabi' al-Tabi'in | Thiqah                    |
+|       │                                       |
+|       ▼                                       |
+|  Yahya ibn Sa'id al-Ansari                    |
+|  Tabi' al-Tabi'in | Thiqah                    |
+|       │                                       |
+|       ▼                                       |
+|  Sufyan ibn 'Uyayna                           |
+|  3rd gen. | Thiqah                            |
+|       │                                       |
+|       ▼                                       |
+|  al-Humaydi                                   |
+|  3rd gen. | Thiqah                            |
+|       │                                       |
+|       ▼                                       |
+|  [al-Bukhari]  ── Compiler                    |
+|                                               |
++-----------------------------------------------+
+```
+
+- Top-to-bottom flow: Prophet at top, compiler at bottom
+- Each narrator node is clickable (navigates to narrator detail page)
+- Node shows: name, generation, reliability — inline and compact
+- Connector lines are 2px with directional arrows
+- Reliability color-coded: green dot for Thiqah, amber for Saduq/Maqbul, red for Da'if — always with text label
+
+### 4.2 Graph View
+
+```
++-----------------------------------------------+
+| ISNAD CHAIN                    [Linear|Graph]  |
++-----------------------------------------------+
+|                                               |
+|         ●                                     |
+|        / \                                    |
+|       ●   ●                                   |
+|       |   |                                   |
+|       ●   ●                                   |
+|        \ /                                    |
+|         ●                                     |
+|         |                                     |
+|         ●                                     |
+|                                               |
++-----------------------------------------------+
+```
+
+- Toggle between linear and mini force-directed graph view
+- Graph view useful when the hadith has multiple chains (e.g., mutawatir hadith)
+- Same rendering engine as Graph Explorer ego-graph
+- Nodes colored by generation
+
+---
+
+## 5. Grading & Metadata
+
+```
++---------------------------------------+
+| GRADING                               |
++---------------------------------------+
+|                                       |
+| PRIMARY GRADE: Sahih                  |
+| ████████████████████████████░  Sahih  |
+|                                       |
+| +------------------+--------+         |
+| | Scholar          | Grade  |         |
+| +------------------+--------+         |
+| | al-Bukhari       | Sahih  |         |
+| | al-Albani        | Sahih  |         |
+| | Shu'ayb Arna'ut  | Sahih  |         |
+| +------------------+--------+         |
+|                                       |
++---------------------------------------+
+| METADATA                              |
++---------------------------------------+
+|                                       |
+| Collection:  Sahih al-Bukhari         |
+|              (صحيح البخاري)            |
+| Book:        كتاب بدء الوحي            |
+|              (Book of Revelation)      |
+| Chapter:     1                        |
+| Hadith No.:  1                        |
+| Volume:      1                        |
+| Narrators:   7                        |
+| Chain type:  Singular (ahad)          |
+|                                       |
++---------------------------------------+
+```
+
+- Primary grade displayed prominently with a colored status bar
+- Grade colors: green (Sahih), amber-green (Hasan), amber (Da'if), red (Mawdu') — always with text label
+- Individual scholar grades in a compact table
+- Metadata in definition-list format
+- Collection name links to collection browse view
+- Arabic book/chapter names displayed RTL
+
+---
+
+## 6. Parallel Hadith Section
+
+```
++-----------------------------------------------------------------------+
+| PARALLEL HADITH (4 found)                          [Sort: Similarity v]|
++-----------------------------------------------------------------------+
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Muslim 1907                              Similarity: 0.96         | |
+| | إنما الأعمال بالنيات...                                              | |
+| | "Actions are judged by intentions..."                              | |
+| | Grade: Sahih  |  Chain: 6 narrators  |  3 shared narrators        | |
+| | [Compare →]                                                        | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Abu Dawud 2201                           Similarity: 0.89         | |
+| | إنما الأعمال بالنيات...                                              | |
+| | "Deeds are only by intentions..."                                  | |
+| | Grade: Sahih  |  Chain: 5 narrators  |  2 shared narrators        | |
+| | [Compare →]                                                        | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Nasa'i 75                                Similarity: 0.84         | |
+| | ...                                                                | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Ibn Majah 4227                           Similarity: 0.81         | |
+| | ...                                                                | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Parallel hadith detected via Phase 4 semantic similarity (CAMeLBERT embeddings)
+- Similarity score (cosine similarity) displayed prominently
+- Shared narrator count shows chain overlap
+- "Compare" button navigates to comparative view with these two hadith pre-loaded
+- Sort options: Similarity (default), Collection, Grade
+
+---
+
+## 7. Topics & Classification
+
+```
++-----------------------------------------------------------------------+
+| TOPICS                                                                |
++-----------------------------------------------------------------------+
+|                                                                       |
+|  [Worship]  [Intention]  [Ethics]  [Migration]                        |
+|                                                                       |
+|  Theme: The role of intention (niyyah) in determining the             |
+|  spiritual value of actions.                                          |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Topic tags as clickable pills — clicking navigates to search filtered by that topic
+- Brief thematic summary from Phase 4 topic classification
+- Tags use neutral background colors with text labels
+
+---
+
+## 8. Citation & Share
+
+```
++-----------------------------------------------------------------------+
+| CITATION                                                              |
++-----------------------------------------------------------------------+
+|                                                                       |
+| Sahih al-Bukhari, Book 1, Hadith 1. Narrated by 'Umar ibn            |
+| al-Khattab.                                                          |
+|                                                                       |
+| [Copy citation]  [Copy Arabic text]  [Copy translation]  [Share ↗]  |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Pre-formatted citation string for academic use
+- Copy buttons for: citation, Arabic matn, English translation
+- Share button copies permalink URL to clipboard
+- Success feedback: brief inline "Copied!" text replacing button label for 2 seconds
+
+---
+
+## 9. RTL and Bidirectional Text
+
+### 9.1 Arabic Hadith Text
+
+- Full matn rendered in `dir="rtl"` block, `lang="ar"`, `--font-arabic` at 18px
+- Line height: 1.8 for Arabic text readability
+- Isnad portion uses lighter color to distinguish from matn body
+- Diacritics preserved in display (not stripped)
+
+### 9.2 Mixed-Script Display
+
+- Arabic and English texts in separate blocks, never interleaved on the same line
+- Book and chapter names show Arabic first (RTL), English parenthetical after
+- Collection names show both scripts
+
+### 9.3 Font Stack
+
+```css
+--font-arabic: 'Noto Naskh Arabic', 'Geeza Pro', 'Traditional Arabic', serif;
+--font-ui: system-ui, -apple-system, sans-serif;
+```
+
+---
+
+## 10. Accessibility
+
+### 10.1 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move through: hadith text > chain nodes > grading table > parallels > citation buttons |
+| Enter | Activate links, chain node navigation, copy buttons |
+| Arrow keys | Navigate chain nodes (up/down in linear view), parallel list |
+| Escape | Close any dropdowns |
+
+### 10.2 Screen Reader Support
+
+- Page title: `<title>Bukhari 1 — Hadith Detail — Isnad Graph</title>`
+- Hadith text section: `aria-label="Hadith text"` with Arabic announced via `lang="ar"`
+- Chain visualization: rendered as `<ol>` with `aria-label="Isnad chain, 7 narrators from Prophet Muhammad to al-Bukhari"`
+- Each chain node: "Umar ibn al-Khattab, Sahabi, trustworthiness Thiqah, link to narrator detail"
+- Parallel section: `aria-label="4 parallel hadith found"`, each card as `role="article"`
+- Copy button feedback: `aria-live="polite"` region announces "Citation copied to clipboard"
+
+### 10.3 High Contrast Mode
+
+- Chain connector lines become 2px solid black
+- Grade status bar uses pattern fill in addition to color
+- Parallel hadith card borders become 2px solid black
+- Reliability dots replaced with icon + text
+
+### 10.4 Reduced Motion
+
+- Chain view toggle between linear/graph is instant
+- Copy confirmation is text-only (no fade animation)
+
+---
+
+## 11. Responsive Breakpoint Summary
+
+| Feature | Desktop (>=1280) | Tablet (768-1279) | Mobile (<768) |
+|---------|:---:|:---:|:---:|
+| Nav sidebar | Visible (220px) | Hamburger overlay | Hamburger overlay |
+| Hadith text | Full width, 18px AR | Full width, 18px AR | Full width, 16px AR |
+| Chain + Grading | Side by side | Stacked | Tab view |
+| Chain visualization | Linear + Graph toggle | Linear + Graph toggle | Linear only |
+| Parallel hadith | Card list | Card list | Condensed cards |
+| Citation bar | Inline | Inline | Sticky bottom bar |
+
+---
+
+## 12. Component Mapping
+
+| Wireframe element | Component | Notes |
+|-------------------|-----------|-------|
+| Page shell | `HadithDetailPage.tsx` | New page, route: `/hadith/:collection/:number` |
+| Hadith text | `HadithTextDisplay` | RTL Arabic + LTR translation |
+| Chain visualization | `ChainVisualization` | Shared with narrator detail page |
+| Grading panel | `GradingPanel` | Table + status bar |
+| Parallel list | `ParallelHadithList` | Cards with similarity scores |
+| Topics | `TopicTags` | Clickable pill components |
+| Citation | `CitationBar` | Copy buttons + share |
+
+---
+
+## 13. Design Tokens
+
+```css
+/* Hadith text */
+--hadith-ar-font-size: 18px;
+--hadith-ar-line-height: 1.8;
+--hadith-en-font-size: 16px;
+--hadith-en-line-height: 1.6;
+--hadith-isnad-color: #555555;
+--hadith-matn-color: #111111;
+
+/* Grading */
+--grade-sahih: oklch(60% 0.15 150);     /* green */
+--grade-hasan: oklch(65% 0.12 120);     /* yellow-green */
+--grade-daif: oklch(70% 0.15 60);       /* amber */
+--grade-mawdu: oklch(55% 0.15 25);      /* red */
+
+/* Parallel cards */
+--parallel-card-bg: #ffffff;
+--parallel-card-border: #e8e8e8;
+--similarity-high: oklch(60% 0.15 150); /* >= 0.9 */
+--similarity-mid: oklch(70% 0.15 60);   /* 0.7-0.9 */
+--similarity-low: oklch(55% 0.10 0);    /* < 0.7 */
+```
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-29 | Sable Nakamura-Whitfield | Initial wireframe specification |

--- a/docs/ux/wireframes/narrator-detail.md
+++ b/docs/ux/wireframes/narrator-detail.md
@@ -1,0 +1,431 @@
+# Narrator Detail — Wireframe Specification
+
+**Author:** Sable Nakamura-Whitfield (Principal UX Designer)
+**Issue:** #538
+**Date:** 2026-03-29
+**Status:** Draft
+
+---
+
+## 1. Design Intent
+
+The narrator detail page is the comprehensive profile for an individual narrator. It must serve both quick-reference lookups (who was this person, are they reliable?) and deep scholarly analysis (network position, transmission patterns, cross-collection presence). The page is organized as a vertical scroll with distinct sections, each self-contained.
+
+Arabic names are always primary — displayed larger and first — with English transliterations secondary. This respects the source language of the tradition while maintaining accessibility for non-Arabic readers.
+
+---
+
+## 2. Page Layout
+
+### 2.1 Desktop (>=1280px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Narrators > Abu Hurayra         [user avatar]   |
++-------+---------------------------------------------------------------+
+| NAV   | PROFILE CARD                                                  |
+| SIDE  +---------------------------------------------------------------+
+| BAR   | +---------------------+  +----------------------------------+ |
+| (220) | | BIOGRAPHY           |  | NETWORK PREVIEW                | |
+|       | | (flex: 1)           |  | (400px, ego-graph)             | |
+|       | |                     |  |                                | |
+|       | |                     |  |        ●───●                   | |
+|       | |                     |  |       / \   \                  | |
+|       | |                     |  |      ●  [★]  ●                | |
+|       | |                     |  |       \ /   /                  | |
+|       | |                     |  |        ●───●                   | |
+|       | |                     |  |                                | |
+|       | |                     |  | [Open in Graph Explorer →]    | |
+|       | +---------------------+  +----------------------------------+ |
+|       +---------------------------------------------------------------+
+|       | RELIABILITY RATINGS                                           |
+|       +---------------------------------------------------------------+
+|       | HADITH LIST                                                    |
+|       +---------------------------------------------------------------+
+|       | CHAIN VISUALIZATION                                           |
+|       +---------------------------------------------------------------+
+```
+
+### 2.2 Tablet (768px–1279px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Abu Hurayra      [hamburger] [user avatar]      |
++-----------------------------------------------------------------------+
+| PROFILE CARD (full width)                                             |
++-----------------------------------------------------------------------+
+| NETWORK PREVIEW (full width, 300px height)                            |
++-----------------------------------------------------------------------+
+| BIOGRAPHY (full width)                                                |
++-----------------------------------------------------------------------+
+| RELIABILITY RATINGS                                                   |
++-----------------------------------------------------------------------+
+| HADITH LIST                                                           |
++-----------------------------------------------------------------------+
+| CHAIN VISUALIZATION                                                   |
++-----------------------------------------------------------------------+
+```
+
+- Biography and network preview stack vertically
+- All sections full-width
+
+### 2.3 Mobile (<768px)
+
+```
++-----------------------------------+
+| HEADER          [ham] [avatar]    |
++-----------------------------------+
+| PROFILE CARD (compact)            |
+| ابو هريرة الدوسي                   |
+| Abu Hurayra al-Dawsi              |
+| Sahabi | d. 59 AH | Thiqah       |
++-----------------------------------+
+| [Tab: Bio] [Network] [Hadith]    |
++-----------------------------------+
+| (tab content, full width)         |
+|                                   |
+|                                   |
++-----------------------------------+
+```
+
+- Sections reorganized into tab navigation to reduce scroll depth
+- Network preview is a simplified static image with "Open in Graph Explorer" link
+
+---
+
+## 3. Profile Card
+
+```
++-----------------------------------------------------------------------+
+|                                                                       |
+|  ابو هريرة الدوسي                                                      |  <- dir="rtl", 28px
+|  Abu Hurayra al-Dawsi                                                 |  <- 20px
+|                                                                       |
+|  +-------------------+-------------------+-------------------+        |
+|  | Full name         | عبد الرحمن بن صخر الدوسي                |        |
+|  | Kunya             | Abu Hurayra (ابو هريرة)                |        |
+|  | Nisba             | al-Dawsi (الدوسي)                      |        |
+|  | Laqab             | —                                     |        |
+|  +-------------------+-------------------+-------------------+        |
+|  | Generation        | Sahabi (Companion)                    |        |
+|  | Birth             | Unknown                               |        |
+|  | Death             | 59 AH (678 CE)                        |        |
+|  | Location          | Medina                                |        |
+|  | Sect              | Sunni                                 |        |
+|  +-------------------+-------------------+-------------------+        |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Arabic name rendered first, largest, RTL
+- Metadata in a definition-list layout (term: value pairs)
+- Dual dating (AH / CE) where both are known
+- Missing values displayed as em dash, not hidden — absence of data is itself informative
+
+---
+
+## 4. Biography Section
+
+```
++-----------------------------------------------------------------------+
+| BIOGRAPHY                                                             |
++-----------------------------------------------------------------------+
+|                                                                       |
+| Abu Hurayra was a companion of the Prophet Muhammad and one of the    |
+| most prolific narrators of hadith. He accepted Islam in the 7th year  |
+| of Hijra and remained in close company with the Prophet until the     |
+| latter's death. He is credited with narrating over 5,000 hadith,     |
+| more than any other companion.                                        |
+|                                                                       |
+| He served as governor of Bahrain under the caliphate of Umar ibn     |
+| al-Khattab and later settled in Medina, where he taught numerous     |
+| students.                                                             |
+|                                                                       |
+| [Show more ▼] (if text exceeds 200 words)                            |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Biography text sourced from curated database field
+- Collapsed to ~200 words by default with "Show more" toggle
+- If no biography available: "No biographical information available for this narrator."
+
+---
+
+## 5. Reliability Ratings
+
+```
++-----------------------------------------------------------------------+
+| RELIABILITY RATINGS                                                    |
++-----------------------------------------------------------------------+
+|                                                                       |
+| AGGREGATE: Thiqah (Trustworthy)     ████████████████████░  4.8/5.0   |
+|                                                                       |
+| +---------------------+-------------+-----------------------------+  |
+| | Scholar             | Rating      | Notes                       |  |
+| +---------------------+-------------+-----------------------------+  |
+| | Ibn Hajar           | Thiqah      | "Sahabi, no criticism req." |  |
+| | al-Dhahabi          | Thiqah      | "Most prolific narrator"    |  |
+| | Ibn Hibban          | Thiqah      | —                           |  |
+| | al-'Ijli            | Thiqah      | —                           |  |
+| | Abu Hatim           | Thiqah      | "His hadith are accepted"   |  |
+| +---------------------+-------------+-----------------------------+  |
+|                                                                       |
+| Rating scale: Thiqah > Saduq > Maqbul > Da'if > Matruk > Kadhdhab   |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Aggregate rating shown as a horizontal bar with numeric score
+- Individual scholar ratings in a table
+- Rating scale legend shown below table for reference
+- Bar color: green (Thiqah/Saduq), amber (Maqbul), red (Da'if and below) — with text label always visible, never color-only
+
+---
+
+## 6. Network Preview
+
+### 6.1 Ego-Graph
+
+```
++----------------------------------+
+|                                  |
+|          ●  ●                    |
+|         / \ |                    |
+|        ●  [★]  ●                 |  <- ★ = selected narrator
+|         \ / \ /                  |
+|          ●   ●                   |
+|          |                       |
+|          ●                       |
+|                                  |
+| Teachers: 12 | Students: 342    |
+| [Open in Graph Explorer →]      |
++----------------------------------+
+```
+
+- Depth-1 ego-graph rendered with the same force-directed engine as Graph Explorer
+- Selected narrator centered and visually distinguished (star/accent ring)
+- Nodes colored by community (same palette as Graph Explorer)
+- Interactive: hover shows tooltip, click navigates to that narrator's detail page
+- "Open in Graph Explorer" navigates to Graph Explorer with this narrator pre-selected
+
+### 6.2 Network Statistics
+
+```
++----------------------------------+
+| NETWORK STATISTICS               |
++----------------------------------+
+| Teachers (in-degree):        12  |
+| Students (out-degree):      342  |
+| Total connections:          354  |
+| Betweenness centrality:  0.087  |
+| PageRank:                0.0042  |
+| Community:          7 (● Blue)   |
+| Closeness centrality:    0.034  |
++----------------------------------+
+```
+
+- Displayed below the ego-graph
+- Tooltips on each metric name explaining what it measures
+- Community shown with color swatch matching the graph palette
+
+---
+
+## 7. Hadith List
+
+```
++-----------------------------------------------------------------------+
+| HADITH NARRATED (5,374 total)                  [Filter by collection v]|
++-----------------------------------------------------------------------+
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Bukhari 1 — كتاب بدء الوحي                                         | |
+| | إنما الأعمال بالنيات...                                              | |
+| | "Actions are judged by intentions..."                              | |
+| | Grade: Sahih  |  Chain: 7 narrators  |  Topics: Worship           | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Muslim 23 — كتاب الإيمان                                           | |
+| | الدين النصيحة...                                                    | |
+| | "The religion is sincerity..."                                     | |
+| | Grade: Sahih  |  Chain: 5 narrators  |  Topics: Ethics            | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| +-------------------------------------------------------------------+ |
+| | Abu Dawud 4 — كتاب الصلاة                                          | |
+| | ...                                                                | |
+| +-------------------------------------------------------------------+ |
+|                                                                       |
+| Showing 1-10 of 5,374          [1] [2] [3] ... [538] [Next →]        |
++-----------------------------------------------------------------------+
+```
+
+- Each hadith shows: collection + number, book name (Arabic), matn preview (Arabic + English), grade, chain length, topics
+- Arabic text in RTL blocks
+- Collection filter dropdown to narrow by source
+- Paginated (10 per page)
+- Click navigates to hadith detail page
+
+---
+
+## 8. Chain Visualization
+
+```
++-----------------------------------------------------------------------+
+| CHAIN VISUALIZATION                              [Select a chain v]   |
++-----------------------------------------------------------------------+
+|                                                                       |
+|  Chain for Bukhari 1:                                                 |
+|                                                                       |
+|  Prophet Muhammad                                                     |
+|       │                                                               |
+|       ▼                                                               |
+|  Umar ibn al-Khattab  ─── Sahabi, Thiqah                             |
+|       │                                                               |
+|       ▼                                                               |
+|  Alqama ibn Waqqas  ─── Tabi'i, Thiqah                               |
+|       │                                                               |
+|       ▼                                                               |
+|  Muhammad ibn Ibrahim  ─── Tabi' al-Tabi'in, Thiqah                  |
+|       │                                                               |
+|       ▼                                                               |
+|  Yahya ibn Sa'id  ─── Tabi' al-Tabi'in, Thiqah                       |
+|       │                                                               |
+|       ▼                                                               |
+| [★ Abu Hurayra]  ─── Sahabi, Thiqah                                  |
+|       │                                                               |
+|       ▼                                                               |
+|  al-Bukhari  ─── Compiler                                            |
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+- Linear top-to-bottom chain rendering
+- Each narrator node is clickable (navigates to their detail page)
+- Current narrator highlighted with accent styling
+- Chain selector dropdown to switch between different chains involving this narrator
+- Generation and reliability shown inline with each narrator
+- On mobile: horizontal scroll if chain is very long
+
+---
+
+## 9. RTL and Bidirectional Text
+
+### 9.1 Name Display
+
+- Arabic name always displayed first (top), larger font, `dir="rtl"` and `lang="ar"`
+- English transliteration below, standard LTR
+- In the profile card, name variants (kunya, nisba, laqab) show both scripts side by side using bidi isolation: `English (عربي)`
+
+### 9.2 Hadith Text
+
+- Matn text always rendered in a `dir="rtl"` block with Arabic font stack
+- Translation follows in a separate `dir="ltr"` block
+- Book/chapter names displayed in Arabic with `dir="rtl"`
+
+### 9.3 Font Stack
+
+```css
+--font-arabic: 'Noto Naskh Arabic', 'Geeza Pro', 'Traditional Arabic', serif;
+--font-ui: system-ui, -apple-system, sans-serif;
+```
+
+---
+
+## 10. Accessibility
+
+### 10.1 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move through sections: profile > biography > ratings > network > hadith list > chains |
+| Enter | Expand collapsed sections, activate links, select chain |
+| Arrow keys | Navigate table rows in ratings, hadith list |
+| Escape | Close dropdowns |
+
+### 10.2 Screen Reader Support
+
+- Page title: `<title>Abu Hurayra — Narrator Detail — Isnad Graph</title>`
+- Profile card: `aria-label="Narrator profile: Abu Hurayra al-Dawsi"` with Arabic name announced via `lang="ar"` attribute
+- Reliability aggregate: "Trustworthiness rating: 4.8 out of 5, Thiqah (Trustworthy)"
+- Network preview: `aria-label="Transmission network preview showing 12 teachers and 342 students"`
+- Ego-graph has a "View as table" alternative listing teachers and students
+- Chain visualization: ordered list (`<ol>`) with `aria-label="Isnad chain for Bukhari hadith 1"`
+
+### 10.3 High Contrast Mode
+
+- Profile card border becomes 2px solid black
+- Rating bar uses pattern fill in addition to color
+- Chain connector lines become 2px solid black
+- Network graph nodes gain 2px black outlines
+
+### 10.4 Reduced Motion
+
+- Ego-graph force simulation completes instantly
+- Section expand/collapse is instant (no slide animation)
+
+---
+
+## 11. Responsive Breakpoint Summary
+
+| Feature | Desktop (>=1280) | Tablet (768-1279) | Mobile (<768) |
+|---------|:---:|:---:|:---:|
+| Nav sidebar | Visible (220px) | Hamburger overlay | Hamburger overlay |
+| Profile card | Full width | Full width | Compact |
+| Bio + Network | Side by side | Stacked | Tab view |
+| Reliability table | Full table | Full table | Card layout |
+| Hadith list | Full cards | Full cards | Condensed cards |
+| Chain visualization | Full vertical | Full vertical | Horizontal scroll |
+| Network preview | Interactive graph | Interactive graph | Static image + link |
+
+---
+
+## 12. Component Mapping
+
+| Wireframe element | Component | Notes |
+|-------------------|-----------|-------|
+| Page shell | `NarratorDetailPage.tsx` | New page, route: `/narrators/:id` |
+| Profile card | `NarratorProfileCard` | Reusable across search results and detail |
+| Biography | `NarratorBiography` | Collapsible text block |
+| Reliability ratings | `ReliabilityRatings` | Table + aggregate bar |
+| Network preview | `EgoGraph` | Shares rendering engine with Graph Explorer |
+| Network stats | `NetworkStatistics` | Metric list with tooltips |
+| Hadith list | `NarratorHadithList` | Paginated, filterable |
+| Chain visualization | `ChainVisualization` | Linear chain renderer, reused on hadith detail |
+
+---
+
+## 13. Design Tokens
+
+```css
+/* Profile card */
+--profile-name-ar-size: 28px;
+--profile-name-en-size: 20px;
+--profile-meta-size: 14px;
+
+/* Reliability bar */
+--rating-bar-height: 8px;
+--rating-bar-bg: #e8e8e8;
+--rating-bar-fill-high: oklch(60% 0.15 150);   /* green */
+--rating-bar-fill-mid: oklch(70% 0.15 60);     /* amber */
+--rating-bar-fill-low: oklch(55% 0.15 25);     /* red */
+
+/* Chain visualization */
+--chain-connector-width: 2px;
+--chain-connector-color: #cccccc;
+--chain-node-size: 12px;
+--chain-node-active: var(--color-accent, #1a73e8);
+
+/* Ego graph */
+--ego-graph-height: 350px;
+--ego-graph-bg: #fafafa;
+```
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-29 | Sable Nakamura-Whitfield | Initial wireframe specification |

--- a/docs/ux/wireframes/search.md
+++ b/docs/ux/wireframes/search.md
@@ -1,0 +1,535 @@
+# Search — Wireframe Specification
+
+**Author:** Sable Nakamura-Whitfield (Principal UX Designer)
+**Issue:** #537
+**Date:** 2026-03-29
+**Status:** Draft
+
+---
+
+## 1. Design Intent
+
+The search view is the primary entry point for directed queries across hadith texts, narrators, collections, and topics. It supports both full-text keyword search and semantic (meaning-based) search, surfacing results as typed entity cards with faceted filtering.
+
+The design treats search as a first-class research tool — not a simple text box. Result cards must communicate enough context to evaluate relevance without clicking through, while remaining scannable at volume. Arabic text is always rendered RTL with proper bidirectional isolation.
+
+---
+
+## 2. Page Layout
+
+### 2.1 Desktop (>=1280px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Search                          [user avatar]   |
++-------+---------------------------------------------------------------+
+| NAV   | SEARCH BAR                                                    |
+| SIDE  | [icon] Search hadith, narrators, collections...     [Search]  |
+| BAR   | [Full-text ◉] [Semantic ○]                                    |
+| (220) +-------------------+-------------------------------------------+
+|       | FILTER SIDEBAR    | RESULTS                                   |
+|       | (260px)           |                                           |
+|       |                   | Showing 142 results for "ابو هريرة"       |
+|       | ENTITY TYPE       | Sort: [Relevance v]                       |
+|       | [x] Narrator (47) |                                           |
+|       | [x] Hadith (82)   | +---------------------------------------+ |
+|       | [ ] Collection(13)| | [Narrator Card]                       | |
+|       |                   | | Abu Hurayra (ابو هريرة)               | |
+|       | COLLECTION        | | Sahabi | d. 59 AH | 342 transmissions | |
+|       | [x] Bukhari       | | Relevance: 0.97                       | |
+|       | [x] Muslim        | +---------------------------------------+ |
+|       | [ ] Abu Dawud     |                                           |
+|       | [ ] Tirmidhi      | +---------------------------------------+ |
+|       | ...               | | [Hadith Card]                         | |
+|       |                   | | Bukhari 1 — كتاب بدء الوحي            | |
+|       | GRADING           | | "Actions are judged by intentions..."  | |
+|       | [x] Sahih         | | Chain: 5 narrators | Grade: Sahih      | |
+|       | [x] Hasan         | | Relevance: 0.94                       | |
+|       | [ ] Da'if         | +---------------------------------------+ |
+|       |                   |                                           |
+|       | CENTURY (AH)      | +---------------------------------------+ |
+|       | [1st] [2nd] [3rd] | | [Collection Card]                     | |
+|       | [4th] [5th+]      | | Sahih al-Bukhari (صحيح البخاري)        | |
+|       |                   | | 7,563 hadith | 97 books               | |
+|       | TOPIC             | | Compiler: Muhammad al-Bukhari         | |
+|       | [ ] Jurisprudence | | Relevance: 0.91                       | |
+|       | [ ] Theology      | +---------------------------------------+ |
+|       | [ ] Ethics        |                                           |
+|       |                   | [1] [2] [3] ... [15]  [Next →]           |
+|       | [Clear filters]   |                                           |
++-------+-------------------+-------------------------------------------+
+```
+
+### 2.2 Tablet (768px–1279px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph                        [hamburger] [user avatar]  |
++-----------------------------------------------------------------------+
+| [icon] Search hadith, narrators, collections...            [Search]   |
+| [Full-text ◉] [Semantic ○]           [Filters (3)]                   |
++-----------------------------------------------------------------------+
+| Showing 142 results for "ابو هريرة"           Sort: [Relevance v]    |
++-----------------------------------------------------------------------+
+| [Result Card]                                                         |
+| [Result Card]                                                         |
+| [Result Card]                                                         |
+| ...                                                                   |
++-----------------------------------------------------------------------+
+| [1] [2] [3] ... [Next →]                                             |
++-----------------------------------------------------------------------+
+```
+
+- Filter sidebar collapses into a modal triggered by `[Filters (N)]` button
+- Nav sidebar becomes hamburger overlay
+
+### 2.3 Mobile (<768px)
+
+```
++-----------------------------------+
+| HEADER          [ham] [avatar]    |
++-----------------------------------+
+| [Search...]            [Filters]  |
+| [Full-text] [Semantic]            |
++-----------------------------------+
+| 142 results        [Relevance v]  |
++-----------------------------------+
+| +-------------------------------+ |
+| | Abu Hurayra (ابو هريرة)       | |
+| | Sahabi | d. 59 AH             | |
+| | Relevance: 0.97               | |
+| +-------------------------------+ |
+| +-------------------------------+ |
+| | Bukhari 1                     | |
+| | "Actions are judged by..."    | |
+| | Sahih | 5 narrators           | |
+| +-------------------------------+ |
+| ...                               |
++-----------------------------------+
+| [1] [2] [3] [Next →]             |
++-----------------------------------+
+```
+
+- Result cards stack vertically, full width
+- Filters open as full-screen modal
+- Search mode toggle displayed as compact pills
+
+---
+
+## 3. Search Bar
+
+### 3.1 Input
+
+```
++------------------------------------------------------------------+
+| [magnifier] Search hadith, narrators, collections...       [x]   |
++------------------------------------------------------------------+
+| SUGGESTIONS (typeahead, 300ms debounce)                          |
+| ┌──────────────────────────────────────────────────────────────┐  |
+| │ NARRATORS                                                    │  |
+| │  Abu Hurayra (ابو هريرة)                    Sahabi, d.59 AH │  |
+| │  Abu Hurayra al-Dawsi (ابو هريرة الدوسي)    Sahabi, d.59 AH │  |
+| │                                                              │  |
+| │ HADITH                                                       │  |
+| │  "Actions are judged by intentions..." Bukhari 1, Sahih      │  |
+| │  "Whoever believes in Allah..."        Abu Dawud 4, Hasan    │  |
+| │                                                              │  |
+| │ COLLECTIONS                                                  │  |
+| │  Sahih al-Bukhari (صحيح البخاري)         7,563 hadith        │  |
+| └──────────────────────────────────────────────────────────────┘  |
+```
+
+- Typeahead groups suggestions by entity type (max 3 per type)
+- Arabic names right-aligned within each row using `dir="rtl"` inline
+- Selecting a suggestion navigates directly to that entity's detail page
+- Pressing Enter submits the query and shows full results below
+- Keyboard: Arrow keys navigate suggestions, Enter selects, Escape closes dropdown
+
+### 3.2 Search Mode Toggle
+
+```
+  [Full-text ◉]  [Semantic ○]
+```
+
+- **Full-text**: Keyword matching against indexed text fields (exact, stemmed, transliteration-normalized)
+- **Semantic**: Vector similarity search against CAMeLBERT embeddings — finds hadiths with similar meaning even if wording differs
+- Radio toggle — one mode active at a time
+- Semantic mode shows a cosine similarity score instead of keyword relevance
+- Tooltip on semantic: "Find hadith with similar meaning, even with different wording"
+
+---
+
+## 4. Filter Sidebar
+
+### 4.1 Entity Type Filter
+
+```
+  ENTITY TYPE
+  [x] Narrator (47)
+  [x] Hadith (82)
+  [ ] Collection (13)
+```
+
+- Checkbox group with result counts per type
+- Counts update dynamically as other filters change
+- At least one type must be selected (disabling the last checked box is prevented)
+
+### 4.2 Collection Filter
+
+```
+  COLLECTION
+  [x] Bukhari (34)
+  [x] Muslim (28)
+  [ ] Abu Dawud (12)
+  [ ] Tirmidhi (8)
+  [ ] Nasa'i (6)
+  [ ] Ibn Majah (4)
+  [Show all...]
+```
+
+- Top 6 collections shown by default, expandable
+- Counts reflect current query results
+- "Show all" reveals Shia collections (al-Kafi, etc.) and minor compilations
+
+### 4.3 Grading Filter
+
+```
+  GRADING
+  [x] Sahih (62)
+  [x] Hasan (18)
+  [ ] Da'if (12)
+  [ ] Mawdu' (3)
+```
+
+### 4.4 Century Filter
+
+```
+  CENTURY (AH)
+  [1st] [2nd] [3rd] [4th] [5th+]
+```
+
+- Segmented toggle buttons — multiple can be active
+- Filters narrators by active lifetime, hadith by chain era
+
+### 4.5 Topic Filter
+
+```
+  TOPIC
+  [ ] Jurisprudence (fiqh)
+  [ ] Theology (aqidah)
+  [ ] Ethics (akhlaq)
+  [ ] Worship (ibadah)
+  [ ] History (sira)
+  [ ] Eschatology
+```
+
+- Topic labels derived from Phase 4 topic classification output
+- Only shown when hadith entity type is active
+
+### 4.6 Clear Filters
+
+```
+  [Clear all filters]
+```
+
+- Resets all filters to defaults (all entity types, no collection/grading/century/topic filters)
+- Only visible when at least one non-default filter is active
+
+---
+
+## 5. Result Cards
+
+### 5.1 Narrator Result Card
+
+```
++---------------------------------------------------------------+
+| [person icon]  NARRATOR                     Relevance: 0.97   |
++---------------------------------------------------------------+
+|                                                               |
+|  ابو هريرة الدوسي                                              |  <- dir="rtl"
+|  Abu Hurayra al-Dawsi                                         |
+|                                                               |
+|  Generation: Sahabi  |  Death: 59 AH  |  Sect: Sunni         |
+|  342 transmissions  |  Trustworthiness: Thiqah               |
+|                                                               |
+|  Matched: name_ar, kunya                                      |  <- which fields matched
++---------------------------------------------------------------+
+```
+
+- Click navigates to narrator detail page
+- "Matched" line shows which fields matched the query (visual cue for why this result appeared)
+
+### 5.2 Hadith Result Card
+
+```
++---------------------------------------------------------------+
+| [document icon]  HADITH                     Relevance: 0.94   |
++---------------------------------------------------------------+
+|                                                               |
+|  إنما الأعمال بالنيات وإنما لكل امرئ ما نوى                    |  <- dir="rtl"
+|  "Actions are judged by intentions, and each person            |
+|   will be rewarded according to what they intended."           |
+|                                                               |
+|  Collection: Sahih al-Bukhari  |  Book 1, Hadith 1           |
+|  Grading: Sahih  |  Chain: 5 narrators                       |
+|  Topics: Worship, Ethics                                      |
+|                                                               |
+|  [View chain →]  [Compare parallels →]                        |
++---------------------------------------------------------------+
+```
+
+- Arabic matn displayed first (RTL), translation below (LTR)
+- Matn text truncated to 2 lines with ellipsis; full text on detail page
+- "View chain" navigates to hadith detail with chain visualization
+- "Compare parallels" navigates to comparative view with this hadith pre-selected
+- In semantic mode, relevance score shows cosine similarity (0.00–1.00)
+
+### 5.3 Collection Result Card
+
+```
++---------------------------------------------------------------+
+| [book icon]  COLLECTION                     Relevance: 0.91   |
++---------------------------------------------------------------+
+|                                                               |
+|  صحيح البخاري                                                  |  <- dir="rtl"
+|  Sahih al-Bukhari                                             |
+|                                                               |
+|  Compiler: Muhammad ibn Ismail al-Bukhari (d. 256 AH)        |
+|  7,563 hadith  |  97 books  |  Sect: Sunni                   |
+|  Canonical rank: #1 of Kutub al-Sittah                        |
+|                                                               |
++---------------------------------------------------------------+
+```
+
+- Click navigates to collection detail/browse view
+
+---
+
+## 6. Results Header
+
+```
+  Showing 142 results for "ابو هريرة"              Sort: [Relevance v]
+```
+
+- Result count updates with filters
+- Query string displayed — Arabic text rendered RTL with bidi isolation
+- Sort options dropdown:
+  - **Relevance** (default): search score descending
+  - **Date (oldest)**: by death date / compilation date ascending
+  - **Date (newest)**: descending
+  - **Name (A-Z)**: alphabetical on English name
+  - **Name (ا-ي)**: alphabetical on Arabic name (RTL sort order)
+
+---
+
+## 7. Pagination
+
+```
+  [← Prev]  [1] [2] [3] ... [15]  [Next →]
+```
+
+- 10 results per page (configurable in future)
+- Current page visually distinguished (filled background)
+- Prev/Next disabled at boundaries
+- Page change scrolls to top of results area
+- URL updates with page parameter for shareability
+
+---
+
+## 8. Empty and Error States
+
+### 8.1 Initial Empty State (no query)
+
+```
++-----------------------------------------------+
+|                                               |
+|        [search icon, muted]                   |
+|                                               |
+|  Search the hadith corpus                     |
+|                                               |
+|  Enter a narrator name, hadith text,          |
+|  or topic to begin exploring.                 |
+|                                               |
+|  Try: Abu Hurayra, الأعمال بالنيات,            |
+|       Sahih al-Bukhari, prayer                |
+|                                               |
++-----------------------------------------------+
+```
+
+- Suggested queries are clickable — each populates the search bar and submits
+
+### 8.2 No Results
+
+```
++-----------------------------------------------+
+|                                               |
+|  No results found for "xyz"                   |
+|                                               |
+|  Suggestions:                                 |
+|  - Try Arabic script: type the name in        |
+|    Arabic for more precise matching            |
+|  - Check transliteration: Abu vs. Aboo,       |
+|    al- vs. el-                                |
+|  - Try semantic search: toggle to find         |
+|    similar meanings                            |
+|  - Broaden filters: you have 3 active         |
+|    filters narrowing results                  |
+|                                               |
+|  [Clear all filters]                          |
+|                                               |
++-----------------------------------------------+
+```
+
+- Suggestions adapt: "Broaden filters" only shown when filters are active
+- "Try semantic search" only shown when in full-text mode
+
+### 8.3 Loading State
+
+```
++-----------------------------------------------+
+| [skeleton bar ████████░░░░░░░░]               |
+| [skeleton card ░░░░░░░░░░░░░░░░░░░░░░]        |
+| [skeleton card ░░░░░░░░░░░░░░░░░░░░░░]        |
+| [skeleton card ░░░░░░░░░░░░░░░░░░░░░░]        |
++-----------------------------------------------+
+```
+
+- Skeleton cards match the shape of result cards
+- Filter sidebar remains interactive during search loading
+- Search bar shows a subtle progress indicator (thin animated line below input)
+
+### 8.4 Error State
+
+```
++-----------------------------------------------+
+|                                               |
+|  Search failed. Please try again.             |
+|  [Retry]                                      |
+|                                               |
++-----------------------------------------------+
+```
+
+---
+
+## 9. RTL and Bidirectional Text
+
+### 9.1 Arabic Text in Results
+
+- All Arabic strings wrapped in `<bdi dir="rtl" lang="ar">` for proper isolation
+- Hadith matn text displayed in a `dir="rtl"` block with `--font-arabic` font stack
+- Search highlights within Arabic text respect character joining (never break ligatures)
+
+### 9.2 Mixed-Script Display
+
+- Result cards display Arabic name/text above English equivalent — never side-by-side on the same line
+- Search bar accepts mixed-script input; typeahead normalizes diacritics and alif/hamza variants
+- Sort by Arabic name uses proper collation (alif before ba, etc.)
+
+### 9.3 Font Stack
+
+```css
+--font-arabic: 'Noto Naskh Arabic', 'Geeza Pro', 'Traditional Arabic', serif;
+--font-ui: system-ui, -apple-system, sans-serif;
+```
+
+---
+
+## 10. Accessibility
+
+### 10.1 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move through: search input > mode toggle > filter sidebar > results > pagination |
+| Enter | Submit search / select suggestion / activate button |
+| Arrow keys | Navigate typeahead suggestions |
+| Escape | Close typeahead dropdown |
+| / | Focus search input from anywhere on page |
+
+### 10.2 Screen Reader Support
+
+- Search input: `role="combobox"` with `aria-expanded`, `aria-activedescendant`
+- Typeahead dropdown: `role="listbox"` with grouped `role="option"` items
+- Result cards: `role="article"` with `aria-label` summarizing entity type and name
+- Filter groups: `role="group"` with `aria-labelledby` pointing to section heading
+- Pagination: `nav` landmark with `aria-label="Search results pagination"`
+- Live region announces: "142 results found for Abu Hurayra" on search completion
+
+### 10.3 High Contrast Mode
+
+- Result card borders become 2px solid black
+- Relevance score uses text label, never color-only encoding
+- Entity type badges use pattern fill in addition to color
+- Focus ring: 3px solid with offset
+
+### 10.4 Reduced Motion
+
+- Skeleton loading animation replaced with static placeholder blocks
+- Typeahead dropdown appears instantly (no slide animation)
+
+---
+
+## 11. Responsive Breakpoint Summary
+
+| Feature | Desktop (>=1280) | Tablet (768-1279) | Mobile (<768) |
+|---------|:---:|:---:|:---:|
+| Nav sidebar | Visible (220px) | Hamburger overlay | Hamburger overlay |
+| Filter sidebar | Visible (260px) | Modal | Full-screen modal |
+| Search mode toggle | Inline text | Inline text | Compact pills |
+| Result cards | Full detail | Full detail | Condensed |
+| Typeahead | Grouped, 3/type | Grouped, 2/type | Simple list |
+| Pagination | Full numbered | Numbered | Prev/Next only |
+| Sort dropdown | Visible | Visible | Icon button |
+
+---
+
+## 12. Component Mapping
+
+| Wireframe element | Component | Notes |
+|-------------------|-----------|-------|
+| Page shell | `SearchPage.tsx` | New page component |
+| Search bar | `SearchBar` | Combobox with typeahead, debounced API calls |
+| Mode toggle | `SearchModeToggle` | Radio group: full-text / semantic |
+| Filter sidebar | `SearchFilters` | Checkbox groups, segmented toggles |
+| Narrator card | `NarratorResultCard` | Shared card component |
+| Hadith card | `HadithResultCard` | Includes matn preview, chain link |
+| Collection card | `CollectionResultCard` | Compact metadata display |
+| Pagination | `Pagination` | Shared component |
+| Empty state | `SearchEmptyState` | Contextual suggestions |
+
+---
+
+## 13. Design Tokens
+
+```css
+/* Search */
+--search-input-height: 48px;
+--search-input-bg: #ffffff;
+--search-input-border: #d0d0d0;
+--search-input-border-focus: var(--color-accent, #1a73e8);
+
+/* Result cards */
+--card-bg: #ffffff;
+--card-border: #e8e8e8;
+--card-border-hover: #c0c0c0;
+--card-shadow-hover: 0 2px 8px rgba(0, 0, 0, 0.08);
+--card-padding: 16px;
+--card-gap: 12px;
+
+/* Relevance badge */
+--relevance-high: oklch(60% 0.15 150);   /* green, >= 0.9 */
+--relevance-mid: oklch(70% 0.15 60);     /* amber, 0.7-0.9 */
+--relevance-low: oklch(55% 0.10 0);      /* gray, < 0.7 */
+
+/* Filter sidebar */
+--filter-width: 260px;
+--filter-section-gap: 20px;
+```
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-29 | Sable Nakamura-Whitfield | Initial wireframe specification |

--- a/docs/ux/wireframes/timeline.md
+++ b/docs/ux/wireframes/timeline.md
@@ -1,0 +1,428 @@
+# Timeline — Wireframe Specification
+
+**Author:** Sable Nakamura-Whitfield (Principal UX Designer)
+**Issue:** #540
+**Date:** 2026-03-29
+**Status:** Draft
+
+---
+
+## 1. Design Intent
+
+The timeline view provides a chronological lens on hadith transmission. Narrators appear as horizontal lifespan bars, transmission events as connections between them, and historical events as contextual markers. This is a Tufte-style small-multiples timeline: dense with data, rewarding close reading, with zoom levels that support both macro patterns (centuries of transmission) and micro analysis (individual lifespans and overlaps).
+
+The primary scholarly question this view answers: "When did narrators live, who could plausibly have met whom, and how does the transmission network unfold across time?"
+
+---
+
+## 2. Page Layout
+
+### 2.1 Desktop (>=1280px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER: Isnad Graph > Timeline                       [user avatar]    |
++-------+---------------------------------------------------------------+
+| NAV   | TOOLBAR                                                       |
+| SIDE  | [Search narrator...] [Zoom: Century|Decade|Year]              |
+| BAR   | [Era filter v] [School filter v]         [Reset] [Export v]   |
+| (220) +---------------------------------------------------------------+
+|       |              TIMELINE CANVAS                                  |
+|       |                                                               |
+|       |  1 AH         50 AH        100 AH       150 AH       200 AH  |
+|       |  |────────────|────────────|────────────|────────────|         |
+|       |                                                               |
+|       |  ████████████████  Prophet Muhammad (d. 11 AH)                |
+|       |     ████████████████████████████  Abu Hurayra (d. 59 AH)      |
+|       |        ████████████████████████████████  Ibn Abbas (d. 68 AH) |
+|       |              ──→──→──→  (transmission links)                  |
+|       |                    ████████████████████████  al-Zuhri (d.124) |
+|       |                          ████████████████████  Malik (d.179)  |
+|       |                                                               |
+|       |  ◆ Battle of Badr (2 AH)                                     |
+|       |         ◆ Conquest of Mecca (8 AH)                            |
+|       |                    ◆ Fall of Umayyads (132 AH)                |
+|       |                                                               |
+|       +---------------------------------------------------------------+
+|       | STATUS: 47 narrators, 3 events | Range: 1-250 AH | Zoom: Dec.|
+|       +---------------------------------------------------------------+
+```
+
+### 2.2 Tablet (768px–1279px)
+
+```
++-----------------------------------------------------------------------+
+| HEADER                                 [hamburger] [user avatar]      |
++-----------------------------------------------------------------------+
+| TOOLBAR (two rows)                                                    |
+| [Search...] [Zoom: Century|Decade|Year]                               |
+| [Era filter v] [School filter v]              [Reset]                 |
++-----------------------------------------------------------------------+
+|                    TIMELINE CANVAS (full width)                        |
+|                    (horizontal scroll enabled)                         |
++-----------------------------------------------------------------------+
+| STATUS BAR                                                            |
++-----------------------------------------------------------------------+
+```
+
+- Horizontal scroll for timeline when zoomed to decade/year level
+- Touch: pinch-to-zoom, two-finger pan
+
+### 2.3 Mobile (<768px)
+
+```
++-----------------------------------+
+| HEADER          [ham] [avatar]    |
++-----------------------------------+
+| [Search...] [Zoom] [Filters]     |
++-----------------------------------+
+|                                   |
+|   TIMELINE CANVAS                 |
+|   (vertical orientation,          |
+|    time flows top-to-bottom)      |
+|                                   |
+|   ── 1 AH ──                     |
+|   ████ Prophet Muhammad           |
+|   ████████ Abu Hurayra            |
+|   ── 50 AH ──                    |
+|   ...                             |
+|                                   |
++-----------------------------------+
+| 47 narrators           [+] [-]   |
++-----------------------------------+
+```
+
+- Timeline rotates to vertical orientation (time flows top-to-bottom)
+- Narrators as horizontal bars extending right from the time axis
+- Single-finger vertical scroll, pinch-to-zoom
+
+---
+
+## 3. Toolbar Controls
+
+### 3.1 Search
+
+```
++----------------------------------------------+
+| [magnifier] Search narrator to highlight...  |
++----------------------------------------------+
+```
+
+- Typeahead search (same pattern as Graph Explorer)
+- Selecting a narrator scrolls the timeline to center on their lifespan bar and highlights it
+- Does not filter — other narrators remain visible but the matched narrator pulses briefly then retains accent styling
+
+### 3.2 Zoom Level
+
+```
+  Zoom: [ Century | Decade | Year ]
+```
+
+- **Century**: Each division = 100 years AH. Macro view. Shows all major narrator generations as layered bars. Best for overview of transmission eras.
+- **Decade**: Each division = 10 years AH. Shows individual narrator lifespans with readable labels. Best for analyzing contemporaries and plausible transmission windows.
+- **Year**: Each division = 1 year AH. Shows exact birth/death dates, event markers, fine-grained overlap analysis.
+- Segmented button group, all options visible
+- Zooming re-renders the axis; narrator bars scale proportionally
+- Mouse wheel zoom supported (continuous, snapping to nearest level)
+
+### 3.3 Era Filter
+
+```
+  [Era filter v]
+  +---------------------------------------+
+  | [ ] Pre-Islamic (before 1 AH)        |
+  | [x] Prophetic era (1-11 AH)          |
+  | [x] Rightly-guided (11-41 AH)        |
+  | [x] Umayyad (41-132 AH)             |
+  | [x] Early Abbasid (132-247 AH)      |
+  | [ ] Later periods (247+ AH)          |
+  |                                       |
+  | [ Apply ]  [ Clear ]                 |
+  +---------------------------------------+
+```
+
+- Checkbox group filtering by historical era
+- Filters both narrators (by active lifetime) and events
+
+### 3.4 School Filter
+
+```
+  [School filter v]
+  +---------------------------------------+
+  | [x] Medinan                           |
+  | [x] Meccan                            |
+  | [x] Kufan                             |
+  | [x] Basran                            |
+  | [ ] Syrian                            |
+  | [ ] Egyptian                          |
+  |                                       |
+  | [ Apply ]  [ Clear ]                 |
+  +---------------------------------------+
+```
+
+- Filters narrators by scholarly school/geographic tradition
+- Useful for studying regional transmission networks
+
+---
+
+## 4. Timeline Canvas
+
+### 4.1 Time Axis
+
+```
+  1 AH         50 AH        100 AH       150 AH       200 AH       250 AH
+  |────────────|────────────|────────────|────────────|────────────|
+```
+
+- Horizontal axis with labeled divisions
+- Century gridlines: 1px solid #e0e0e0
+- Decade gridlines: 1px dashed #f0f0f0 (visible at decade/year zoom)
+- Year gridlines: 1px dotted #f5f5f5 (visible at year zoom only)
+- Axis labels centered on divisions
+
+### 4.2 Narrator Lifespan Bars
+
+```
+  ████████████████████████████████  Abu Hurayra (d. 59 AH)
+  ^                              ^
+  birth (unknown, estimated)     death
+```
+
+- Horizontal bars representing narrator lifespans
+- Bar height: 20px with 4px gap between bars
+- Bar color: by generation (same palette as Graph Explorer era overlay)
+  - Sahabi: oklch(65% 0.15 250) — blue
+  - Tabi'i: oklch(70% 0.15 150) — green
+  - Tabi' al-Tabi'in: oklch(65% 0.15 60) — amber
+  - Later: oklch(55% 0.15 0) — gray
+- Bars sorted vertically by death date (earliest at top)
+- Label shows name + death date, positioned to the right of the bar (or inside if bar is wide enough)
+- Unknown birth dates: bar starts with a tapered/faded left edge
+- Hover: bar darkens, tooltip appears
+
+### 4.3 Narrator Hover Tooltip
+
+```
++----------------------------------+
+| Abu Hurayra (ابو هريرة)          |
+| Born: unknown | Died: 59 AH      |
+| Generation: Sahabi               |
+| Location: Medina                 |
+| 342 transmissions                |
+| [View narrator detail →]        |
++----------------------------------+
+```
+
+### 4.4 Transmission Links
+
+```
+  ████████████████  Narrator A
+                ──→
+  ████████████████████  Narrator B
+```
+
+- Shown when a narrator is selected (clicked)
+- Lines connect the selected narrator's bar to their teachers (upward) and students (downward)
+- Arrow direction indicates transmission flow (teacher → student)
+- Line opacity: 0.6 for general links, 1.0 for selected chain
+- Line color: accent color (#1a73e8) for direct links
+- Only shown for the selected narrator to avoid visual chaos
+
+### 4.5 Historical Event Markers
+
+```
+  ◆ Battle of Badr (2 AH)
+  ◆ Conquest of Mecca (8 AH)
+  ◆ Death of Prophet (11 AH)
+  ◆ First Fitna (35 AH)
+  ◆ Fall of Umayyads (132 AH)
+```
+
+- Diamond markers positioned on the time axis
+- Vertical dashed line extends from marker across the full timeline height
+- Label below the axis
+- Click to see event detail popover:
+
+```
++----------------------------------+
+| Battle of Badr (2 AH / 624 CE)  |
+| Major military engagement in     |
+| early Islamic history. Several   |
+| key narrators participated.      |
+|                                  |
+| Related narrators: 12            |
+| [Highlight related narrators]   |
++----------------------------------+
+```
+
+- "Highlight related narrators" temporarily colors the bars of narrators associated with the event
+
+### 4.6 Overlap Analysis
+
+When two narrator bars overlap temporally, the overlap region represents the window when transmission could plausibly have occurred. At year zoom level, this overlap is highlighted:
+
+```
+  ████████████████████████ Narrator A (d. 80 AH)
+                ████████████████████████████ Narrator B (b. 60 AH)
+                ████████  <- overlap: 60-80 AH (highlighted region)
+```
+
+- Overlap highlight: subtle background stripe (5% opacity of accent color) between the two bars
+- Only shown when two narrators are compared (shift-click second narrator)
+
+---
+
+## 5. Event Cards
+
+```
++-----------------------------------------------+
+| EVENTS IN VIEW (5)                             |
++-----------------------------------------------+
+| ◆ 2 AH   Battle of Badr                       |
+| ◆ 8 AH   Conquest of Mecca                    |
+| ◆ 11 AH  Death of Prophet Muhammad             |
+| ◆ 35 AH  First Fitna begins                   |
+| ◆ 61 AH  Battle of Karbala                     |
++-----------------------------------------------+
+```
+
+- Collapsible panel listing events currently visible in the viewport
+- Clicking an event scrolls the timeline to center on it
+- Events sourced from HISTORICAL_EVENT nodes in the graph
+
+---
+
+## 6. RTL and Bidirectional Text
+
+### 6.1 Arabic Names
+
+- Narrator hover tooltip shows Arabic name (RTL) above English name (LTR)
+- Event card text uses bidi isolation for mixed-script content
+- Timeline bar labels are English-only at default zoom; Arabic names appear in tooltips and detail popovers
+
+### 6.2 Layout Direction
+
+- Timeline canvas and page layout remain LTR (time flows left-to-right, matching scholarly convention)
+- Arabic text within tooltips and popovers uses `dir="rtl"` block-level direction
+- On mobile vertical orientation, time flows top-to-bottom (not reversed for RTL)
+
+### 6.3 Font Stack
+
+```css
+--font-arabic: 'Noto Naskh Arabic', 'Geeza Pro', 'Traditional Arabic', serif;
+--font-ui: system-ui, -apple-system, sans-serif;
+```
+
+---
+
+## 7. Accessibility
+
+### 7.1 Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| Tab | Move through: search > zoom toggle > filters > timeline canvas > event list |
+| Arrow left/right | In canvas: pan timeline by one division |
+| Arrow up/down | In canvas: move focus between narrator bars |
+| Enter | Select focused narrator bar (shows transmission links) |
+| + / - | Zoom in / out |
+| Escape | Deselect narrator, close popovers |
+| / | Focus search input |
+
+### 7.2 Screen Reader Support
+
+- Timeline canvas: `role="application"` with `aria-label="Chronological timeline of hadith narrators"`
+- On narrator bar focus: "{name}, {generation}, born {birth} AH, died {death} AH, {transmissions} transmissions"
+- On event marker focus: "{event name}, {year} AH"
+- Timeline has a "View as table" alternative:
+
+**Narrators table:**
+| Name | Generation | Birth (AH) | Death (AH) | Location | Transmissions |
+
+**Events table:**
+| Event | Year (AH) | Year (CE) | Related Narrators |
+
+### 7.3 High Contrast Mode
+
+- Narrator bars gain 2px black outlines
+- Generation colors are supplemented with pattern fills (hatching for Sahabi, dots for Tabi'i, stripes for later)
+- Event markers become 2px solid black diamonds
+- Gridlines become more visible (darker)
+
+### 7.4 Reduced Motion
+
+- Zoom level transitions are instant (no animated axis rescaling)
+- Narrator bar hover effects are instant
+- Scroll-to-narrator on search is instant (no smooth scroll)
+
+---
+
+## 8. Responsive Breakpoint Summary
+
+| Feature | Desktop (>=1280) | Tablet (768-1279) | Mobile (<768) |
+|---------|:---:|:---:|:---:|
+| Nav sidebar | Visible (220px) | Hamburger overlay | Hamburger overlay |
+| Timeline orientation | Horizontal | Horizontal (scroll) | Vertical |
+| Zoom control | Segmented buttons | Segmented buttons | Dropdown |
+| Filters | Dropdown panels | Modal | Full-screen modal |
+| Narrator labels | Inline on bars | Inline on bars | Tooltip only |
+| Event markers | Inline + list | Inline + list | List only |
+| Overlap analysis | Shift-click | Long-press | Not available |
+| Transmission links | On click | On click | On tap |
+| Touch gestures | n/a | Pinch/pan | Pinch/pan/scroll |
+| Export | PNG/SVG/CSV | PNG/CSV | PNG only |
+
+---
+
+## 9. Component Mapping
+
+| Wireframe element | Component | Notes |
+|-------------------|-----------|-------|
+| Page shell | `TimelinePage.tsx` | New page, route: `/timeline` |
+| Timeline canvas | `TimelineCanvas` | HTML5 Canvas or SVG, custom renderer |
+| Time axis | `TimeAxis` | Responsive divisions based on zoom level |
+| Narrator bar | `NarratorBar` | Horizontal lifespan bar, interactive |
+| Event marker | `EventMarker` | Diamond glyph + vertical line |
+| Narrator tooltip | `NarratorTooltip` | Shared with Graph Explorer tooltip |
+| Event popover | `EventPopover` | Detail card for historical events |
+| Zoom control | `ZoomControl` | Segmented button group |
+| Filter panels | `TimelineFilters` | Era + school checkbox groups |
+| Table alternative | `TimelineTableView` | Accessible alternative rendering |
+
+---
+
+## 10. Design Tokens
+
+```css
+/* Timeline canvas */
+--timeline-bg: #fafafa;
+--timeline-axis-color: #333333;
+--timeline-grid-century: #e0e0e0;
+--timeline-grid-decade: #f0f0f0;
+
+/* Narrator bars */
+--bar-height: 20px;
+--bar-gap: 4px;
+--bar-radius: 3px;
+--bar-sahabi: oklch(65% 0.15 250);
+--bar-tabii: oklch(70% 0.15 150);
+--bar-tabi-tabiin: oklch(65% 0.15 60);
+--bar-later: oklch(55% 0.15 0);
+
+/* Event markers */
+--event-marker-size: 10px;
+--event-marker-color: #d32f2f;
+--event-line-color: #d32f2f;
+--event-line-opacity: 0.3;
+
+/* Overlap highlight */
+--overlap-bg: rgba(26, 115, 232, 0.05);
+```
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-29 | Sable Nakamura-Whitfield | Initial wireframe specification |


### PR DESCRIPTION
## Summary

- Add wireframe specifications for search, narrator detail, hadith detail, timeline, comparative analysis, and admin panel views
- Each wireframe follows the established style from graph-explorer.md with ASCII layouts, interaction specs, responsive breakpoints (desktop/tablet/mobile), RTL/BiDi handling, WCAG accessibility (keyboard nav, screen reader, high contrast, reduced motion), component mapping, and design tokens
- All wireframes use the shared OKLCH color palette and design token conventions

## Wireframes

| File | Issue | View |
|------|-------|------|
| `docs/ux/wireframes/search.md` | #537 | Full-text + semantic search with faceted filtering |
| `docs/ux/wireframes/narrator-detail.md` | #538 | Narrator profile, reliability ratings, ego-graph, hadith list |
| `docs/ux/wireframes/hadith-detail.md` | #539 | Hadith text, isnad chain visualization, parallels, grading |
| `docs/ux/wireframes/timeline.md` | #540 | Chronological narrator lifespans with zoom levels |
| `docs/ux/wireframes/comparative.md` | #541 | Side-by-side hadith comparison with diff highlighting |
| `docs/ux/wireframes/admin.md` | #542 | Pipeline, users, moderation, system health dashboard |

Closes #537, Closes #538, Closes #539, Closes #540, Closes #541, Closes #542

## Test plan

- [ ] Verify each wireframe renders correctly in GitHub markdown preview
- [ ] Confirm ASCII layouts are legible at standard viewport widths
- [ ] Review RTL/BiDi sections for completeness
- [ ] Check component mapping tables reference plausible component names

🤖 Generated with [Claude Code](https://claude.com/claude-code)