### PR TITLE
feat(acquire): re-enable Kaggle narrators + QURAN-NLP assessment

### DIFF
--- a/src/acquire/sanadset.py
+++ b/src/acquire/sanadset.py
@@ -3,13 +3,13 @@
 Datasets:
 - Mendeley Data ``5xth87zwb5`` v4 — sanadset.csv (~650K hadiths), books.csv
 - Kaggle ``fahd09/hadith-dataset`` — same data (removed/intermittent as of early 2026)
-- Kaggle ``fahd09/hadith-narrators`` — narrator biographies (24K+)
+- Kaggle ``fahd09/hadith-narrators`` — narrator biographies (24K+), CC0 licensed
 
-The Kaggle datasets (``fahd09/hadith-dataset`` and ``fahd09/hadith-narrators``) were
-removed or made private circa early 2026. Mendeley Data hosts the same Sanadset
-corpus (DOI: 10.17632/5xth87zwb5.4) with stable public download URLs and is now
-the primary acquisition path. Kaggle is retained as a fallback for the narrators
-dataset, which is not available on Mendeley.
+The Kaggle narrator dataset (``fahd09/hadith-narrators``) was temporarily removed
+circa early 2026 but is accessible again as of March 2026. Mendeley Data hosts the
+Sanadset hadith corpus (DOI: 10.17632/5xth87zwb5.4) with stable public download
+URLs and is the primary acquisition path. The narrators dataset is downloaded from
+Kaggle using the Python API (with CLI subprocess as fallback).
 """
 
 from __future__ import annotations
@@ -91,7 +91,23 @@ def _download_mendeley(dest: Path) -> list[Path]:
 
 
 def _run_kaggle_download(dataset: str, dest: Path) -> None:
-    """Run ``kaggle datasets download`` via subprocess."""
+    """Download a Kaggle dataset using the Python API, falling back to CLI subprocess."""
+    logger.info("kaggle_download_start", dataset=dataset, dest=str(dest))
+
+    # Try the Python API first (works even when CLI binary is not installed)
+    try:
+        import kaggle  # type: ignore[import-untyped]  # noqa: PLC0415
+
+        kaggle.api.authenticate()
+        kaggle.api.dataset_download_files(dataset, path=str(dest), unzip=True)
+        logger.info("kaggle_download_complete", dataset=dataset, method="python_api")
+        return
+    except ImportError:
+        logger.debug("kaggle_python_api_unavailable", note="falling back to CLI")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("kaggle_python_api_failed", dataset=dataset, error=str(exc))
+
+    # Fallback: CLI subprocess
     cmd = [
         "kaggle",
         "datasets",
@@ -102,7 +118,6 @@ def _run_kaggle_download(dataset: str, dest: Path) -> None:
         str(dest),
         "--unzip",
     ]
-    logger.info("kaggle_download_start", dataset=dataset, dest=str(dest))
     try:
         subprocess.run(  # noqa: S603
             cmd,
@@ -111,7 +126,7 @@ def _run_kaggle_download(dataset: str, dest: Path) -> None:
             text=True,
             check=True,
         )
-        logger.info("kaggle_download_complete", dataset=dataset)
+        logger.info("kaggle_download_complete", dataset=dataset, method="cli")
     except subprocess.TimeoutExpired:
         logger.error("kaggle_download_timeout", dataset=dataset, timeout=_SUBPROCESS_TIMEOUT)
         raise


### PR DESCRIPTION
## Summary

- **#577 Kaggle hadith-narrators:** Confirmed `fahd09/hadith-narrators` is accessible again (24,325 narrator biographies, CC0). Updated `src/acquire/sanadset.py` to use the Kaggle Python API as the primary download method with CLI subprocess as fallback, ensuring the download works even without the `kaggle` CLI binary installed.

- **#576 QURAN-NLP repo:** Investigated `islamAndAi/QURAN-NLP`. Findings:
  - `kaggle_rawis.csv` (24,325 rows) is identical to the Kaggle `fahd09/hadith-narrators` dataset (same schema, same data) — no new downloader needed
  - Sanadset hadith samples in the repo are only 10 rows (a tiny subset of our 650K Mendeley source)
  - Thaqalayn CSVs (27 files, 27K rows) duplicate data already acquired by our `thaqalayn.py` acquirer
  - Quran-specific data (quran.csv, tafaseer, translations) is out of scope for hadith analysis

## Changes

- `src/acquire/sanadset.py`: Updated `_run_kaggle_download()` to try `kaggle` Python API first, fall back to CLI subprocess. Updated module docstring to reflect current dataset availability.

## Test plan

- [x] Lint passes (`ruff check`, `ruff format`)
- [x] Type check passes (`mypy`)
- [x] Unit tests pass (`pytest`)
- [x] Verified Kaggle Python API successfully downloads `fahd09/hadith-narrators`
- [x] Verified QURAN-NLP `kaggle_rawis.csv` matches Kaggle download (identical schema/data)

Closes #576
Closes #577

🤖 Generated with [Claude Code](https://claude.ai/code)