### PR TITLE
feat(enrich): Wikipedia timeline scraper + compiler ACTIVE_DURING edges

### DIFF
--- a/scripts/scrape_islamic_timeline.py
+++ b/scripts/scrape_islamic_timeline.py
@@ -1,0 +1,531 @@
+"""Scrape Wikipedia Timeline of Islam pages for historical events.
+
+Extracts structured event data from the main timeline page and
+century-specific sub-pages (7th–15th century CE).  Outputs YAML to
+``data/curated/historical_events.yaml`` preserving the existing schema
+so that ``src/graph/load_nodes.py`` can load events without changes.
+
+Usage::
+
+    uv run python scripts/scrape_islamic_timeline.py
+    uv run python scripts/scrape_islamic_timeline.py --centuries 7 8 9
+    uv run python scripts/scrape_islamic_timeline.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import math
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+from bs4 import BeautifulSoup, Tag
+
+# ---------------------------------------------------------------------------
+# CE ↔ AH conversion
+# ---------------------------------------------------------------------------
+
+# The Islamic (Hijri) calendar started on 16 July 622 CE.
+# The calendar is lunar (~354.36667 days/year vs ~365.25 for Gregorian).
+
+_HIJRI_EPOCH_CE = 622
+_ISLAMIC_YEAR_DAYS = 354.36667
+_GREGORIAN_YEAR_DAYS = 365.25
+
+
+def ce_to_ah(ce_year: int) -> int:
+    """Convert a Common Era year to an approximate Hijri year.
+
+    Uses the standard astronomical approximation.  Accurate to ±1 year
+    for the 7th–15th century range relevant to hadith scholarship.
+    """
+    if ce_year < _HIJRI_EPOCH_CE:
+        return 0  # pre-Islamic
+    return math.floor((ce_year - _HIJRI_EPOCH_CE) * (_GREGORIAN_YEAR_DAYS / _ISLAMIC_YEAR_DAYS)) + 1
+
+
+def ah_to_ce(ah_year: int) -> int:
+    """Convert a Hijri year to an approximate Common Era year."""
+    return math.floor(ah_year * (_ISLAMIC_YEAR_DAYS / _GREGORIAN_YEAR_DAYS) + _HIJRI_EPOCH_CE)
+
+
+# ---------------------------------------------------------------------------
+# Event categorization
+# ---------------------------------------------------------------------------
+
+_CATEGORY_KEYWORDS: dict[str, list[str]] = {
+    "caliphate": [
+        "caliph",
+        "caliphate",
+        "succession",
+        "inaugurated",
+        "proclaimed",
+        "abdicate",
+    ],
+    "fitna": [
+        "fitna",
+        "civil war",
+        "revolt",
+        "rebellion",
+        "uprising",
+        "assassination",
+        "murdered",
+        "killed",
+        "martyr",
+        "karbala",
+    ],
+    "conquest": [
+        "conquest",
+        "capture",
+        "siege",
+        "conquer",
+        "fall of",
+        "invasion",
+        "annex",
+        "occupy",
+        "expedition",
+    ],
+    "compilation_effort": [
+        "compil",
+        "hadith",
+        "sahih",
+        "sunan",
+        "musnad",
+        "wrote",
+        "author",
+        "book",
+        "scholar",
+        "jurisprud",
+        "fiqh",
+        "school",
+        "madhhab",
+    ],
+    "theological_controversy": [
+        "mutazil",
+        "ashari",
+        "theology",
+        "creed",
+        "doctrine",
+        "mihna",
+        "inquisition",
+        "heresy",
+        "debate",
+    ],
+    "dynasty_transition": [
+        "dynasty",
+        "overthrow",
+        "revolution",
+        "founded",
+        "established",
+        "umayyad",
+        "abbasid",
+        "fatimid",
+        "ayyubid",
+        "mamluk",
+        "seljuk",
+        "ottoman",
+    ],
+    "persecution": [
+        "persecution",
+        "massacre",
+        "pogrom",
+        "exile",
+        "expulsion",
+    ],
+}
+
+# Priority order when multiple categories match
+_CATEGORY_PRIORITY = [
+    "fitna",
+    "conquest",
+    "dynasty_transition",
+    "caliphate",
+    "theological_controversy",
+    "compilation_effort",
+    "persecution",
+]
+
+
+def categorize_event(description: str) -> str:
+    """Assign a HistoricalEventType category based on keyword matching."""
+    desc_lower = description.lower()
+    scores: dict[str, int] = {}
+    for cat, keywords in _CATEGORY_KEYWORDS.items():
+        score = sum(1 for kw in keywords if kw in desc_lower)
+        if score > 0:
+            scores[cat] = score
+    if not scores:
+        return "conquest"  # default for military/political events
+    # Tie-break by priority order
+    max_score = max(scores.values())
+    for cat in _CATEGORY_PRIORITY:
+        if scores.get(cat, 0) == max_score:
+            return cat
+    return max(scores, key=lambda k: scores[k])
+
+
+# ---------------------------------------------------------------------------
+# Wikipedia scraping
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "https://en.wikipedia.org"
+_MAIN_PAGE = "/wiki/Timeline_of_the_history_of_Islam"
+_CENTURY_TEMPLATE = "/wiki/Timeline_of_the_history_of_Islam_({century}_century)"
+
+_USER_AGENT = (
+    "isnad-graph/0.1 (https://github.com/parametrization/isnad-graph; "
+    "educational research) Python/httpx"
+)
+_REQUEST_DELAY = 1.0  # seconds between requests
+
+# Match year(s) at the start of a list item: "622", "622–632", "c. 750"
+_YEAR_PATTERN = re.compile(
+    r"^(?:c\.?\s*)?(\d{3,4})"  # first year
+    r"(?:\s*[–—\-/]\s*(?:c\.?\s*)?(\d{3,4}))?"  # optional second year
+)
+
+_CENTURY_NAMES = {
+    6: "6th",
+    7: "7th",
+    8: "8th",
+    9: "9th",
+    10: "10th",
+    11: "11th",
+    12: "12th",
+    13: "13th",
+    14: "14th",
+    15: "15th",
+}
+
+
+def _make_event_id(ce_year: int, description: str) -> str:
+    """Generate a deterministic event ID from year and description."""
+    slug = re.sub(r"[^a-z0-9]+", "-", description[:60].lower()).strip("-")
+    # Add a short hash to avoid collisions
+    h = hashlib.sha256(f"{ce_year}:{description}".encode()).hexdigest()[:6]
+    return f"evt:wiki-{ce_year}-{slug}-{h}"
+
+
+def _clean_text(text: str) -> str:
+    """Clean scraped text: normalize whitespace, strip footnote references."""
+    text = re.sub(r"\[(?:citation needed|\d+|a-z)\]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    # Remove trailing period duplication
+    text = re.sub(r"\.\.+$", ".", text)
+    return text
+
+
+def _extract_events_from_list_items(
+    soup: BeautifulSoup,
+    source_url: str,
+) -> list[dict[str, Any]]:
+    """Extract events from <li> elements in a Wikipedia timeline page."""
+    events: list[dict[str, Any]] = []
+
+    # Find all list items in the main content area
+    content = soup.find("div", {"class": "mw-parser-output"})
+    if not content:
+        return events
+
+    assert isinstance(content, Tag)
+    for li in content.find_all("li", recursive=True):
+        # Skip items inside navigation, references, or table of contents
+        parent_classes = " ".join(
+            c for p in li.parents if isinstance(p, Tag) for c in (p.get("class") or [])
+        )
+        if any(
+            skip in parent_classes
+            for skip in ["reflist", "toc", "navbox", "sidebar", "mw-references"]
+        ):
+            continue
+
+        text = _clean_text(li.get_text())
+        if len(text) < 10:
+            continue
+
+        match = _YEAR_PATTERN.match(text)
+        if not match:
+            continue
+
+        year_start_ce = int(match.group(1))
+        year_end_ce = int(match.group(2)) if match.group(2) else year_start_ce
+
+        # Skip events outside Islamic history range
+        if year_start_ce < 570 or year_start_ce > 1500:
+            continue
+
+        # Extract description: everything after the year(s) and separators
+        desc_start = match.end()
+        description = text[desc_start:].lstrip(" –—-:,")
+        description = _clean_text(description)
+
+        if len(description) < 5:
+            continue
+
+        # Strip leading date fragments (e.g., "9 September – ")
+        description = re.sub(
+            r"^(?:\d{1,2}\s+\w+\s*[–—-]\s*(?:\d{1,2}\s+\w+\s*[–—-]\s*)?)",
+            "",
+            description,
+        ).strip(" –—-")
+
+        year_start_ah = ce_to_ah(year_start_ce)
+        year_end_ah = ce_to_ah(year_end_ce)
+        category = categorize_event(description)
+
+        events.append(
+            {
+                "id": _make_event_id(year_start_ce, description),
+                "name_en": description[:120] if len(description) > 120 else description,
+                "year_start_ah": year_start_ah,
+                "year_end_ah": year_end_ah,
+                "year_start_ce": year_start_ce,
+                "year_end_ce": year_end_ce,
+                "type": category,
+                "description": description,
+                "source_url": source_url,
+            }
+        )
+
+    return events
+
+
+def fetch_page(client: httpx.Client, path: str) -> BeautifulSoup:
+    """Fetch a Wikipedia page and return parsed BeautifulSoup."""
+    url = f"{_BASE_URL}{path}"
+    resp = client.get(url)
+    resp.raise_for_status()
+    return BeautifulSoup(resp.text, "lxml")
+
+
+def scrape_timeline(
+    centuries: list[int] | None = None,
+    delay: float = _REQUEST_DELAY,
+) -> list[dict[str, Any]]:
+    """Scrape Wikipedia Timeline of Islam pages and return event dicts.
+
+    Parameters
+    ----------
+    centuries
+        Which century pages to scrape (default: 7–15 for hadith relevance).
+    delay
+        Seconds to wait between HTTP requests (respects Wikipedia rate limits).
+    """
+    if centuries is None:
+        centuries = list(range(7, 16))  # 7th through 15th century
+
+    all_events: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    headers = {"User-Agent": _USER_AGENT}
+
+    with httpx.Client(headers=headers, timeout=30.0, follow_redirects=True) as client:
+        # 1. Scrape main overview page
+        print(f"Fetching main timeline page: {_MAIN_PAGE}")
+        soup = fetch_page(client, _MAIN_PAGE)
+        main_events = _extract_events_from_list_items(soup, f"{_BASE_URL}{_MAIN_PAGE}")
+        for evt in main_events:
+            if evt["id"] not in seen_ids:
+                seen_ids.add(evt["id"])
+                all_events.append(evt)
+        print(f"  -> {len(main_events)} events from main page")
+
+        time.sleep(delay)
+
+        # 2. Scrape century-specific pages
+        for century in centuries:
+            name = _CENTURY_NAMES.get(century, f"{century}th")
+            path = _CENTURY_TEMPLATE.format(century=name)
+            print(f"Fetching {name} century page: {path}")
+            try:
+                soup = fetch_page(client, path)
+                century_events = _extract_events_from_list_items(soup, f"{_BASE_URL}{path}")
+                new_count = 0
+                for evt in century_events:
+                    if evt["id"] not in seen_ids:
+                        seen_ids.add(evt["id"])
+                        all_events.append(evt)
+                        new_count += 1
+                print(f"  -> {len(century_events)} events ({new_count} new)")
+            except httpx.HTTPStatusError as e:
+                print(f"  -> SKIPPED (HTTP {e.response.status_code})", file=sys.stderr)
+
+            time.sleep(delay)
+
+    # Sort by year
+    all_events.sort(key=lambda e: (e["year_start_ce"], e.get("year_end_ce", 0)))
+    return all_events
+
+
+# ---------------------------------------------------------------------------
+# YAML output
+# ---------------------------------------------------------------------------
+
+
+def _merge_with_existing(
+    new_events: list[dict[str, Any]],
+    existing_path: Path,
+) -> list[dict[str, Any]]:
+    """Merge new scraped events with existing curated events.
+
+    Existing hand-curated events (non-wiki IDs) are preserved.
+    Wiki-sourced events are replaced with the fresh scrape.
+    """
+    if not existing_path.exists():
+        return new_events
+
+    with open(existing_path) as f:
+        data = yaml.safe_load(f) or {}
+
+    existing = data.get("events", [])
+    # Keep non-wiki events (hand-curated)
+    curated = [e for e in existing if not e.get("id", "").startswith("evt:wiki-")]
+    curated_ids = {e["id"] for e in curated}
+
+    # Also keep wiki events that don't conflict
+    merged = list(curated)
+    for evt in new_events:
+        if evt["id"] not in curated_ids:
+            merged.append(evt)
+
+    merged.sort(key=lambda e: (e.get("year_start_ce", 0), e.get("year_end_ce", 0)))
+    return merged
+
+
+def write_events_yaml(
+    events: list[dict[str, Any]],
+    output_path: Path,
+    *,
+    merge: bool = True,
+) -> None:
+    """Write events to YAML file, optionally merging with existing data."""
+    if merge:
+        events = _merge_with_existing(events, output_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Remove source_url from YAML output (not part of Neo4j schema)
+    yaml_events = []
+    for evt in events:
+        entry: dict[str, Any] = {
+            "id": evt["id"],
+            "name_en": evt["name_en"],
+            "year_start_ah": evt["year_start_ah"],
+            "year_end_ah": evt["year_end_ah"],
+            "year_start_ce": evt["year_start_ce"],
+            "year_end_ce": evt["year_end_ce"],
+            "type": evt["type"],
+        }
+        if evt.get("caliphate"):
+            entry["caliphate"] = evt["caliphate"]
+        if evt.get("region"):
+            entry["region"] = evt["region"]
+        if evt.get("description"):
+            entry["description"] = evt["description"]
+        if evt.get("source_url"):
+            entry["source_url"] = evt["source_url"]
+        yaml_events.append(entry)
+
+    data = {"events": yaml_events}
+
+    with open(output_path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120)
+
+    print(f"\nWrote {len(yaml_events)} events to {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def print_report(events: list[dict[str, Any]]) -> None:
+    """Print event count and category distribution."""
+    print(f"\n{'=' * 60}")
+    print("Historical Events Report")
+    print(f"{'=' * 60}")
+    print(f"Total events: {len(events)}")
+
+    # Category distribution
+    cats: dict[str, int] = {}
+    for evt in events:
+        cat = evt.get("type", "unknown")
+        cats[cat] = cats.get(cat, 0) + 1
+    print("\nCategory distribution:")
+    for cat, count in sorted(cats.items(), key=lambda x: -x[1]):
+        print(f"  {cat:<30s} {count:>4d}")
+
+    # Century distribution
+    centuries: dict[str, int] = {}
+    for evt in events:
+        ce = evt.get("year_start_ce", 0)
+        c = f"{ce // 100 + 1}th century"
+        centuries[c] = centuries.get(c, 0) + 1
+    print("\nCentury distribution:")
+    for century, count in sorted(centuries.items()):
+        print(f"  {century:<30s} {count:>4d}")
+
+    # Date range
+    if events:
+        min_ce = min(e.get("year_start_ce", 9999) for e in events)
+        max_ce = max(e.get("year_end_ce", 0) or e.get("year_start_ce", 0) for e in events)
+        print(f"\nDate range: {min_ce} CE – {max_ce} CE")
+        print(f"           {ce_to_ah(min_ce)} AH – {ce_to_ah(max_ce)} AH")
+    print(f"{'=' * 60}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape Wikipedia Timeline of Islam for historical events."
+    )
+    parser.add_argument(
+        "--centuries",
+        nargs="+",
+        type=int,
+        default=None,
+        help="Century numbers to scrape (default: 7-15)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/curated/historical_events.yaml"),
+        help="Output YAML path (default: data/curated/historical_events.yaml)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=_REQUEST_DELAY,
+        help="Delay between HTTP requests in seconds (default: 1.0)",
+    )
+    parser.add_argument(
+        "--no-merge",
+        action="store_true",
+        help="Overwrite existing file instead of merging",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scrape and report but don't write output file",
+    )
+    args = parser.parse_args()
+
+    events = scrape_timeline(centuries=args.centuries, delay=args.delay)
+    print_report(events)
+
+    if not args.dry_run:
+        write_events_yaml(events, args.output, merge=not args.no_merge)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/enrich/historical.py
+++ b/src/enrich/historical.py
@@ -1,4 +1,4 @@
-"""Historical overlay — link narrators to events via date overlap."""
+"""Historical overlay — link narrators and compilers to events via date overlap."""
 
 from __future__ import annotations
 
@@ -33,20 +33,96 @@ WHERE n.birth_year_ah IS NULL OR n.death_year_ah IS NULL
 RETURN count(n) AS cnt
 """
 
