### PR TITLE
fix(deploy): pass OAuth credentials to API container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,15 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
           REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          AUTH_GOOGLE_CLIENT_ID: ${{ secrets.AUTH_GOOGLE_CLIENT_ID }}
+          AUTH_GOOGLE_CLIENT_SECRET: ${{ secrets.AUTH_GOOGLE_CLIENT_SECRET }}
+          AUTH_GITHUB_CLIENT_ID: ${{ secrets.AUTH_GITHUB_CLIENT_ID }}
+          AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.AUTH_GITHUB_CLIENT_SECRET }}
         with:
           host: ${{ vars.VPS_HOST }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
-          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD
+          envs: NEO4J_PASSWORD,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,REDIS_PASSWORD,AUTH_GOOGLE_CLIENT_ID,AUTH_GOOGLE_CLIENT_SECRET,AUTH_GITHUB_CLIENT_ID,AUTH_GITHUB_CLIENT_SECRET
           script: |
             set -euo pipefail
             cd /opt/isnad-graph
@@ -43,6 +47,10 @@ jobs:
             export POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
             export POSTGRES_DB="$POSTGRES_DB"
             export REDIS_PASSWORD="$REDIS_PASSWORD"
+            export AUTH_GOOGLE_CLIENT_ID="$AUTH_GOOGLE_CLIENT_ID"
+            export AUTH_GOOGLE_CLIENT_SECRET="$AUTH_GOOGLE_CLIENT_SECRET"
+            export AUTH_GITHUB_CLIENT_ID="$AUTH_GITHUB_CLIENT_ID"
+            export AUTH_GITHUB_CLIENT_SECRET="$AUTH_GITHUB_CLIENT_SECRET"
 
             echo "==> Pulling GHCR image for API (falls back to local build)..."
             docker compose -f docker-compose.prod.yml pull api 2>/dev/null || echo "GHCR pull failed — will build locally"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -133,6 +133,11 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}
       - PG_DSN=postgresql://${POSTGRES_USER:?POSTGRES_USER must be set}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB must be set}
       - REDIS_URL=redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set}@redis:6379/0
+      - AUTH_GOOGLE_CLIENT_ID=${AUTH_GOOGLE_CLIENT_ID:-}
+      - AUTH_GOOGLE_CLIENT_SECRET=${AUTH_GOOGLE_CLIENT_SECRET:-}
+      - AUTH_GITHUB_CLIENT_ID=${AUTH_GITHUB_CLIENT_ID:-}
+      - AUTH_GITHUB_CLIENT_SECRET=${AUTH_GITHUB_CLIENT_SECRET:-}
+      - AUTH_OAUTH_REDIRECT_BASE_URL=https://isnad-graph.noorinalabs.com
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Summary
Wire Google and GitHub OAuth secrets through the deploy workflow to the API container so OAuth login works in production.

## Changes
- deploy.yml: Add AUTH_GOOGLE_CLIENT_ID/SECRET and AUTH_GITHUB_CLIENT_ID/SECRET to env/envs
- docker-compose.prod.yml: Pass OAuth env vars to API container, set AUTH_OAUTH_REDIRECT_BASE_URL

## Test plan
- [ ] Google OAuth redirects to consent screen with valid client_id
- [ ] GitHub OAuth redirects to authorization page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
