### PR TITLE
fix(frontend): LoginPage calls correct OAuth endpoint

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 const API_BASE = '/api/v1'
@@ -5,10 +6,33 @@ const API_BASE = '/api/v1'
 export default function LoginPage() {
   const location = useLocation()
   const from = (location.state as { from?: string })?.from || '/'
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<string | null>(null)
 
-  function handleOAuth(provider: 'google' | 'github') {
-    const params = new URLSearchParams({ return_url: from })
-    window.location.href = `${API_BASE}/auth/${provider}/authorize?${params}`
+  async function handleOAuth(provider: 'google' | 'github') {
+    setError(null)
+    setLoading(provider)
+
+    try {
+      const res = await fetch(`${API_BASE}/auth/login/${provider}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }))
+        throw new Error(data.detail || `Failed to initiate ${provider} login`)
+      }
+
+      const data = await res.json()
+      // Store return URL for after OAuth callback
+      sessionStorage.setItem('oauth_return_url', from)
+      // Redirect to provider's OAuth consent screen
+      window.location.href = data.authorization_url
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed')
+      setLoading(null)
+    }
   }
 
   return (
@@ -19,10 +43,17 @@ export default function LoginPage() {
           <p className="text-sm text-muted-foreground">Sign in to continue</p>
         </div>
 
+        {error && (
+          <div className="rounded-lg border border-destructive bg-destructive/10 px-4 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
         <div className="space-y-3">
           <button
             onClick={() => handleOAuth('google')}
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors"
+            disabled={loading !== null}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-50"
           >
             <svg width="18" height="18" viewBox="0 0 24 24">
               <path
@@ -42,17 +73,18 @@ export default function LoginPage() {
                 fill="#EA4335"
               />
             </svg>
-            Continue with Google
+            {loading === 'google' ? 'Redirecting...' : 'Continue with Google'}
           </button>
 
           <button
             onClick={() => handleOAuth('github')}
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors"
+            disabled={loading !== null}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-50"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
             </svg>
-            Continue with GitHub
+            {loading === 'github' ? 'Redirecting...' : 'Continue with GitHub'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
LoginPage was navigating to /auth/{provider}/authorize (non-existent, 404). Now correctly calls POST /auth/login/{provider} via fetch, gets authorization_url from response, and redirects to OAuth consent screen.

## Changes
- fetch POST to /auth/login/{provider} instead of direct navigation
- Error display for failed API calls
- Loading state on buttons during redirect

## Test plan
- [ ] Click "Continue with Google" redirects to Google OAuth
- [ ] Click "Continue with GitHub" redirects to GitHub OAuth
- [ ] Error displays if API is unreachable

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
