### PR TITLE
feat(ux): apply Qalam theme to design tokens

### DIFF
--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -4,7 +4,7 @@
  * Isnad Graph Design Token System
  * ================================
  * Tokens organized by category: color, typography, spacing, borders, shadows,
- * z-index, transitions. Default palette: Proposal C (Riwaya).
+ * z-index, transitions. Default palette: Proposal A (Qalam).
  *
  * Color space: OKLCH (perceptually uniform) with hex fallbacks.
  * All color combinations verified for WCAG 2.2 AA contrast.
@@ -16,63 +16,63 @@
  */
 
 /* ============================================================
- * COLOR TOKENS — Light Mode (Riwaya / Proposal C)
+ * COLOR TOKENS — Light Mode (Qalam / Proposal A)
  * ============================================================ */
 @theme {
   /* --- Semantic colors --- */
-  --color-primary: oklch(0.48 0.12 180);
-  --color-primary-hover: oklch(0.53 0.12 180);
+  --color-primary: oklch(0.55 0.14 45);
+  --color-primary-hover: oklch(0.60 0.14 45);
   --color-primary-foreground: #ffffff;
-  --color-secondary: oklch(0.82 0.01 60);
-  --color-secondary-foreground: oklch(0.22 0.015 250);
-  --color-muted: oklch(0.93 0.005 60);
-  --color-muted-foreground: oklch(0.58 0.015 60);
-  --color-accent: oklch(0.90 0.03 180);
-  --color-accent-foreground: oklch(0.35 0.10 180);
-  --color-destructive: oklch(0.55 0.18 15);
+  --color-secondary: oklch(0.85 0.01 85);
+  --color-secondary-foreground: oklch(0.25 0.02 260);
+  --color-muted: oklch(0.93 0.005 85);
+  --color-muted-foreground: oklch(0.45 0.01 260);
+  --color-accent: oklch(0.90 0.03 45);
+  --color-accent-foreground: oklch(0.40 0.12 45);
+  --color-destructive: oklch(0.60 0.18 30);
   --color-destructive-foreground: #ffffff;
-  --color-success: oklch(0.50 0.14 160);
+  --color-success: oklch(0.55 0.10 175);
   --color-success-foreground: #ffffff;
-  --color-warning: oklch(0.65 0.16 75);
-  --color-warning-foreground: oklch(0.22 0.015 250);
-  --color-info: oklch(0.45 0.14 250);
+  --color-warning: oklch(0.65 0.14 75);
+  --color-warning-foreground: oklch(0.25 0.02 260);
+  --color-info: oklch(0.45 0.12 260);
   --color-info-foreground: #ffffff;
 
   /* --- Surface colors --- */
-  --color-background: oklch(0.97 0.008 80);
-  --color-foreground: oklch(0.22 0.015 250);
-  --color-card: oklch(0.99 0.005 80);
-  --color-card-foreground: oklch(0.22 0.015 250);
-  --color-popover: oklch(0.99 0.005 80);
-  --color-popover-foreground: oklch(0.22 0.015 250);
+  --color-background: oklch(0.96 0.01 85);
+  --color-foreground: oklch(0.25 0.02 260);
+  --color-card: oklch(0.99 0.005 85);
+  --color-card-foreground: oklch(0.25 0.02 260);
+  --color-popover: oklch(0.99 0.005 85);
+  --color-popover-foreground: oklch(0.25 0.02 260);
 
   /* --- Interactive --- */
-  --color-border: oklch(0.82 0.01 60);
-  --color-input: oklch(0.82 0.01 60);
-  --color-ring: oklch(0.48 0.12 180);
+  --color-border: oklch(0.85 0.01 85);
+  --color-input: oklch(0.85 0.01 85);
+  --color-ring: oklch(0.55 0.14 45);
 
   /* --- Domain: hadith grading --- */
-  --color-sahih: oklch(0.50 0.14 160);
-  --color-sahih-bg: oklch(0.93 0.04 160);
-  --color-hasan: oklch(0.65 0.16 75);
+  --color-sahih: oklch(0.55 0.10 175);
+  --color-sahih-bg: oklch(0.93 0.03 175);
+  --color-hasan: oklch(0.65 0.14 75);
   --color-hasan-bg: oklch(0.95 0.04 75);
-  --color-daif: oklch(0.55 0.18 15);
-  --color-daif-bg: oklch(0.95 0.03 15);
-  --color-mawdu: oklch(0.45 0.18 5);
-  --color-mawdu-bg: oklch(0.94 0.03 5);
+  --color-daif: oklch(0.60 0.18 30);
+  --color-daif-bg: oklch(0.95 0.03 30);
+  --color-mawdu: oklch(0.50 0.15 15);
+  --color-mawdu-bg: oklch(0.94 0.03 15);
 
   /* --- Domain: sect indicators --- */
-  --color-sunni: oklch(0.50 0.14 160);
-  --color-sunni-bg: oklch(0.93 0.04 160);
-  --color-shia: oklch(0.45 0.14 250);
-  --color-shia-bg: oklch(0.93 0.04 250);
+  --color-sunni: oklch(0.55 0.10 175);
+  --color-sunni-bg: oklch(0.93 0.03 175);
+  --color-shia: oklch(0.45 0.12 260);
+  --color-shia-bg: oklch(0.93 0.03 260);
 
   /* --- Domain: narrator reliability tiers --- */
-  --color-tier-thiqah: oklch(0.50 0.14 160);
-  --color-tier-saduq: oklch(0.55 0.10 180);
-  --color-tier-daif-narrator: oklch(0.65 0.16 75);
-  --color-tier-matruk: oklch(0.55 0.18 15);
-  --color-tier-kadhdhab: oklch(0.45 0.18 5);
+  --color-tier-thiqah: oklch(0.55 0.10 175);
+  --color-tier-saduq: oklch(0.60 0.10 45);
+  --color-tier-daif-narrator: oklch(0.65 0.14 75);
+  --color-tier-matruk: oklch(0.60 0.18 30);
+  --color-tier-kadhdhab: oklch(0.50 0.15 15);
 
   /* --- Radii --- */
   --radius-sm: 0.25rem;
@@ -124,10 +124,10 @@
  * ============================================================ */
 :root {
   /* Font families */
-  --font-arabic: 'Amiri', 'Noto Naskh Arabic', serif;
-  --font-heading: 'Source Sans 3', 'Inter', system-ui, sans-serif;
-  --font-body: 'Source Sans 3', 'Inter', system-ui, sans-serif;
-  --font-mono: 'Source Code Pro', 'JetBrains Mono', ui-monospace, monospace;
+  --font-arabic: 'Noto Naskh Arabic', serif;
+  --font-heading: 'IBM Plex Serif', 'Georgia', serif;
+  --font-body: 'IBM Plex Sans', 'Inter', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
 
   /* Modular type scale (1.25 ratio) */
   --text-xs: 0.75rem;
@@ -190,59 +190,59 @@
 @media (prefers-color-scheme: dark) {
   @theme {
     /* Surface colors */
-    --color-background: oklch(0.18 0.012 60);
-    --color-foreground: oklch(0.95 0.008 80);
-    --color-card: oklch(0.23 0.012 60);
-    --color-card-foreground: oklch(0.93 0.008 80);
-    --color-popover: oklch(0.23 0.012 60);
-    --color-popover-foreground: oklch(0.93 0.008 80);
+    --color-background: oklch(0.20 0.015 260);
+    --color-foreground: oklch(0.92 0.01 85);
+    --color-card: oklch(0.25 0.015 260);
+    --color-card-foreground: oklch(0.92 0.01 85);
+    --color-popover: oklch(0.25 0.015 260);
+    --color-popover-foreground: oklch(0.92 0.01 85);
 
     /* Semantic colors */
-    --color-primary: oklch(0.65 0.12 180);
-    --color-primary-hover: oklch(0.70 0.12 180);
-    --color-primary-foreground: oklch(0.18 0.012 60);
-    --color-secondary: oklch(0.30 0.01 60);
-    --color-secondary-foreground: oklch(0.90 0.008 80);
-    --color-muted: oklch(0.25 0.01 60);
-    --color-muted-foreground: oklch(0.62 0.015 60);
-    --color-accent: oklch(0.25 0.03 180);
-    --color-accent-foreground: oklch(0.75 0.10 180);
-    --color-destructive: oklch(0.65 0.16 15);
-    --color-destructive-foreground: oklch(0.18 0.012 60);
-    --color-success: oklch(0.60 0.12 160);
-    --color-success-foreground: oklch(0.18 0.012 60);
-    --color-warning: oklch(0.75 0.14 75);
-    --color-warning-foreground: oklch(0.18 0.012 60);
-    --color-info: oklch(0.55 0.12 250);
+    --color-primary: oklch(0.65 0.14 45);
+    --color-primary-hover: oklch(0.70 0.14 45);
+    --color-primary-foreground: oklch(0.20 0.015 260);
+    --color-secondary: oklch(0.30 0.01 260);
+    --color-secondary-foreground: oklch(0.90 0.01 85);
+    --color-muted: oklch(0.25 0.01 260);
+    --color-muted-foreground: oklch(0.60 0.01 260);
+    --color-accent: oklch(0.28 0.03 45);
+    --color-accent-foreground: oklch(0.75 0.12 45);
+    --color-destructive: oklch(0.70 0.16 30);
+    --color-destructive-foreground: oklch(0.20 0.015 260);
+    --color-success: oklch(0.65 0.10 175);
+    --color-success-foreground: oklch(0.20 0.015 260);
+    --color-warning: oklch(0.75 0.12 75);
+    --color-warning-foreground: oklch(0.20 0.015 260);
+    --color-info: oklch(0.55 0.10 260);
     --color-info-foreground: #ffffff;
 
     /* Interactive */
-    --color-border: oklch(0.35 0.01 60);
-    --color-input: oklch(0.35 0.01 60);
-    --color-ring: oklch(0.65 0.12 180);
+    --color-border: oklch(0.35 0.01 260);
+    --color-input: oklch(0.35 0.01 260);
+    --color-ring: oklch(0.65 0.14 45);
 
     /* Domain: hadith grading (dark) */
-    --color-sahih: oklch(0.60 0.12 160);
-    --color-sahih-bg: oklch(0.25 0.04 160);
-    --color-hasan: oklch(0.75 0.14 75);
+    --color-sahih: oklch(0.65 0.10 175);
+    --color-sahih-bg: oklch(0.25 0.03 175);
+    --color-hasan: oklch(0.75 0.12 75);
     --color-hasan-bg: oklch(0.28 0.04 75);
-    --color-daif: oklch(0.65 0.16 15);
-    --color-daif-bg: oklch(0.25 0.03 15);
-    --color-mawdu: oklch(0.55 0.16 5);
-    --color-mawdu-bg: oklch(0.24 0.03 5);
+    --color-daif: oklch(0.70 0.16 30);
+    --color-daif-bg: oklch(0.25 0.03 30);
+    --color-mawdu: oklch(0.60 0.14 15);
+    --color-mawdu-bg: oklch(0.24 0.03 15);
 
     /* Domain: sect indicators (dark) */
-    --color-sunni: oklch(0.60 0.12 160);
-    --color-sunni-bg: oklch(0.25 0.04 160);
-    --color-shia: oklch(0.55 0.12 250);
-    --color-shia-bg: oklch(0.25 0.04 250);
+    --color-sunni: oklch(0.65 0.10 175);
+    --color-sunni-bg: oklch(0.25 0.03 175);
+    --color-shia: oklch(0.55 0.10 260);
+    --color-shia-bg: oklch(0.25 0.03 260);
 
     /* Domain: narrator reliability tiers (dark) */
-    --color-tier-thiqah: oklch(0.60 0.12 160);
-    --color-tier-saduq: oklch(0.65 0.10 180);
-    --color-tier-daif-narrator: oklch(0.75 0.14 75);
-    --color-tier-matruk: oklch(0.65 0.16 15);
-    --color-tier-kadhdhab: oklch(0.55 0.16 5);
+    --color-tier-thiqah: oklch(0.65 0.10 175);
+    --color-tier-saduq: oklch(0.70 0.10 45);
+    --color-tier-daif-narrator: oklch(0.75 0.12 75);
+    --color-tier-matruk: oklch(0.70 0.16 30);
+    --color-tier-kadhdhab: oklch(0.60 0.14 15);
   }
 
   :root {


### PR DESCRIPTION
## Summary

- Replace Riwaya (Proposal C) palette with Qalam (Proposal A) per user selection
- Sienna primary, parchment background, vellum surfaces, ink foreground
- Typography updated to IBM Plex family with Noto Naskh Arabic for Arabic text
- Dark mode values updated to match Qalam dark mode spec

## Test plan

- [ ] Verify WCAG 2.2 AA contrast ratios for all Qalam color pairs
- [ ] Test dark mode token values toggle correctly
- [ ] Confirm typography stack renders IBM Plex Serif headings, IBM Plex Sans body

🤖 Generated with [Claude Code](https://claude.ai/code)