-_MERGE_ACTIVE_DURING = """\
+_FETCH_COMPILERS = """\
+MATCH (c:Collection)
+WHERE c.compilation_year_ah IS NOT NULL
+RETURN c.id AS id, c.compilation_year_ah AS compilation_year_ah,
+       c.compiler_name AS compiler_name
+"""
+
+_MERGE_ACTIVE_DURING_NARRATOR = """\
 UNWIND $batch AS row
 MATCH (n:Narrator {id: row.narrator_id})
 MATCH (e:HistoricalEvent {id: row.event_id})
 MERGE (n)-[:ACTIVE_DURING]->(e)
 """
 
+_MERGE_ACTIVE_DURING_COMPILER = """\
+UNWIND $batch AS row
+MATCH (c:Collection {id: row.compiler_id})
+MATCH (e:HistoricalEvent {id: row.event_id})
+MERGE (c)-[:ACTIVE_DURING]->(e)
+"""
+
+
+def _compute_overlap_batch(
+    entities: list[dict[str, Any]],
+    sorted_events: list[dict[str, Any]],
+    event_starts: list[int],
+    entity_id_key: str,
+    batch_id_key: str,
+) -> tuple[list[dict[str, str]], set[str], set[str]]:
+    """Compute ACTIVE_DURING overlap batch for a set of entities.
+
+    Uses binary search on sorted events to efficiently find overlapping
+    event periods for each entity's lifetime.
+    """
+    batch: list[dict[str, str]] = []
+    linked_entities: set[str] = set()
+    linked_events: set[str] = set()
+
+    for ent in entities:
+        n_birth = ent["birth_year_ah"]
+        n_death = ent["death_year_ah"]
+        # Only consider events whose start year <= entity's death year
+        upper = bisect.bisect_right(event_starts, n_death)
+        for idx in range(upper):
+            evt = sorted_events[idx]
+            e_end = evt["year_end_ah"]
+            # Overlap: entity alive during any part of the event
+            if n_death >= evt["year_start_ah"] and n_birth <= e_end:
+                batch.append({batch_id_key: ent[entity_id_key], "event_id": evt["id"]})
+                linked_entities.add(ent[entity_id_key])
+                linked_events.add(evt["id"])
+
+    return batch, linked_entities, linked_events
+
+
+def _log_distribution(
+    batch: list[dict[str, str]],
+    entity_key: str,
+    entity_label: str,
+) -> None:
+    """Log edge distribution statistics for a batch."""
+    if not batch:
+        return
+    events_per_entity: dict[str, int] = {}
+    entities_per_event: dict[str, int] = {}
+    for row in batch:
+        events_per_entity[row[entity_key]] = events_per_entity.get(row[entity_key], 0) + 1
+        entities_per_event[row["event_id"]] = entities_per_event.get(row["event_id"], 0) + 1
+
+    epe_values = list(events_per_entity.values())
+    npe_values = list(entities_per_event.values())
+    log.info(
+        f"historical_overlay_{entity_label}_distribution",
+        events_per_entity_avg=round(sum(epe_values) / len(epe_values), 2),
+        events_per_entity_max=max(epe_values),
+        entities_per_event_avg=round(sum(npe_values) / len(npe_values), 2),
+        entities_per_event_max=max(npe_values),
+    )
+
 
 def run_historical_overlay(client: Neo4jClient) -> HistoricalResult:
-    """Create ACTIVE_DURING edges between narrators and historical events.
+    """Create ACTIVE_DURING edges between narrators/compilers and historical events.
 
     For each narrator-event pair, checks whether the narrator's active period
     (birth_year_ah to death_year_ah) overlaps with the event period.
     Narrators with lifespan > 120 AH are skipped as a data-quality filter.
+
+    Compilers (collections) are matched using compilation_year_ah as a proxy
+    for the compiler's active period. A ±30 year window around the compilation
+    year is used to approximate the compiler's scholarly active years.
     """
     events = client.execute_read(_FETCH_EVENTS)
     narrators = client.execute_read(_FETCH_NARRATORS)
