### PR TITLE
hotfix(deploy): write .env file for docker-compose secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,23 +41,26 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
 
-            echo "==> Building and starting services..."
-            export NEO4J_PASSWORD="$NEO4J_PASSWORD"
-            export POSTGRES_USER="$POSTGRES_USER"
-            export POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
-            export POSTGRES_DB="$POSTGRES_DB"
-            export REDIS_PASSWORD="$REDIS_PASSWORD"
-            export AUTH_GOOGLE_CLIENT_ID="$AUTH_GOOGLE_CLIENT_ID"
-            export AUTH_GOOGLE_CLIENT_SECRET="$AUTH_GOOGLE_CLIENT_SECRET"
-            export AUTH_GITHUB_CLIENT_ID="$AUTH_GITHUB_CLIENT_ID"
-            export AUTH_GITHUB_CLIENT_SECRET="$AUTH_GITHUB_CLIENT_SECRET"
+            echo "==> Writing .env for docker-compose..."
+            cat > .env <<DOTENV
+NEO4J_PASSWORD=$NEO4J_PASSWORD
+POSTGRES_USER=$POSTGRES_USER
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+POSTGRES_DB=$POSTGRES_DB
+REDIS_PASSWORD=$REDIS_PASSWORD
+AUTH_GOOGLE_CLIENT_ID=$AUTH_GOOGLE_CLIENT_ID
+AUTH_GOOGLE_CLIENT_SECRET=$AUTH_GOOGLE_CLIENT_SECRET
+AUTH_GITHUB_CLIENT_ID=$AUTH_GITHUB_CLIENT_ID
+AUTH_GITHUB_CLIENT_SECRET=$AUTH_GITHUB_CLIENT_SECRET
+CACHEBUST=$(date +%s)
+DOTENV
+            chmod 600 .env
 
+            echo "==> Building and starting services..."
             echo "==> Pulling GHCR image for API (falls back to local build)..."
             docker compose -f docker-compose.prod.yml pull api 2>/dev/null || echo "GHCR pull failed — will build locally"
 
-            export CACHEBUST=$(date +%s)
-
-            docker compose -f docker-compose.prod.yml up -d --build --force-recreate --remove-orphans
+            docker compose -f docker-compose.prod.yml --env-file .env up -d --build --force-recreate --remove-orphans
 
             echo "==> Waiting for services to stabilize..."
             sleep 15


### PR DESCRIPTION
## Summary
Shell exports from appleboy/ssh-action were not reaching docker-compose containers. Now writes all secrets to a .env file (chmod 600) on the VPS and passes it explicitly via --env-file.

## Test plan
- [ ] AUTH_GOOGLE_CLIENT_ID appears in the Google OAuth authorization URL
- [ ] OAuth login redirects to Google consent screen with valid client_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)
