### PR TITLE
fix(auth): OAuth callback redirects to frontend instead of returning JSON

### DIFF
--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -7,11 +7,16 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     const token = searchParams.get('token')
-    const returnUrl = searchParams.get('return_url') || '/'
+    const refreshToken = searchParams.get('refresh_token')
+    const returnUrl = sessionStorage.getItem('oauth_return_url') || '/'
 
     if (token) {
       localStorage.setItem('access_token', token)
     }
+    if (refreshToken) {
+      localStorage.setItem('refresh_token', refreshToken)
+    }
+    sessionStorage.removeItem('oauth_return_url')
 
     navigate(returnUrl, { replace: true })
   }, [searchParams, navigate])

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import secrets
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
 
 from src.api.middleware import require_auth
 from src.auth.models import AuthorizationUrlResponse, TokenResponse, User
@@ -41,9 +43,9 @@ def login(provider: str) -> AuthorizationUrlResponse:
     return AuthorizationUrlResponse(authorization_url=url)
 
 
-@router.get("/auth/callback/{provider}", response_model=TokenResponse)
-async def callback(provider: str, code: str, state: str) -> TokenResponse:
-    """Handle OAuth callback — exchange code for tokens."""
+@router.get("/auth/callback/{provider}")
+async def callback(provider: str, code: str, state: str) -> RedirectResponse:
+    """Handle OAuth callback — exchange code for tokens, redirect to frontend."""
     if provider not in PROVIDERS:
         raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
 
@@ -62,17 +64,13 @@ async def callback(provider: str, code: str, state: str) -> TokenResponse:
 
     # Use provider + provider_user_id as the internal user ID
     user_id = f"{user_info.provider}:{user_info.provider_user_id}"
-    settings = get_settings().auth
 
     access_token = create_access_token(user_id)
     refresh_token = create_refresh_token(user_id)
 
-    return TokenResponse(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        token_type="bearer",
-        expires_in=settings.access_token_expire_minutes * 60,
-    )
+    # Redirect to frontend callback page with token
+    params = urlencode({"token": access_token, "refresh_token": refresh_token})
+    return RedirectResponse(url=f"/auth/callback/{provider}?{params}", status_code=302)
 
 
 @router.post("/auth/refresh", response_model=TokenResponse)


### PR DESCRIPTION
## Summary
OAuth callback was returning raw JSON tokens in the browser. Now redirects to the frontend AuthCallbackPage which stores tokens in localStorage and navigates to the return URL.

## Test plan
- [ ] Google OAuth: login -> consent -> redirect to app with auth
- [ ] GitHub OAuth: same flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
