### PR TITLE
fix(deploy): bust Docker build cache for frontend on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,8 @@ jobs:
             echo "==> Pulling GHCR image for API (falls back to local build)..."
             docker compose -f docker-compose.prod.yml pull api 2>/dev/null || echo "GHCR pull failed — will build locally"
 
+            export CACHEBUST=$(date +%s)
+
             docker compose -f docker-compose.prod.yml up -d --build --remove-orphans
 
             echo "==> Waiting for services to stabilize..."

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -172,6 +172,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        CACHEBUST: ${CACHEBUST:-1}
     expose:
       - "80"
     read_only: true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,8 @@ FROM node:24-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
+# Cache-bust: ARG changes invalidate all subsequent layers
+ARG CACHEBUST=1
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Summary
Frontend Dockerfile COPY layer was cached even when source files changed, causing stale JS bundles in production. Adds a CACHEBUST build arg set to current timestamp on every deploy, invalidating the COPY and npm run build layers.

## Test plan
- [ ] Deploy triggers frontend rebuild with fresh source
- [ ] LoginPage fix (#622) appears on live site after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
