### PR TITLE
fix(pipeline): resolve 5 pipeline bugs (#570-#574)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-setup: ## Install dependencies with uv
-	uv sync
+setup: ## Install dependencies with uv (includes ML group for dedup)
+	uv sync --group ml
 
 setup-hooks: ## Configure git hooks (legacy .githooks + pre-commit)
 	git config core.hooksPath .githooks

--- a/src/acquire/fawaz.py
+++ b/src/acquire/fawaz.py
@@ -33,10 +33,32 @@ _EDITION_PREFIXES = ("eng-", "ara-")
 
 
 def _edition_keys(editions: dict[str, Any] | list[Any]) -> list[str]:
-    """Return edition keys that start with ``eng-`` or ``ara-``."""
-    if isinstance(editions, dict):
-        return sorted(k for k in editions if any(k.startswith(p) for p in _EDITION_PREFIXES))
-    return []
+    """Return edition keys that start with ``eng-`` or ``ara-``.
+
+    Handles both the legacy flat dict format (key -> edition data) and the
+    current nested format where each top-level key maps to an object with
+    a ``collection`` list of edition objects containing a ``name`` field.
+    """
+    if not isinstance(editions, dict):
+        return []
+
+    # Check if any top-level key matches an edition prefix (legacy flat format).
+    flat_keys = [k for k in editions if any(k.startswith(p) for p in _EDITION_PREFIXES)]
+    if flat_keys:
+        return sorted(flat_keys)
+
+    # Current nested format: {collection_name: {name, collection: [{name, ...}, ...]}}.
+    nested_keys: list[str] = []
+    for _coll_name, coll_data in editions.items():
+        if not isinstance(coll_data, dict):
+            continue
+        for edition in coll_data.get("collection", []):
+            if not isinstance(edition, dict):
+                continue
+            name = edition.get("name", "")
+            if any(name.startswith(p) for p in _EDITION_PREFIXES):
+                nested_keys.append(name)
+    return sorted(nested_keys)
 
 
 def run(raw_dir: Path) -> Path:

--- a/src/parse/muhaddithat.py
+++ b/src/parse/muhaddithat.py
@@ -64,7 +64,13 @@ def _parse_narrator_bios(narrators_path: Path) -> tuple[pa.Table, dict[str, str]
 
     # Detect column names (the repo may use various conventions).
     id_col = header_map.get("id") or header_map.get("narrator_id")
-    name_col = header_map.get("name") or header_map.get("display_name")
+    name_col = (
+        header_map.get("name")
+        or header_map.get("displayname")
+        or header_map.get("display_name")
+        or header_map.get("fullname")
+        or header_map.get("arabicname")
+    )
     gender_col = header_map.get("gender")
     bio_col = header_map.get("bio") or header_map.get("biography")
 

--- a/src/parse/open_hadith.py
+++ b/src/parse/open_hadith.py
@@ -25,7 +25,7 @@ from src.utils.logging import get_logger
 logger = get_logger(__name__)
 
 # Patterns indicating a diacritics/tashkeel file.
-_DIACRITICS_RE = re.compile(r"tashkeel|diacritics", re.IGNORECASE)
+_DIACRITICS_RE = re.compile(r"tashkeel|diacritics|mushakkala", re.IGNORECASE)
 
 # Common column name mappings (lowercase -> canonical).
 _TEXT_COLUMNS = {"hadith", "text", "matn", "content", "hadith_text", "حديث", "متن"}
@@ -86,6 +86,16 @@ def run(raw_dir: Path, staging_dir: Path) -> Path:
         book_col = _find_column(headers, _BOOK_COLUMNS)
         chapter_col = _find_column(headers, _CHAPTER_COLUMNS)
 
+        # Handle headerless CSVs (auto-generated column names like f0, f1, f2).
+        # Open Hadith Data CSVs have no headers: col 0 = number, col 1 = text.
+        if (
+            not text_col
+            and len(headers) >= 2
+            and all(h.startswith("f") and h[1:].isdigit() for h in headers)
+        ):
+            number_col = headers[0]
+            text_col = headers[1]
+
         # Convert columns to Python lists once (avoid O(n^2) per-row conversion).
         number_vals = table.column(number_col).to_pylist() if number_col else None
         text_vals = table.column(text_col).to_pylist() if text_col else None
@@ -108,11 +118,11 @@ def run(raw_dir: Path, staging_dir: Path) -> Path:
                     "book_number": book_num,
                     "chapter_number": chapter_num,
                     "hadith_number": hadith_num,
-                    "matn_ar": text_value,
+                    "matn_ar": None,
                     "matn_en": None,
                     "isnad_raw_ar": None,
                     "isnad_raw_en": None,
-                    "full_text_ar": text_value if text_col is None else None,
+                    "full_text_ar": text_value,
                     "full_text_en": None,
                     "grade": None,
                     "chapter_name_ar": None,

--- a/src/resolve/disambiguate.py
+++ b/src/resolve/disambiguate.py
@@ -429,7 +429,9 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
 
     # Load inputs.
     candidates = _load_candidates(staging_dir)
-    mentions = _load_mentions(staging_dir)
+    # NER writes narrator_mentions_resolved.parquet to output_dir (curated),
+    # so load mentions from there rather than staging_dir.
+    mentions = _load_mentions(output_dir)
 
     if not mentions:
         logger.warning("disambiguate_no_mentions")
@@ -494,7 +496,7 @@ def run(staging_dir: Path, output_dir: Path) -> list[Path]:
             else:
                 rec = canonical_map[canonical_id]
                 raw_count = rec.get("mention_count")
-                prev = int(raw_count) if isinstance(raw_count, (int, str)) else 0
+                prev = int(raw_count) if isinstance(raw_count, int | str) else 0
                 rec["mention_count"] = prev + 1
                 # Merge source IDs.
                 src_ids = rec.get("source_ids")


### PR DESCRIPTION
## Summary

Fixes 5 pipeline bugs identified during the full Phase 1-2 pipeline run (see `docs/data/full-pipeline-results.md`):

- **#570 fawaz CDN**: Upstream `editions.json` changed from flat dict to nested structure (`{collection: {name, collection: [{name, ...}]}}`). Updated `_edition_keys()` to extract edition names from the nested format while preserving backward compatibility with the legacy flat format.
- **#571 muhaddithat parser**: Raw CSV has columns `displayname`, `fullname`, `arabicname` — not `name`. Added these to the column detection fallback chain.
- **#572 disambiguate path mismatch**: NER writes `narrator_mentions_resolved.parquet` to `data/curated/` but disambiguate read from `data/staging/`. Fixed `_load_mentions()` to read from `output_dir` (curated).
- **#573 sentence-transformers**: Already declared in `[dependency-groups] ml` but `make setup` ran `uv sync` without `--group ml`. Updated Makefile to install with ML group.
- **#574 open_hadith matn fields**: Two root causes: (1) diacritics regex missed `mushakkala` filenames, (2) CSVs have no header row so auto-generated column names didn't match text column candidates. Added `mushakkala` to regex and added headerless CSV detection. Also corrected field mapping — source text is combined isnad+matn so it belongs in `full_text_ar`, not `matn_ar`.

Closes #570, Closes #571, Closes #572, Closes #573, Closes #574

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `ruff format` passes
- [x] `mypy` passes
- [x] 824 unit tests pass
- [ ] Re-run `make acquire` to verify fawaz downloads succeed with new CDN structure
- [ ] Re-run `make parse` to verify muhaddithat and open_hadith produce non-empty output
- [ ] Re-run `make resolve` to verify disambiguate loads NER mentions and produces canonical narrators

🤖 Generated with [Claude Code](https://claude.com/claude-code)
