### PR TITLE
feat(admin): bootstrap first admin user (#633)

### DIFF
--- a/docs/ops/admin-bootstrap.md
+++ b/docs/ops/admin-bootstrap.md
@@ -1,0 +1,50 @@
+# Admin Bootstrap
+
+The platform requires at least one admin user to access the admin dashboard
+(user management, moderation, health, analytics, config). Since the dashboard
+itself is gated behind `is_admin`, bootstrapping the first admin is a
+chicken-and-egg problem that must be solved out-of-band.
+
+Two mechanisms are provided:
+
+## Option 1: CLI promotion (recommended for existing deployments)
+
+Promote any registered user to admin by email:
+
+```bash
+isnad admin promote user@example.com
+```
+
+This connects to Neo4j, finds the `USER` node matching the given email, and
+sets `is_admin = true`. The command exits with code 1 if no matching user is
+found.
+
+**Prerequisites:** the user must have logged in at least once via OAuth so that
+a `USER` node exists in the graph.
+
+## Option 2: First-user-is-admin (recommended for fresh deployments)
+
+Set the environment variable before starting the API:
+
+```bash
+AUTH_FIRST_USER_IS_ADMIN=true
+```
+
+When enabled, the OAuth callback checks whether any `USER` nodes exist in
+Neo4j. If the graph is empty (zero users), the first user to complete the
+OAuth flow is automatically promoted to admin.
+
+Once the first admin exists, subsequent users are created with the default
+`is_admin = false` regardless of this setting.
+
+**Security note:** disable this variable (`AUTH_FIRST_USER_IS_ADMIN=false` or
+remove it) after the first admin has been created, especially in production.
+
+## Verifying admin access
+
+After promotion, the user should:
+
+1. Log out and log back in (to get a fresh JWT reflecting the updated claims).
+2. Navigate to the admin dashboard -- the admin link should appear in the
+   sidebar.
+3. Confirm access to user management, health, and config pages.

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -5,14 +5,23 @@ from __future__ import annotations
 import secrets
 from urllib.parse import urlencode
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
 
 from src.api.middleware import require_auth
 from src.auth.models import AuthorizationUrlResponse, TokenResponse, User
-from src.auth.providers import PROVIDERS, get_provider, retrieve_pkce_verifier, store_pkce_verifier
+from src.auth.providers import (
+    PROVIDERS,
+    OAuthUserInfo,
+    get_provider,
+    retrieve_pkce_verifier,
+    store_pkce_verifier,
+)
 from src.auth.tokens import create_access_token, create_refresh_token, revoke_token, verify_token
 from src.config import get_settings
+
+log = structlog.get_logger(logger_name=__name__)
 
 router = APIRouter()
 
@@ -43,9 +52,58 @@ def login(provider: str) -> AuthorizationUrlResponse:
     return AuthorizationUrlResponse(authorization_url=url)
 
 
+def _upsert_user(request: Request, user_id: str, user_info: OAuthUserInfo) -> None:
+    """Create or update the USER node in Neo4j.
+
+    When ``AUTH_FIRST_USER_IS_ADMIN`` is ``true`` and no USER nodes exist yet,
+    the newly created user is automatically promoted to admin.
+    """
+    try:
+        neo4j = request.app.state.neo4j
+    except AttributeError:
+        log.debug("neo4j_not_available_for_upsert", user_id=user_id)
+        return
+
+    settings = get_settings()
+
+    # Determine whether this user should be auto-promoted
+    make_admin = False
+    if settings.auth.first_user_is_admin:
+        count_result = neo4j.execute_read("MATCH (u:USER) RETURN count(u) AS cnt")
+        user_count = count_result[0]["cnt"] if count_result else 0
+        if user_count == 0:
+            make_admin = True
+            log.info("first_user_auto_admin", user_id=user_id)
+
+    query = """
+        MERGE (u:USER {id: $user_id})
+        ON CREATE SET
+            u.email = $email,
+            u.name = $name,
+            u.provider = $provider,
+            u.created_at = datetime(),
+            u.is_admin = $is_admin,
+            u.is_suspended = false
+        ON MATCH SET
+            u.email = $email,
+            u.name = $name
+        RETURN u
+    """
+    neo4j.execute_write(
+        query,
+        {
+            "user_id": user_id,
+            "email": user_info.email,
+            "name": user_info.name,
+            "provider": user_info.provider,
+            "is_admin": make_admin,
+        },
+    )
+
+
 @router.get("/auth/callback/{provider}")
-async def callback(provider: str, code: str, state: str) -> RedirectResponse:
-    """Handle OAuth callback — exchange code for tokens, redirect to frontend."""
+async def callback(provider: str, code: str, state: str, request: Request) -> RedirectResponse:
+    """Handle OAuth callback — exchange code for tokens, upsert user, redirect to frontend."""
     if provider not in PROVIDERS:
         raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
 
@@ -64,6 +122,9 @@ async def callback(provider: str, code: str, state: str) -> RedirectResponse:
 
     # Use provider + provider_user_id as the internal user ID
     user_id = f"{user_info.provider}:{user_info.provider_user_id}"
+
+    # Upsert user in Neo4j and apply first-user-is-admin if configured
+    _upsert_user(request, user_id, user_info)
 
     access_token = create_access_token(user_id)
     refresh_token = create_refresh_token(user_id)

--- a/src/cli.py
+++ b/src/cli.py
@@ -405,6 +405,28 @@ def _cmd_audit(*, last_n: int = 10) -> None:
         print()
 
 
+def _cmd_admin_promote(email: str) -> None:
+    """Promote a user to admin by email address."""
+    from src.utils.neo4j_client import Neo4jClient
+
+    _check_neo4j()
+
+    with Neo4jClient() as client:
+        query = """
+            MATCH (u:USER {email: $email})
+            SET u.is_admin = true
+            RETURN u.id AS id, u.email AS email, u.name AS name
+        """
+        records = client.execute_write(query, {"email": email})
+
+    if not records:
+        print(f"ERROR: No user found with email '{email}'.")
+        sys.exit(1)
+
+    r = records[0]
+    print(f"User promoted to admin: {r['name']} ({r['email']}) [id={r['id']}]")
+
+
 def _cmd_stub(name: str) -> None:
     """Print a not-yet-implemented message for a pipeline stage."""
     print(f"Command '{name}' not yet implemented. See Makefile targets.")
@@ -457,6 +479,11 @@ def main() -> None:
         default=10,
         help="Number of recent audit entries to display (default: 10)",
     )
