### PR TITLE
feat(scripts): add manifest generator for incremental pipeline

### DIFF
--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Generate a manifest of Parquet files for incremental pipeline diffing.
+
+Walks data/staging/ and data/curated/, computes MD5 hash, row count, and file
+size for each .parquet file, and writes the result to data/.manifest.json.
+
+Usage:
+    python scripts/generate_manifest.py [--data-dir DATA_DIR] [--output OUTPUT]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+
+def md5_file(path: Path, chunk_size: int = 8192) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        while chunk := f.read(chunk_size):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def generate_manifest(data_dir: Path) -> dict[str, dict]:
+    manifest: dict[str, dict] = {}
+    for subdir in ("staging", "curated"):
+        d = data_dir / subdir
+        if not d.exists():
+            continue
+        for p in sorted(d.glob("*.parquet")):
+            key = f"{subdir}/{p.name}"
+            rows = pq.read_metadata(p).num_rows
+            manifest[key] = {
+                "md5": md5_file(p),
+                "rows": rows,
+                "size_bytes": p.stat().st_size,
+            }
+    return manifest
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "data",
+        help="Root data directory containing staging/ and curated/",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: <data-dir>/.manifest.json)",
+    )
+    args = parser.parse_args()
+
+    output = args.output or args.data_dir / ".manifest.json"
+    manifest = generate_manifest(args.data_dir)
+
+    if not manifest:
+        print("No parquet files found — nothing to write.", file=sys.stderr)
+        sys.exit(1)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {len(manifest)} entries to {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Added `scripts/generate_manifest.py` — walks `data/staging/` and `data/curated/`, computes MD5 hash, row count, and file size for each Parquet file, writes to `data/.manifest.json`. Reusable for #598 (incremental pipeline).
- Performed one-off VPS data sync and Neo4j load:
  - Synced 16 Parquet files (~977MB) to `deploy@isnad-graph.noorinalabs.com:/opt/isnad-graph/data/`
  - Loaded into production Neo4j: **96,377 Hadiths**, **33,978 Chains**, **33,478 Gradings**, **75 Collections**, **12 Historical Events** (163,920 total nodes, 33,478 edges)
  - Generated `data/.manifest.json` and `data/last_loaded_manifest.json` on VPS as baseline for incremental diffing

## Notes

- Narrator nodes not loaded because `narrators_canonical.parquet` (Phase 2 entity resolution output) does not exist yet. TRANSMITTED_TO, NARRATED, and STUDIED_UNDER edges consequently have zero entries.
- Load required 6GB container memory (default 2GB caused OOM with 512MB sanadset Parquet). Used one-off compose override — does not affect production config.
- API endpoints behind auth; verified data via `cypher-shell` inside Neo4j container.

## Verification plan

- [x] `scripts/generate_manifest.py` produces valid JSON with correct MD5/rows/size
- [x] Pre-commit hooks pass (ruff, mypy, pycheck, gitleaks)
- [x] Neo4j node counts verified via `cypher-shell`
- [x] Validation queries passed (chain integrity, collection coverage, orphan narrators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)