### PR TITLE
fix(frontend): dark mode default, theme toggle, and auth-gated routing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,17 @@
       rel="stylesheet"
     />
     <title>Isnad Graph — Hadith Analysis Platform</title>
+    <script>
+      // Set data-theme before first paint to prevent flash of wrong theme
+      (function() {
+        var stored = localStorage.getItem('isnad-graph-theme');
+        var theme = stored === 'light' || stored === 'dark' ? stored
+          : stored === 'system' || !stored
+            ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            : 'light';
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './hooks/useAuth'
 import Layout from './components/Layout'
 import AdminLayout from './components/AdminLayout'
+import ProtectedRoute from './components/ProtectedRoute'
+import AdminRoute from './components/AdminRoute'
+import LoginPage from './pages/LoginPage'
+import AuthCallbackPage from './pages/AuthCallbackPage'
 import NarratorsPage from './pages/NarratorsPage'
 import NarratorDetailPage from './pages/NarratorDetailPage'
 import HadithsPage from './pages/HadithsPage'
@@ -36,28 +40,39 @@ export default function App() {
       <AuthProvider>
         <BrowserRouter>
           <Routes>
-            <Route element={<Layout />}>
-              <Route index element={<Navigate to="/narrators" replace />} />
-              <Route path="narrators" element={<NarratorsPage />} />
-              <Route path="narrators/:id" element={<NarratorDetailPage />} />
-              <Route path="hadiths" element={<HadithsPage />} />
-              <Route path="hadiths/:id" element={<HadithDetailPage />} />
-              <Route path="collections" element={<CollectionsPage />} />
-              <Route path="collections/:id" element={<CollectionDetailPage />} />
-              <Route path="search" element={<SearchPage />} />
-              <Route path="timeline" element={<TimelinePage />} />
-              <Route path="compare" element={<ComparativePage />} />
-              <Route path="graph" element={<GraphExplorerPage />} />
-            </Route>
-            <Route path="admin" element={<AdminLayout />}>
-              <Route index element={<Navigate to="/admin/users" replace />} />
-              <Route path="users" element={<UserManagementPage />} />
-              <Route path="health" element={<SystemHealthPage />} />
-              <Route path="stats" element={<ContentStatsPage />} />
-              <Route path="analytics" element={<UsageAnalyticsPage />} />
-              <Route path="moderation" element={<ModerationPage />} />
-              <Route path="reports" element={<ReportsPage />} />
-              <Route path="config" element={<ConfigPage />} />
+            {/* Public routes */}
+            <Route path="login" element={<LoginPage />} />
+            <Route path="auth/callback/:provider" element={<AuthCallbackPage />} />
+
+            {/* Authenticated routes */}
+            <Route element={<ProtectedRoute />}>
+              <Route element={<Layout />}>
+                <Route index element={<Navigate to="/narrators" replace />} />
+                <Route path="narrators" element={<NarratorsPage />} />
+                <Route path="narrators/:id" element={<NarratorDetailPage />} />
+                <Route path="hadiths" element={<HadithsPage />} />
+                <Route path="hadiths/:id" element={<HadithDetailPage />} />
+                <Route path="collections" element={<CollectionsPage />} />
+                <Route path="collections/:id" element={<CollectionDetailPage />} />
+                <Route path="search" element={<SearchPage />} />
+                <Route path="timeline" element={<TimelinePage />} />
+                <Route path="compare" element={<ComparativePage />} />
+                <Route path="graph" element={<GraphExplorerPage />} />
+              </Route>
+
+              {/* Admin routes — require isAdmin */}
+              <Route element={<AdminRoute />}>
+                <Route path="admin" element={<AdminLayout />}>
+                  <Route index element={<Navigate to="/admin/users" replace />} />
+                  <Route path="users" element={<UserManagementPage />} />
+                  <Route path="health" element={<SystemHealthPage />} />
+                  <Route path="stats" element={<ContentStatsPage />} />
+                  <Route path="analytics" element={<UsageAnalyticsPage />} />
+                  <Route path="moderation" element={<ModerationPage />} />
+                  <Route path="reports" element={<ReportsPage />} />
+                  <Route path="config" element={<ConfigPage />} />
+                </Route>
+              </Route>
             </Route>
           </Routes>
         </BrowserRouter>

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function AdminRoute() {
+  const { isAdmin } = useAuth()
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+        <h1 className="text-4xl font-bold">403</h1>
+        <p className="text-muted-foreground">You do not have permission to access this page.</p>
+      </div>
+    )
+  }
+
+  return <Outlet />
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function ProtectedRoute() {
+  const { user, loading } = useAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  }
+
+  return <Outlet />
+}

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+export default function AuthCallbackPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  useEffect(() => {
+    const token = searchParams.get('token')
+    const returnUrl = searchParams.get('return_url') || '/'
+
+    if (token) {
+      localStorage.setItem('access_token', token)
+    }
+
+    navigate(returnUrl, { replace: true })
+  }, [searchParams, navigate])
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,61 @@
+import { useLocation } from 'react-router-dom'
+
+const API_BASE = '/api/v1'
+
+export default function LoginPage() {
+  const location = useLocation()
+  const from = (location.state as { from?: string })?.from || '/'
+
+  function handleOAuth(provider: 'google' | 'github') {
+    const params = new URLSearchParams({ return_url: from })
+    window.location.href = `${API_BASE}/auth/${provider}/authorize?${params}`
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-border bg-card p-8 shadow-lg">
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold font-heading">Isnad Graph</h1>
+          <p className="text-sm text-muted-foreground">Sign in to continue</p>
+        </div>
+
+        <div className="space-y-3">
+          <button
+            onClick={() => handleOAuth('google')}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Continue with Google
+          </button>
+
+          <button
+            onClick={() => handleOAuth('github')}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+            Continue with GitHub
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -314,6 +314,54 @@
 }
 
 [data-theme="light"] {
+  --color-background: oklch(0.96 0.01 85);
+  --color-foreground: oklch(0.25 0.02 260);
+  --color-card: oklch(0.99 0.005 85);
+  --color-card-foreground: oklch(0.25 0.02 260);
+  --color-popover: oklch(0.99 0.005 85);
+  --color-popover-foreground: oklch(0.25 0.02 260);
+  --color-primary: oklch(0.55 0.14 45);
+  --color-primary-hover: oklch(0.60 0.14 45);
+  --color-primary-foreground: #ffffff;
+  --color-secondary: oklch(0.85 0.01 85);
+  --color-secondary-foreground: oklch(0.25 0.02 260);
+  --color-muted: oklch(0.93 0.005 85);
+  --color-muted-foreground: oklch(0.45 0.01 260);
+  --color-accent: oklch(0.90 0.03 45);
+  --color-accent-foreground: oklch(0.40 0.12 45);
+  --color-destructive: oklch(0.60 0.18 30);
+  --color-destructive-foreground: #ffffff;
+  --color-success: oklch(0.55 0.10 175);
+  --color-success-foreground: #ffffff;
+  --color-warning: oklch(0.65 0.14 75);
+  --color-warning-foreground: oklch(0.25 0.02 260);
+  --color-info: oklch(0.45 0.12 260);
+  --color-info-foreground: #ffffff;
+  --color-border: oklch(0.85 0.01 85);
+  --color-input: oklch(0.85 0.01 85);
+  --color-ring: oklch(0.55 0.14 45);
+  --color-sahih: oklch(0.55 0.10 175);
+  --color-sahih-bg: oklch(0.93 0.03 175);
+  --color-hasan: oklch(0.65 0.14 75);
+  --color-hasan-bg: oklch(0.95 0.04 75);
+  --color-daif: oklch(0.60 0.18 30);
+  --color-daif-bg: oklch(0.95 0.03 30);
+  --color-mawdu: oklch(0.50 0.15 15);
+  --color-mawdu-bg: oklch(0.94 0.03 15);
+  --color-sunni: oklch(0.55 0.10 175);
+  --color-sunni-bg: oklch(0.93 0.03 175);
+  --color-shia: oklch(0.45 0.12 260);
+  --color-shia-bg: oklch(0.93 0.03 260);
+  --color-tier-thiqah: oklch(0.55 0.10 175);
+  --color-tier-saduq: oklch(0.60 0.10 45);
+  --color-tier-daif-narrator: oklch(0.65 0.14 75);
+  --color-tier-matruk: oklch(0.60 0.18 30);
+  --color-tier-kadhdhab: oklch(0.50 0.15 15);
+  --shadow-xs: 0 1px 2px oklch(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px oklch(0 0 0 / 0.1), 0 1px 2px oklch(0 0 0 / 0.06);
+  --shadow-md: 0 4px 6px oklch(0 0 0 / 0.1), 0 2px 4px oklch(0 0 0 / 0.06);
+  --shadow-lg: 0 10px 15px oklch(0 0 0 / 0.1), 0 4px 6px oklch(0 0 0 / 0.05);
+  --shadow-xl: 0 20px 25px oklch(0 0 0 / 0.1), 0 8px 10px oklch(0 0 0 / 0.04);
   color-scheme: light;
 }
 


### PR DESCRIPTION
## Summary

- **#599 Dark mode fix**: Add inline theme init script in `index.html` to set `data-theme` before first paint, preventing flash of wrong theme. Populate `[data-theme="light"]` CSS block with all light-mode color tokens so the JS toggle can override OS dark preference.
- **#601 Auth-gated routing**: Create `ProtectedRoute` (redirects to `/login` if unauthenticated, preserves return URL) and `AdminRoute` (shows 403 for non-admin). Add `LoginPage` with Google/GitHub OAuth buttons and `AuthCallbackPage` for token handling. Wrap all main routes with `ProtectedRoute` and admin routes with `AdminRoute`.

Closes #599, Closes #601

## Test plan

- [ ] Verify site defaults to light mode (Qalam parchment) with no localStorage preference
- [ ] Verify `prefers-color-scheme: dark` OS setting triggers dark mode
- [ ] Verify theme toggle switches between light and dark visually
- [ ] Verify theme persists across page reloads via localStorage
- [ ] Verify toggle icon reflects current state (sun/moon)
- [ ] Verify unauthenticated users are redirected to `/login`
- [ ] Verify admin routes show 403 for non-admin users
- [ ] Verify return URL is preserved after login
- [ ] Verify loading spinner shows while auth initializes
- [ ] `npm run build` passes clean