@@ -77,62 +153,87 @@ def run_historical_overlay(client: Neo4jClient) -> HistoricalResult:
     )
 
     # Build overlap batch — sort events by start year and use binary search
-    # to skip events that start after the narrator's death, reducing O(N*M)
-    # to O(N * log(M) + relevant matches).
     sorted_events = sorted(events, key=lambda e: e["year_start_ah"])
     event_starts = [e["year_start_ah"] for e in sorted_events]
 
-    batch: list[dict[str, str]] = []
-    linked_narrators: set[str] = set()
-    linked_events: set[str] = set()
+    # --- Narrator ACTIVE_DURING edges ---
+    narrator_batch, linked_narrators, linked_events_nar = _compute_overlap_batch(
+        valid_narrators,
+        sorted_events,
+        event_starts,
+        entity_id_key="id",
+        batch_id_key="narrator_id",
+    )
 
-    for nar in valid_narrators:
-        n_birth = nar["birth_year_ah"]
-        n_death = nar["death_year_ah"]
-        # Only consider events whose start year <= narrator's death year
-        upper = bisect.bisect_right(event_starts, n_death)
-        for idx in range(upper):
-            evt = sorted_events[idx]
-            e_end = evt["year_end_ah"]
-            # Overlap: narrator alive during any part of the event
-            if n_death >= evt["year_start_ah"] and n_birth <= e_end:
-                batch.append({"narrator_id": nar["id"], "event_id": evt["id"]})
-                linked_narrators.add(nar["id"])
-                linked_events.add(evt["id"])
+    narrator_edges = (
+        client.execute_write_batch(_MERGE_ACTIVE_DURING_NARRATOR, narrator_batch)
+        if narrator_batch
+        else 0
+    )
+    _log_distribution(narrator_batch, "narrator_id", "narrator")
 