+    admin_parser = subparsers.add_parser("admin", help="Admin management commands")
+    admin_sub = admin_parser.add_subparsers(dest="admin_command")
+    promote_parser = admin_sub.add_parser("promote", help="Promote a user to admin by email")
+    promote_parser.add_argument("email", help="Email address of the user to promote")
+
     vs_parser = subparsers.add_parser("validate-staging", help="Validate staging Parquet files")
     vs_parser.add_argument(
         "--strict",
@@ -520,6 +547,11 @@ def main() -> None:
         _cmd_audit(last_n=args.last)
     elif args.command == "validate":
         _cmd_validate()
+    elif args.command == "admin":
+        if args.admin_command == "promote":
+            _cmd_admin_promote(args.email)
+        else:
+            admin_parser.print_help()
     else:
         _cmd_stub(args.command)
 

--- a/src/config.py
+++ b/src/config.py
@@ -59,6 +59,7 @@ class AuthSettings(BaseSettings):
     github_client_id: str = ""
     github_client_secret: str = ""
     oauth_redirect_base_url: str = "http://localhost:8000"
+    first_user_is_admin: bool = False
 
     model_config = SettingsConfigDict(env_prefix="AUTH_")
 


### PR DESCRIPTION
## Summary

- Add `isnad admin promote <email>` CLI command that sets `is_admin=true` on a USER node in Neo4j by email address
- Add `AUTH_FIRST_USER_IS_ADMIN` env var to `AuthSettings` — when true, the first user to complete OAuth login is automatically promoted to admin
- Upsert USER node in Neo4j during OAuth callback (MERGE on id, sets email/name/provider/created_at)
- Document the bootstrap process in `docs/ops/admin-bootstrap.md`

Closes #633

## Test plan

- [x] All 865 unit tests pass (`pytest -m "not integration and not e2e and not ml"`)
- [x] Ruff lint + format clean
- [x] mypy strict passes
- [ ] Manual: deploy, set `AUTH_FIRST_USER_IS_ADMIN=true`, log in as first user, verify admin access
- [ ] Manual: run `isnad admin promote user@example.com` against a live Neo4j, verify promotion

🤖 Generated with [Claude Code](https://claude.ai/claude-code)