-    edges_created = client.execute_write_batch(_MERGE_ACTIVE_DURING, batch) if batch else 0
+    log.info(
+        "historical_overlay_narrators_complete",
+        edges_created=narrator_edges,
+        narrators_linked=len(linked_narrators),
+        events_linked=len(linked_events_nar),
+    )
 
-    # Log edge distribution
-    if linked_narrators:
-        events_per_narrator: dict[str, int] = {}
-        narrators_per_event: dict[str, int] = {}
-        for row in batch:
-            events_per_narrator[row["narrator_id"]] = (
-                events_per_narrator.get(row["narrator_id"], 0) + 1
-            )
-            narrators_per_event[row["event_id"]] = narrators_per_event.get(row["event_id"], 0) + 1
-
-        epn_values = list(events_per_narrator.values())
-        npe_values = list(narrators_per_event.values())
-        log.info(
-            "historical_overlay_distribution",
-            events_per_narrator_avg=round(sum(epn_values) / len(epn_values), 2),
-            events_per_narrator_max=max(epn_values),
-            narrators_per_event_avg=round(sum(npe_values) / len(npe_values), 2),
-            narrators_per_event_max=max(npe_values),
+    # --- Compiler ACTIVE_DURING edges ---
+    # Use compilation_year_ah ± 30 as proxy for compiler active period
+    _COMPILER_WINDOW_AH = 30
+    compilers_raw = client.execute_read(_FETCH_COMPILERS)
+    compiler_entities: list[dict[str, Any]] = []
+    for comp in compilers_raw:
+        year = comp["compilation_year_ah"]
+        compiler_entities.append(
+            {
+                "id": comp["id"],
+                "birth_year_ah": max(1, year - _COMPILER_WINDOW_AH),
+                "death_year_ah": year + _COMPILER_WINDOW_AH,
+            }
         )
+
+    compiler_batch, linked_compilers, linked_events_comp = _compute_overlap_batch(
+        compiler_entities,
+        sorted_events,
+        event_starts,
+        entity_id_key="id",
+        batch_id_key="compiler_id",
+    )
+
+    compiler_edges = (
+        client.execute_write_batch(_MERGE_ACTIVE_DURING_COMPILER, compiler_batch)
+        if compiler_batch
+        else 0
+    )
+    _log_distribution(compiler_batch, "compiler_id", "compiler")
+
+    log.info(
+        "historical_overlay_compilers_complete",
+        edges_created=compiler_edges,
+        compilers_linked=len(linked_compilers),
+        events_linked=len(linked_events_comp),
+    )
+
+    total_edges = narrator_edges + compiler_edges
+    all_linked_events = linked_events_nar | linked_events_comp
 
     log.info(
         "historical_overlay_complete",
-        edges_created=edges_created,
+        total_edges_created=total_edges,
+        narrator_edges=narrator_edges,
+        compiler_edges=compiler_edges,
         narrators_linked=len(linked_narrators),
-        events_linked=len(linked_events),
+        compilers_linked=len(linked_compilers),
+        events_linked=len(all_linked_events),
     )
 
     return HistoricalResult(
-        edges_created=edges_created,
+        edges_created=total_edges,
         narrators_linked=len(linked_narrators),
-        events_linked=len(linked_events),
+        compilers_linked=len(linked_compilers),
+        events_linked=len(all_linked_events),
         narrators_skipped_no_dates=narrators_skipped_no_dates,
         narrators_skipped_max_lifetime=narrators_skipped_max_lifetime,
     )

--- a/src/graph/load_nodes.py
+++ b/src/graph/load_nodes.py
@@ -455,7 +455,8 @@ SET n.name_en       = row.name_en,
     n.event_type    = row.event_type,
     n.caliphate     = row.caliphate,
     n.region        = row.region,
-    n.description   = row.description
+    n.description   = row.description,
+    n.source_url    = row.source_url
 """
 
 
@@ -506,6 +507,7 @@ def _load_historical_events(
                 "caliphate": evt.get("caliphate"),
                 "region": evt.get("region"),
                 "description": evt.get("description"),
+                "source_url": evt.get("source_url"),
             }
         )
 

--- a/src/models/enrich.py
+++ b/src/models/enrich.py
@@ -25,6 +25,7 @@ class HistoricalResult(BaseModel):
 
     edges_created: int
     narrators_linked: int
+    compilers_linked: int = 0
     events_linked: int
     narrators_skipped_no_dates: int
     narrators_skipped_max_lifetime: int

--- a/src/models/historical.py
+++ b/src/models/historical.py
@@ -44,6 +44,8 @@ class HistoricalEvent(BaseModel):
     """Geographic region of the event."""
     description: str | None = None
     """Narrative description of the event."""
+    source_url: str | None = None
+    """URL of the source from which the event was scraped."""
 
 
 class Location(BaseModel):

--- a/tests/test_enrich/test_historical.py
+++ b/tests/test_enrich/test_historical.py
@@ -27,6 +27,10 @@ def _make_event(eid: str, start: int, end: int) -> dict[str, str | int]:
     return {"id": eid, "year_start_ah": start, "year_end_ah": end}
 
 
+def _make_compiler(cid: str, year: int) -> dict[str, str | int | None]:
+    return {"id": cid, "compilation_year_ah": year, "compiler_name": f"compiler-{cid}"}
+
+
 class TestDateOverlap:
     """Test the overlap logic: narrator alive during any part of event."""
 
@@ -36,6 +40,7 @@ class TestDateOverlap:
             [_make_event("e1", 50, 60)],  # events
             [_make_narrator("n1", 10, 80)],  # narrators
             [{"cnt": 0}],  # no-dates count
+            [],  # compilers
         ]
         mock_client.execute_write_batch.return_value = 1
 
@@ -45,7 +50,7 @@ class TestDateOverlap:
         assert result.narrators_linked == 1
         assert result.events_linked == 1
 
-        batch_arg = mock_client.execute_write_batch.call_args.args[1]
+        batch_arg = mock_client.execute_write_batch.call_args_list[0].args[1]
         assert {"narrator_id": "n1", "event_id": "e1"} in batch_arg
 
     def test_narrator_born_after_event(self, mock_client: MagicMock) -> None:
@@ -54,6 +59,7 @@ class TestDateOverlap:
             [_make_event("e1", 50, 60)],
             [_make_narrator("n1", 100, 170)],
             [{"cnt": 0}],
+            [],  # compilers
         ]
 
         result = run_historical_overlay(mock_client)
@@ -69,6 +75,7 @@ class TestDateOverlap:
             [_make_event("e1", 50, 60)],
             [_make_narrator("n1", 10, 40)],
             [{"cnt": 0}],
+            [],  # compilers
         ]
 
         result = run_historical_overlay(mock_client)
@@ -85,6 +92,7 @@ class TestMaxLifetimeFilter:
             [_make_event("e1", 50, 60)],
             [_make_narrator("n1", 10, 200)],  # 190-year lifespan
             [{"cnt": 0}],
+            [],  # compilers
         ]
 
         result = run_historical_overlay(mock_client)
@@ -99,6 +107,7 @@ class TestMaxLifetimeFilter:
             [_make_event("e1", 50, 60)],
             [_make_narrator("n1", 0, 120)],  # exactly 120
             [{"cnt": 0}],
+            [],  # compilers
         ]
         mock_client.execute_write_batch.return_value = 1
 
@@ -112,11 +121,60 @@ class TestMaxLifetimeFilter:
             [_make_event("e1", 50, 60)],
             [_make_narrator("n1", 0, 121)],  # 121 > 120
             [{"cnt": 0}],
+            [],  # compilers
         ]
 
         result = run_historical_overlay(mock_client)
 
         assert result.narrators_skipped_max_lifetime == 1
+
+
+class TestCompilerOverlay:
+    """Test ACTIVE_DURING edges for compilers (collections)."""
+
+    def test_compiler_linked_to_event(self, mock_client: MagicMock) -> None:
+        """Compiler with compilation_year_ah=232 should link to event 218-234."""
+        mock_client.execute_read.side_effect = [
+            [_make_event("e1", 218, 234)],  # mihna event
+            [],  # no narrators
+            [{"cnt": 0}],
+            [_make_compiler("col:bukhari", 232)],  # compilation year
+        ]
+        mock_client.execute_write_batch.return_value = 1
+
+        result = run_historical_overlay(mock_client)
+
+        assert result.compilers_linked == 1
+        assert result.edges_created == 1
+
+    def test_compiler_no_overlap(self, mock_client: MagicMock) -> None:
+        """Compiler compilation_year_ah=232, event 50-60 => no overlap with ±30 window."""
+        mock_client.execute_read.side_effect = [
+            [_make_event("e1", 50, 60)],
+            [],  # no narrators
+            [{"cnt": 0}],
+            [_make_compiler("col:bukhari", 232)],
+        ]
+
+        result = run_historical_overlay(mock_client)
+
+        assert result.compilers_linked == 0
+
+    def test_narrator_and_compiler_both_linked(self, mock_client: MagicMock) -> None:
+        """Both narrator and compiler can create ACTIVE_DURING edges."""
+        mock_client.execute_read.side_effect = [
+            [_make_event("e1", 50, 60)],
+            [_make_narrator("n1", 10, 80)],
+            [{"cnt": 0}],
+            [_make_compiler("col:test", 55)],  # compilation year within event
+        ]
+        mock_client.execute_write_batch.return_value = 1
+
+        result = run_historical_overlay(mock_client)
+
+        assert result.narrators_linked == 1
+        assert result.compilers_linked == 1
+        assert result.edges_created == 2  # 1 narrator + 1 compiler
 
 
 class TestHistoricalResult:
@@ -130,6 +188,7 @@ class TestHistoricalResult:
                 _make_narrator("n2", 60, 100),
             ],
             [{"cnt": 3}],  # 3 narrators without dates
+            [],  # no compilers
         ]
         mock_client.execute_write_batch.return_value = 3
 
@@ -138,6 +197,7 @@ class TestHistoricalResult:
         assert isinstance(result, HistoricalResult)
         assert result.edges_created == 3
         assert result.narrators_linked == 2
+        assert result.compilers_linked == 0
         assert result.events_linked == 2
         assert result.narrators_skipped_no_dates == 3
         assert result.narrators_skipped_max_lifetime == 0
@@ -151,11 +211,12 @@ class TestEdgeBatchCall:
             [_make_event("e1", 50, 60)],
             [_make_narrator("n1", 10, 80)],
             [{"cnt": 0}],
+            [],  # compilers
         ]
         mock_client.execute_write_batch.return_value = 1
 
         run_historical_overlay(mock_client)
 
-        query_arg = mock_client.execute_write_batch.call_args.args[0]
+        query_arg = mock_client.execute_write_batch.call_args_list[0].args[0]
         assert "MERGE" in query_arg
         assert "ACTIVE_DURING" in query_arg


### PR DESCRIPTION
## Summary

- **#579**: Add `scripts/scrape_islamic_timeline.py` — scrapes Wikipedia Timeline of Islam (main page + 7th–15th century sub-pages), extracts events with CE/AH dates, keyword-based categorization, and outputs to `data/curated/historical_events.yaml` with merge support for existing curated events
- **#580**: Extend `HistoricalEvent` model and Neo4j loader with `source_url` field; loader already supports the scraped YAML output via existing `_load_historical_events`
- **#581**: Extend `src/enrich/historical.py` to create `ACTIVE_DURING` edges for both `Narrator` and `Collection` (compiler) nodes; compilers use `compilation_year_ah ± 30` as active window proxy; add `compilers_linked` to `HistoricalResult` model

## Key Design Decisions

- Uses `httpx` (already a project dependency) instead of `requests` for HTTP
- CE-to-AH conversion uses standard astronomical approximation (±1 year accuracy)
- Compiler active window of ±30 AH years around compilation date is a reasonable proxy for scholarly activity period
- Scraper is idempotent: deterministic event IDs via SHA-256 hash, merge-on-rerun with existing curated events
- 1-second delay between Wikipedia requests with proper User-Agent header

## Test Plan

- [x] All 24 existing + new enrichment tests pass (including 3 new compiler overlay tests)
- [x] Ruff lint/format clean
- [x] mypy strict mode passes
- [ ] Run scraper manually: `uv run python scripts/scrape_islamic_timeline.py --dry-run`
- [ ] Verify YAML output merges correctly with existing curated events

Closes #579, Closes #580, Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)