### PR TITLE
feat(frontend): apply Qalam design system polish across all pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import UsageAnalyticsPage from './pages/admin/UsageAnalyticsPage'
 import ModerationPage from './pages/admin/ModerationPage'
 import ReportsPage from './pages/admin/ReportsPage'
 import ConfigPage from './pages/admin/ConfigPage'
+import NotFoundPage from './pages/NotFoundPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -74,6 +75,9 @@ export default function App() {
                 </Route>
               </Route>
             </Route>
+
+            {/* Catch-all 404 */}
+            <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/frontend/src/components/AdminLayout.module.css
+++ b/frontend/src/components/AdminLayout.module.css
@@ -6,8 +6,19 @@
 
 .header {
   padding: var(--spacing-3) var(--spacing-6);
-  border-bottom: var(--border-width-thin) solid var(--color-border);
   background: var(--color-card);
+  border-bottom: var(--border-width-thick) solid transparent;
+  border-image: repeating-linear-gradient(
+    90deg,
+    var(--color-primary) 0px,
+    var(--color-primary) 8px,
+    transparent 8px,
+    transparent 12px,
+    var(--color-border) 12px,
+    var(--color-border) 14px,
+    transparent 14px,
+    transparent 18px
+  ) 4;
 }
 
 .headerLink {
@@ -19,6 +30,9 @@
   margin: 0;
   font-size: var(--text-xl);
   font-family: var(--font-heading);
+  font-weight: 600;
+  color: var(--color-primary);
+  letter-spacing: var(--tracking-tight);
 }
 
 .body {
@@ -63,18 +77,20 @@
 }
 
 .sidebarLink:hover {
-  background: var(--color-muted);
+  background: var(--color-accent);
+  color: var(--color-primary);
 }
 
 .sidebarLinkActive {
   text-decoration: none;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--color-primary);
   display: block;
   padding: var(--spacing-1_5) var(--spacing-3);
   border-radius: var(--radius-md);
   background: var(--color-accent);
   font-size: var(--text-sm);
+  border-inline-start: 3px solid var(--color-primary);
 }
 
 .main {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,24 +6,36 @@ export default function Layout() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <header
+        className="geo-border-bottom"
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 'var(--spacing-3)',
+          gap: 'var(--spacing-4)',
           padding: 'var(--spacing-3) var(--spacing-6)',
-          borderBottom: 'var(--border-width-thin) solid var(--color-border)',
           background: 'var(--color-card)',
         }}
       >
-        <h1 style={{ margin: 0, fontSize: 'var(--text-xl)', fontFamily: 'var(--font-heading)', flex: 1 }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 'var(--text-xl)',
+            fontFamily: 'var(--font-heading)',
+            fontWeight: 600,
+            color: 'var(--color-primary)',
+            letterSpacing: 'var(--tracking-tight)',
+            flex: 1,
+          }}
+        >
           Isnad Graph
         </h1>
-        <span className="small-muted">Hadith Analysis Platform</span>
+        <span className="small-muted" style={{ fontFamily: 'var(--font-heading)' }}>
+          Hadith Analysis Platform
+        </span>
         <ThemeToggle />
       </header>
       <div style={{ display: 'flex', flex: 1 }}>
         <Sidebar />
-        <main style={{ flex: 1, padding: 'var(--spacing-6)' }}>
+        <main style={{ flex: 1, padding: 'var(--spacing-6)', overflow: 'auto' }}>
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,13 +2,13 @@ import { NavLink } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
 const navItems = [
-  { to: '/narrators', label: 'Narrators' },
-  { to: '/hadiths', label: 'Hadiths' },
-  { to: '/collections', label: 'Collections' },
-  { to: '/search', label: 'Search' },
-  { to: '/timeline', label: 'Timeline' },
-  { to: '/compare', label: 'Compare' },
-  { to: '/graph', label: 'Graph Explorer' },
+  { to: '/narrators', label: 'Narrators', icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' },
+  { to: '/hadiths', label: 'Hadiths', icon: 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253' },
+  { to: '/collections', label: 'Collections', icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10' },
+  { to: '/search', label: 'Search', icon: 'M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z' },
+  { to: '/timeline', label: 'Timeline', icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z' },
+  { to: '/compare', label: 'Compare', icon: 'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5' },
+  { to: '/graph', label: 'Graph Explorer', icon: 'M7.5 3.75H6A2.25 2.25 0 003.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0120.25 6v1.5m0 9V18A2.25 2.25 0 0118 20.25h-1.5m-9 0H6A2.25 2.25 0 013.75 18v-1.5M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
 ]
 
 export default function Sidebar() {
@@ -18,7 +18,7 @@ export default function Sidebar() {
     <nav
       aria-label="Main navigation"
       style={{
-        width: 220,
+        width: 240,
         padding: 'var(--spacing-4)',
         borderInlineEnd: 'var(--border-width-thin) solid var(--color-border)',
         background: 'var(--color-card)',
@@ -26,22 +26,41 @@ export default function Sidebar() {
     >
       <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
         {navItems.map((item) => (
-          <li key={item.to} style={{ marginBottom: 'var(--spacing-2)' }}>
+          <li key={item.to} style={{ marginBottom: 'var(--spacing-1)' }}>
             <NavLink
               to={item.to}
               style={({ isActive }) => ({
                 textDecoration: 'none',
-                fontWeight: isActive ? 700 : 400,
+                fontWeight: isActive ? 600 : 400,
                 color: isActive ? 'var(--color-primary)' : 'var(--color-foreground)',
                 fontFamily: 'var(--font-body)',
                 fontSize: 'var(--text-sm)',
-                display: 'block',
-                padding: 'var(--spacing-1_5) var(--spacing-3)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--spacing-2_5)',
+                padding: 'var(--spacing-2) var(--spacing-3)',
                 borderRadius: 'var(--radius-md)',
                 background: isActive ? 'var(--color-accent)' : 'transparent',
-                transition: 'background-color var(--duration-fast) var(--ease-default)',
+                borderInlineStart: isActive
+                  ? '3px solid var(--color-primary)'
+                  : '3px solid transparent',
+                transition: 'all var(--duration-fast) var(--ease-default)',
               })}
             >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                style={{ flexShrink: 0, opacity: 0.7 }}
+              >
+                <path d={item.icon} />
+              </svg>
               {item.label}
             </NavLink>
           </li>
@@ -58,16 +77,36 @@ export default function Sidebar() {
               to="/admin"
               style={({ isActive }) => ({
                 textDecoration: 'none',
-                fontWeight: isActive ? 700 : 400,
+                fontWeight: isActive ? 600 : 400,
                 color: isActive ? 'var(--color-primary)' : 'var(--color-foreground)',
                 fontFamily: 'var(--font-body)',
                 fontSize: 'var(--text-sm)',
-                display: 'block',
-                padding: 'var(--spacing-1_5) var(--spacing-3)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--spacing-2_5)',
+                padding: 'var(--spacing-2) var(--spacing-3)',
                 borderRadius: 'var(--radius-md)',
                 background: isActive ? 'var(--color-accent)' : 'transparent',
+                borderInlineStart: isActive
+                  ? '3px solid var(--color-primary)'
+                  : '3px solid transparent',
               })}
             >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                style={{ flexShrink: 0, opacity: 0.7 }}
+              >
+                <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
               Admin Dashboard
             </NavLink>
           </li>

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -12,9 +12,15 @@ export default function CollectionsPage() {
 
   return (
     <div>
-      <h2>Collections</h2>
+      <h2 className="page-heading">Collections</h2>
 
-      {isLoading && <p>Loading...</p>}
+      {isLoading && (
+        <div>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="skeleton skeleton-row" style={{ width: `${90 - i * 5}%` }} />
+          ))}
+        </div>
+      )}
       {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (

--- a/frontend/src/pages/ComparativePage.tsx
+++ b/frontend/src/pages/ComparativePage.tsx
@@ -16,12 +16,18 @@ export default function ComparativePage() {
 
   return (
     <div>
-      <h2>Comparative Analysis</h2>
-      <p className="muted-text" style={{ marginBottom: '1rem' }}>
+      <h2 className="page-heading">Comparative Analysis</h2>
+      <p className="muted-text" style={{ marginBottom: 'var(--spacing-4)' }}>
         Browse cross-sectarian parallel hadith pairs (PARALLEL_OF relationships).
       </p>
 
-      {isLoading && <p>Loading...</p>}
+      {isLoading && (
+        <div>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="skeleton skeleton-row" style={{ width: `${90 - i * 5}%` }} />
+          ))}
+        </div>
+      )}
       {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (
@@ -71,7 +77,7 @@ export default function ComparativePage() {
             </tbody>
           </table>
 
-          <div className="pagination" style={{ marginTop: '1.5rem' }}>
+          <div className="pagination">
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
               Previous
             </button>

--- a/frontend/src/pages/ForbiddenPage.tsx
+++ b/frontend/src/pages/ForbiddenPage.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom'
+
+export default function ForbiddenPage() {
+  return (
+    <div className="error-page">
+      {/* Locked node icon */}
+      <div className="empty-state-icon">
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+          {/* Lock body */}
+          <rect x="28" y="38" width="24" height="18" rx="3" />
+          {/* Lock shackle */}
+          <path d="M34 38V30a6 6 0 0 1 12 0v8" />
+          {/* Keyhole */}
+          <circle cx="40" cy="47" r="2" />
+          <line x1="40" y1="49" x2="40" y2="52" />
+        </svg>
+      </div>
+      <div className="error-page-code">403</div>
+      <div className="error-page-title">Access denied</div>
+      <div className="error-page-body">
+        You do not have permission to access this page.
+      </div>
+      <Link to="/" className="btn-primary" style={{ textDecoration: 'none' }}>
+        Return home
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -226,7 +226,7 @@ export default function GraphExplorerPage() {
                 border: 'none',
                 cursor: 'pointer',
                 fontSize: '1rem',
-                color: '#666',
+                color: 'var(--color-muted-foreground)',
               }}
               aria-label="Clear search"
             >
@@ -265,7 +265,7 @@ export default function GraphExplorerPage() {
                   }}
                 >
                   <span>{n.name_en}</span>
-                  <span dir="rtl" lang="ar" style={{ color: '#666', fontSize: '0.875rem' }}>
+                  <span dir="rtl" lang="ar" style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>
                     {n.name_ar}
                   </span>
                 </div>
@@ -359,7 +359,7 @@ export default function GraphExplorerPage() {
           </button>
         )}
 
-        {isLoading && <span style={{ fontSize: '0.875rem', color: '#888' }}>Loading...</span>}
+        {isLoading && <span style={{ fontSize: '0.875rem', color: 'var(--color-muted-foreground)' }}>Loading...</span>}
       </div>
 
       {/* --- Node limit warning --- */}
@@ -409,38 +409,33 @@ export default function GraphExplorerPage() {
               height={dimensions.height}
             />
           ) : (
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                height: '100%',
-                color: '#888',
-                gap: '1rem',
-              }}
-            >
-              <svg width="64" height="64" viewBox="0 0 64 64" fill="none" stroke="#bbb">
-                <circle cx="16" cy="16" r="4" />
-                <circle cx="48" cy="16" r="4" />
-                <circle cx="32" cy="48" r="4" />
-                <circle cx="48" cy="48" r="4" />
-                <line x1="20" y1="16" x2="44" y2="16" />
-                <line x1="18" y1="20" x2="30" y2="44" />
-                <line x1="34" y1="48" x2="44" y2="48" />
-              </svg>
-              <p>Search for a narrator to begin exploring the transmission network.</p>
-              <p style={{ fontSize: '0.875rem' }}>
+            <div className="empty-state" style={{ height: '100%' }}>
+              <div className="empty-state-icon">
+                <svg width="64" height="64" viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+                  <circle cx="16" cy="16" r="4" />
+                  <circle cx="48" cy="16" r="4" />
+                  <circle cx="32" cy="48" r="4" />
+                  <circle cx="48" cy="48" r="4" />
+                  <line x1="20" y1="16" x2="44" y2="16" strokeDasharray="4 3" />
+                  <line x1="18" y1="20" x2="30" y2="44" strokeDasharray="4 3" />
+                  <line x1="34" y1="48" x2="44" y2="48" strokeDasharray="4 3" />
+                </svg>
+              </div>
+              <div className="empty-state-heading">No graph data</div>
+              <div className="empty-state-body">
+                Search for a narrator to explore the transmission network.
+              </div>
+              <p style={{ fontSize: 'var(--text-sm)', marginTop: 'var(--spacing-4)' }}>
                 Try:{' '}
                 {SUGGESTED_NARRATORS.map((name, i) => (
                   <span key={name}>
                     {i > 0 && ', '}
                     <button
                       onClick={() => handleSuggestedSearch(name)}
+                      className="link-primary"
                       style={{
                         background: 'none',
                         border: 'none',
-                        color: '#1a73e8',
                         cursor: 'pointer',
                         textDecoration: 'underline',
                         padding: 0,
@@ -623,7 +618,7 @@ export default function GraphExplorerPage() {
                   fontSize: '0.75rem',
                   textTransform: 'uppercase',
                   letterSpacing: '0.05em',
-                  color: '#888',
+                  color: 'var(--color-muted-foreground)',
                 }}
               >
                 Narrator
@@ -635,7 +630,7 @@ export default function GraphExplorerPage() {
                   border: 'none',
                   cursor: 'pointer',
                   fontSize: '1rem',
-                  color: '#666',
+                  color: 'var(--color-muted-foreground)',
                 }}
                 aria-label="Close detail panel"
               >
@@ -654,7 +649,7 @@ export default function GraphExplorerPage() {
                 }}
               />
             ) : (
-              <p style={{ color: '#888', fontSize: '0.875rem' }}>Loading details...</p>
+              <p style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>Loading details...</p>
             )}
           </div>
         )}
@@ -666,7 +661,7 @@ export default function GraphExplorerPage() {
           padding: '0.25rem 1rem',
           borderTop: '1px solid var(--color-border, #e0e0e0)',
           fontSize: '0.75rem',
-          color: '#888',
+          color: 'var(--color-muted-foreground)',
           display: 'flex',
           gap: '1.5rem',
           background: 'var(--color-card, #fff)',
@@ -722,34 +717,34 @@ function NarratorDetailPanel({
       <div style={{ fontSize: '0.85rem', lineHeight: 1.6, marginBottom: '1rem' }}>
         {narrator.kunya && (
           <div>
-            <span style={{ color: '#888' }}>Kunya:</span> {narrator.kunya}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Kunya:</span> {narrator.kunya}
           </div>
         )}
         {narrator.nisba && (
           <div>
-            <span style={{ color: '#888' }}>Nisba:</span> {narrator.nisba}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Nisba:</span> {narrator.nisba}
           </div>
         )}
         {narrator.generation && (
           <div>
-            <span style={{ color: '#888' }}>Generation:</span> {narrator.generation}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Generation:</span> {narrator.generation}
           </div>
         )}
         <div>
-          <span style={{ color: '#888' }}>Birth:</span>{' '}
+          <span style={{ color: 'var(--color-muted-foreground)' }}>Birth:</span>{' '}
           {narrator.birth_year_ah != null ? `${narrator.birth_year_ah} AH` : '\u2014'}
           {' | '}
-          <span style={{ color: '#888' }}>Death:</span>{' '}
+          <span style={{ color: 'var(--color-muted-foreground)' }}>Death:</span>{' '}
           {narrator.death_year_ah != null ? `${narrator.death_year_ah} AH` : '\u2014'}
         </div>
         {narrator.sect_affiliation && (
           <div>
-            <span style={{ color: '#888' }}>Sect:</span> {narrator.sect_affiliation}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Sect:</span> {narrator.sect_affiliation}
           </div>
         )}
         {narrator.trustworthiness_consensus && (
           <div>
-            <span style={{ color: '#888' }}>Trustworthiness:</span>{' '}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Trustworthiness:</span>{' '}
             {narrator.trustworthiness_consensus}
           </div>
         )}
@@ -768,7 +763,7 @@ function NarratorDetailPanel({
             fontSize: '0.75rem',
             textTransform: 'uppercase',
             letterSpacing: '0.05em',
-            color: '#888',
+            color: 'var(--color-muted-foreground)',
             marginBottom: '0.5rem',
           }}
         >
@@ -776,26 +771,26 @@ function NarratorDetailPanel({
         </div>
         <div style={{ fontSize: '0.85rem', lineHeight: 1.6 }}>
           <div>
-            <span style={{ color: '#888' }}>Teachers (in):</span> {narrator.in_degree ?? '\u2014'}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Teachers (in):</span> {narrator.in_degree ?? '\u2014'}
           </div>
           <div>
-            <span style={{ color: '#888' }}>Students (out):</span>{' '}
+            <span style={{ color: 'var(--color-muted-foreground)' }}>Students (out):</span>{' '}
             {narrator.out_degree ?? '\u2014'}
           </div>
           {narrator.betweenness_centrality != null && (
             <div>
-              <span style={{ color: '#888' }}>Betweenness:</span>{' '}
+              <span style={{ color: 'var(--color-muted-foreground)' }}>Betweenness:</span>{' '}
               {narrator.betweenness_centrality.toFixed(4)}
             </div>
           )}
           {narrator.pagerank != null && (
             <div>
-              <span style={{ color: '#888' }}>PageRank:</span> {narrator.pagerank.toFixed(4)}
+              <span style={{ color: 'var(--color-muted-foreground)' }}>PageRank:</span> {narrator.pagerank.toFixed(4)}
             </div>
           )}
           {narrator.community_id != null && (
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-              <span style={{ color: '#888' }}>Community:</span> {narrator.community_id}
+              <span style={{ color: 'var(--color-muted-foreground)' }}>Community:</span> {narrator.community_id}
               <span
                 style={{
                   display: 'inline-block',
@@ -831,7 +826,7 @@ function NarratorDetailPanel({
               fontSize: '0.75rem',
               textTransform: 'uppercase',
               letterSpacing: '0.05em',
-              color: '#888',
+              color: 'var(--color-muted-foreground)',
             }}
           >
             Chains ({chainsTotal} total)
@@ -839,7 +834,7 @@ function NarratorDetailPanel({
         </div>
         <div style={{ maxHeight: 200, overflowY: 'auto' }}>
           {chains.length === 0 && (
-            <div style={{ color: '#999', fontSize: '0.85rem' }}>No chains found.</div>
+            <div style={{ color: 'var(--color-muted-foreground)', fontSize: '0.85rem' }}>No chains found.</div>
           )}
           {chains.map((c) => (
             <div
@@ -847,13 +842,13 @@ function NarratorDetailPanel({
               onClick={() => onChainSelect(c)}
               style={{
                 padding: '0.375rem 0',
-                borderBottom: '1px solid #f0f0f0',
+                borderBottom: '1px solid var(--color-border)',
                 cursor: 'pointer',
                 fontSize: '0.8rem',
               }}
             >
               <div style={{ fontWeight: 500 }}>
-                {c.grade && <span style={{ color: '#888' }}>[{c.grade}]</span>}{' '}
+                {c.grade && <span style={{ color: 'var(--color-muted-foreground)' }}>[{c.grade}]</span>}{' '}
                 {c.matn_en || c.hadith_id}
               </div>
               {c.matn_ar && (
@@ -861,7 +856,7 @@ function NarratorDetailPanel({
                   dir="rtl"
                   lang="ar"
                   style={{
-                    color: '#666',
+                    color: 'var(--color-muted-foreground)',
                     fontSize: '0.75rem',
                     whiteSpace: 'nowrap',
                     overflow: 'hidden',
@@ -883,7 +878,7 @@ function NarratorDetailPanel({
         style={{
           display: 'block',
           textAlign: 'center',
-          color: '#1a73e8',
+          color: 'var(--color-primary)',
           fontSize: '0.85rem',
           textDecoration: 'none',
           padding: '0.5rem',

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -16,9 +16,15 @@ export default function HadithsPage() {
 
   return (
     <div>
-      <h2>Hadiths</h2>
+      <h2 className="page-heading">Hadiths</h2>
 
-      {isLoading && <p>Loading...</p>}
+      {isLoading && (
+        <div>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="skeleton skeleton-row" style={{ width: `${90 - i * 5}%` }} />
+          ))}
+        </div>
+      )}
       {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       {data && (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -37,14 +37,42 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-6 rounded-xl border border-border bg-card p-8 shadow-lg">
-        <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold font-heading">Isnad Graph</h1>
-          <p className="text-sm text-muted-foreground">Sign in to continue</p>
+      <div className="w-full max-w-sm space-y-6 rounded-2xl border border-border bg-card p-10 shadow-xl">
+        {/* Geometric accent line */}
+        <div className="geo-border-top" />
+
+        <div className="text-center space-y-3">
+          {/* Octagonal icon placeholder */}
+          <div
+            className="mx-auto flex items-center justify-center"
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 'var(--radius-lg)',
+              background: 'var(--color-primary)',
+              color: 'var(--color-primary-foreground)',
+              transform: 'rotate(0deg)',
+            }}
+          >
+            <svg width="28" height="28" viewBox="0 0 32 32" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="10" cy="10" r="3" />
+              <circle cx="22" cy="10" r="3" />
+              <circle cx="16" cy="22" r="3" />
+              <line x1="13" y1="10" x2="19" y2="10" />
+              <line x1="11" y1="13" x2="15" y2="19" />
+              <line x1="21" y1="13" x2="17" y2="19" />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-semibold" style={{ fontFamily: 'var(--font-heading)', color: 'var(--color-foreground)' }}>
+            Isnad Graph
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Sign in to access the hadith analysis platform
+          </p>
         </div>
 
         {error && (
-          <div className="rounded-lg border border-destructive bg-destructive/10 px-4 py-2 text-sm text-destructive">
+          <div className="rounded-lg border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {error}
           </div>
         )}
@@ -53,7 +81,7 @@ export default function LoginPage() {
           <button
             onClick={() => handleOAuth('google')}
             disabled={loading !== null}
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium hover:bg-muted hover:border-primary/30 transition-colors disabled:opacity-50"
           >
             <svg width="18" height="18" viewBox="0 0 24 24">
               <path
@@ -79,7 +107,7 @@ export default function LoginPage() {
           <button
             onClick={() => handleOAuth('github')}
             disabled={loading !== null}
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium hover:bg-muted hover:border-primary/30 transition-colors disabled:opacity-50"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
@@ -87,6 +115,9 @@ export default function LoginPage() {
             {loading === 'github' ? 'Redirecting...' : 'Continue with GitHub'}
           </button>
         </div>
+
+        {/* Geometric accent line */}
+        <div className="geo-border-bottom" />
       </div>
     </div>
   )

--- a/frontend/src/pages/NarratorsPage.tsx
+++ b/frontend/src/pages/NarratorsPage.tsx
@@ -23,9 +23,9 @@ export default function NarratorsPage() {
 
   return (
     <div>
-      <h2>Narrators</h2>
+      <h2 className="page-heading">Narrators</h2>
 
-      <div className="flex-row" style={{ marginBottom: '1rem' }}>
+      <div className="flex-row" style={{ marginBottom: 'var(--spacing-4)' }}>
         <input
           type="text"
           placeholder="Search narrators..."
@@ -36,15 +36,36 @@ export default function NarratorsPage() {
           className="form-input"
           style={{ flex: 1, maxWidth: 400 }}
         />
-        <button onClick={handleSearch} className="btn">
+        <button onClick={handleSearch} className="btn-primary">
           Search
         </button>
       </div>
 
-      {isLoading && <p>Loading...</p>}
+      {isLoading && (
+        <div>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="skeleton skeleton-row" style={{ width: `${90 - i * 5}%` }} />
+          ))}
+        </div>
+      )}
       {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
-      {data && (
+      {data && data.items.length === 0 && (
+        <div className="empty-state">
+          <div className="empty-state-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </div>
+          <div className="empty-state-heading">No narrators found</div>
+          <div className="empty-state-body">
+            Try adjusting your search terms or clearing the filter.
+          </div>
+        </div>
+      )}
+
+      {data && data.items.length > 0 && (
         <>
           <table className="data-table">
             <thead>

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFoundPage() {
+  return (
+    <div className="error-page">
+      {/* Disconnected graph node icon */}
+      <div className="empty-state-icon">
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+          <circle cx="25" cy="25" r="5" />
+          <circle cx="55" cy="25" r="5" />
+          <circle cx="40" cy="55" r="5" />
+          {/* Broken edge */}
+          <line x1="30" y1="25" x2="38" y2="25" />
+          <line x1="42" y1="25" x2="50" y2="25" />
+          {/* Intact edges */}
+          <line x1="27" y1="30" x2="38" y2="50" />
+          <line x1="53" y1="30" x2="42" y2="50" />
+          {/* Drifting disconnected node */}
+          <circle cx="65" cy="60" r="4" opacity="0.4" strokeDasharray="3 2" />
+        </svg>
+      </div>
+      <div className="error-page-code">404</div>
+      <div className="error-page-title">Page not found</div>
+      <div className="error-page-body">
+        The page you are looking for does not exist or has been moved.
+      </div>
+      <Link to="/" className="btn-primary" style={{ textDecoration: 'none' }}>
+        Return home
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -381,7 +381,7 @@ export default function SearchPage() {
 
   return (
     <div className="max-w-7xl mx-auto">
-      <h2 className="text-2xl font-semibold mb-4">Search</h2>
+      <h2 className="page-heading">Search</h2>
 
       {/* Search bar */}
       <form onSubmit={handleSubmit} className="mb-4">

--- a/frontend/src/pages/ServerErrorPage.tsx
+++ b/frontend/src/pages/ServerErrorPage.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom'
+
+export default function ServerErrorPage() {
+  return (
+    <div className="error-page">
+      {/* Broken graph edges icon */}
+      <div className="empty-state-icon">
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+          <circle cx="25" cy="25" r="5" />
+          <circle cx="55" cy="25" r="5" />
+          <circle cx="40" cy="55" r="5" />
+          <circle cx="15" cy="55" r="5" />
+          {/* Jagged/broken edges */}
+          <polyline points="30,25 36,22 38,28 42,22 44,28 50,25" />
+          <polyline points="27,30 30,35 26,38 32,42 28,46 38,50" />
+          <polyline points="53,30 50,38 54,42 48,48 42,50" />
+        </svg>
+      </div>
+      <div className="error-page-code">500</div>
+      <div className="error-page-title">Something went wrong</div>
+      <div className="error-page-body">
+        An unexpected error occurred. Please try again.
+      </div>
+      <Link to="/" className="btn-primary" style={{ textDecoration: 'none' }}>
+        Return home
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -132,8 +132,8 @@ export default function TimelinePage() {
 
   return (
     <div>
-      <h2>Timeline</h2>
-      <p className="muted-text" style={{ marginBottom: '1rem' }}>
+      <h2 className="page-heading">Timeline</h2>
+      <p className="muted-text" style={{ marginBottom: 'var(--spacing-4)' }}>
         Historical events and narrator activity periods (Anno Hegirae).
       </p>
 
@@ -158,7 +158,13 @@ export default function TimelinePage() {
         </label>
       </div>
 
-      {isLoading && <p>Loading timeline...</p>}
+      {isLoading && (
+        <div>
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="skeleton skeleton-row" style={{ width: `${80 - i * 10}%` }} />
+          ))}
+        </div>
+      )}
       {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
       <div className="timeline-body">

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -1,4 +1,9 @@
-/* Shared styles for the Isnad Graph frontend — Qalam Design System */
+/* Shared styles for the Isnad Graph frontend — Qalam Design System
+ * ================================================================
+ * Visual polish pass: consistent Qalam palette application,
+ * table striping, skeleton loading, empty/error states,
+ * Islamic geometric accent patterns, button/card uniformity.
+ */
 
 /* --- Error / status text --- */
 .error-text {
@@ -27,24 +32,41 @@
   flex-wrap: wrap;
 }
 
-/* --- Tables --- */
+/* ============================================================
+ * TABLES — Qalam-styled with alternating row colors
+ * ============================================================ */
 .data-table {
   width: 100%;
   border-collapse: collapse;
+  font-size: var(--text-sm);
 }
 
 .data-table thead tr {
-  border-bottom: var(--border-width-medium) solid var(--color-border);
+  border-bottom: var(--border-width-medium) solid var(--color-primary);
   text-align: left;
 }
 
-.data-table th,
+.data-table th {
+  padding: var(--spacing-3) var(--spacing-3);
+  font-family: var(--font-heading);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted-foreground);
+}
+
 .data-table td {
-  padding: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-3);
 }
 
 .data-table tbody tr {
   border-bottom: var(--border-width-thin) solid var(--color-border);
+}
+
+/* Alternating row striping */
+.data-table tbody tr:nth-child(even) {
+  background: var(--color-muted);
 }
 
 .data-table tbody tr.clickable-row {
@@ -54,7 +76,7 @@
 
 .data-table tbody tr.clickable-row:hover,
 .data-table tbody tr.clickable-row:focus-visible {
-  background-color: var(--color-muted);
+  background-color: var(--color-accent);
 }
 
 /* Compact variant for nested tables */
@@ -63,7 +85,9 @@
   padding: var(--spacing-1);
 }
 
-/* --- Stat / status cards --- */
+/* ============================================================
+ * CARDS — Unified Qalam styling
+ * ============================================================ */
 .stat-card {
   border: var(--border-width-thin) solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -72,11 +96,18 @@
   text-align: center;
   background: var(--color-card);
   color: var(--color-card-foreground);
-  box-shadow: var(--shadow-xs);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--duration-normal) var(--ease-default);
+}
+
+.stat-card:hover {
+  box-shadow: var(--shadow-md);
 }
 
 .stat-card-label {
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
   color: var(--color-muted-foreground);
   margin-bottom: var(--spacing-2);
 }
@@ -84,15 +115,16 @@
 .stat-card-value {
   font-size: var(--text-2xl);
   font-weight: var(--font-weight-bold);
+  font-family: var(--font-heading);
   color: var(--color-foreground);
 }
 
 .stat-card-value-lg {
   font-size: var(--text-xl);
   font-weight: var(--font-weight-bold);
+  font-family: var(--font-heading);
 }
 
-/* --- Metric card (bordered section) --- */
 .metric-card {
   border: var(--border-width-thin) solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -100,7 +132,7 @@
   margin-bottom: var(--spacing-4);
   background: var(--color-card);
   color: var(--color-card-foreground);
-  box-shadow: var(--shadow-xs);
+  box-shadow: var(--shadow-sm);
 }
 
 .metric-card h3 {
@@ -116,18 +148,21 @@
   padding: var(--spacing-1) 0;
 }
 
-/* --- Badges --- */
+/* ============================================================
+ * BADGES — Consistent rounding and sizing
+ * ============================================================ */
 .badge {
   display: inline-block;
   padding: 0.15rem var(--spacing-2);
-  border-radius: var(--radius-sm);
-  font-size: var(--text-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
   font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.01em;
 }
 
 .badge-sm {
   padding: 0.1rem var(--spacing-1_5);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
 }
 
@@ -137,7 +172,7 @@
   background: var(--color-info);
   color: var(--color-info-foreground);
   padding: 0.125rem var(--spacing-1_5);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   opacity: 0.85;
 }
 
@@ -164,8 +199,8 @@
 .badge-topic {
   display: inline-block;
   margin-inline-end: var(--spacing-1);
-  padding: 0.1rem var(--spacing-1_5);
-  border-radius: var(--radius-sm);
+  padding: 0.15rem var(--spacing-2);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
   background: var(--color-accent);
   color: var(--color-accent-foreground);
@@ -173,7 +208,7 @@
 
 .badge-topic-lg {
   padding: var(--spacing-1) var(--spacing-2_5);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   background: var(--color-accent);
   color: var(--color-accent-foreground);
   font-size: var(--text-sm);
@@ -182,23 +217,21 @@
 /* Moderation status badges */
 .badge-approved {
   padding: 0.2rem var(--spacing-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   background: var(--color-success);
   color: var(--color-success-foreground);
-  opacity: 0.9;
 }
 
 .badge-rejected {
   padding: 0.2rem var(--spacing-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   background: var(--color-destructive);
   color: var(--color-destructive-foreground);
-  opacity: 0.9;
 }
 
 .badge-pending {
   padding: 0.2rem var(--spacing-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   background: var(--color-warning);
   color: var(--color-warning-foreground);
 }
@@ -223,26 +256,28 @@
 .badge-similarity-high {
   background: var(--color-sahih-bg);
   padding: 0.15rem var(--spacing-1_5);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   font-size: var(--text-sm);
 }
 
 .badge-similarity-low {
   background: var(--color-hasan-bg);
   padding: 0.15rem var(--spacing-1_5);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   font-size: var(--text-sm);
 }
 
-/* --- Forms --- */
+/* ============================================================
+ * FORMS & BUTTONS — Consistent sizing, focus states
+ * ============================================================ */
 .form-input {
-  padding: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
   border: var(--border-width-thin) solid var(--color-input);
   border-radius: var(--radius-md);
   background: var(--color-card);
   color: var(--color-foreground);
   font-family: var(--font-body);
-  font-size: var(--text-base);
+  font-size: var(--text-sm);
   transition: border-color var(--duration-fast) var(--ease-default),
     box-shadow var(--duration-fast) var(--ease-default);
 }
@@ -250,29 +285,35 @@
 .form-input:focus {
   outline: none;
   border-color: var(--color-ring);
-  box-shadow: 0 0 0 2px var(--color-ring) / 0.25;
+  box-shadow: 0 0 0 3px oklch(from var(--color-ring) l c h / 0.15);
+}
+
+.form-input::placeholder {
+  color: var(--color-muted-foreground);
 }
 
 .form-input-block {
   display: block;
   width: 100%;
   margin-top: var(--spacing-1);
-  padding: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
   border: var(--border-width-thin) solid var(--color-input);
   border-radius: var(--radius-md);
   background: var(--color-card);
   color: var(--color-foreground);
   font-family: var(--font-body);
+  font-size: var(--text-sm);
 }
 
 .form-input-sm {
   width: 80px;
-  padding: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
   border: var(--border-width-thin) solid var(--color-input);
   border-radius: var(--radius-md);
   background: var(--color-card);
   color: var(--color-foreground);
   font-family: var(--font-body);
+  font-size: var(--text-sm);
 }
 
 .btn {
@@ -285,11 +326,21 @@
   font-size: var(--text-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: background-color var(--duration-fast) var(--ease-default);
+  transition: background-color var(--duration-fast) var(--ease-default),
+    box-shadow var(--duration-fast) var(--ease-default);
 }
 
 .btn:hover {
   background: var(--color-muted);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-ring);
+  outline-offset: 2px;
+}
+
+.btn:active {
+  transform: translateY(1px);
 }
 
 .btn-sm {
@@ -301,6 +352,11 @@
   color: var(--color-secondary-foreground);
   cursor: pointer;
   font-family: var(--font-body);
+  transition: background-color var(--duration-fast) var(--ease-default);
+}
+
+.btn-sm:hover {
+  background: var(--color-muted);
 }
 
 .btn-action {
@@ -310,7 +366,12 @@
   border: var(--border-width-thin) solid var(--color-border);
   border-radius: var(--radius-sm);
   font-family: var(--font-body);
-  transition: background-color var(--duration-fast) var(--ease-default);
+  transition: background-color var(--duration-fast) var(--ease-default),
+    filter var(--duration-fast) var(--ease-default);
+}
+
+.btn-action:hover {
+  filter: brightness(0.95);
 }
 
 .btn-action-suspend {
@@ -335,36 +396,57 @@
 
 .btn-primary {
   padding: var(--spacing-2) var(--spacing-6);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-semibold);
   background: var(--color-primary);
   color: var(--color-primary-foreground);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-family: var(--font-body);
-  transition: background-color var(--duration-fast) var(--ease-default);
+  font-size: var(--text-sm);
+  transition: background-color var(--duration-fast) var(--ease-default),
+    box-shadow var(--duration-fast) var(--ease-default);
 }
 
 .btn-primary:hover {
   background: var(--color-primary-hover);
 }
 
+.btn-primary:focus-visible {
+  outline: 2px solid var(--color-ring);
+  outline-offset: 2px;
+}
+
+.btn-primary:active {
+  transform: translateY(1px);
+}
+
 .btn-danger {
   color: var(--color-destructive);
   background: transparent;
   border: var(--border-width-thin) solid var(--color-destructive);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   cursor: pointer;
   padding: var(--spacing-1) var(--spacing-2);
   font-family: var(--font-body);
+  font-size: var(--text-sm);
+  transition: background-color var(--duration-fast) var(--ease-default);
 }
 
-/* --- Pagination --- */
+.btn-danger:hover {
+  background: var(--color-destructive);
+  color: var(--color-destructive-foreground);
+}
+
+/* ============================================================
+ * PAGINATION
+ * ============================================================ */
 .pagination {
   display: flex;
-  gap: var(--spacing-2);
-  margin-top: var(--spacing-4);
+  gap: var(--spacing-1);
+  margin-top: var(--spacing-6);
   align-items: center;
+  justify-content: center;
 }
 
 .pagination button {
@@ -380,15 +462,25 @@
 }
 
 .pagination button:hover:not(:disabled) {
-  background: var(--color-muted);
+  background: var(--color-accent);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .pagination button:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
-/* --- Links --- */
+.pagination span {
+  padding: 0 var(--spacing-3);
+  font-size: var(--text-sm);
+  color: var(--color-muted-foreground);
+}
+
+/* ============================================================
+ * LINKS
+ * ============================================================ */
 .link-primary {
   color: var(--color-primary);
   text-decoration: none;
@@ -397,9 +489,12 @@
 
 .link-primary:hover {
   color: var(--color-primary-hover);
+  text-decoration: underline;
 }
 
-/* --- Section spacing --- */
+/* ============================================================
+ * SECTION SPACING
+ * ============================================================ */
 .section {
   margin-top: var(--spacing-6);
 }
@@ -408,7 +503,22 @@
   margin-bottom: var(--spacing-8);
 }
 
-/* --- Grid layouts --- */
+/* ============================================================
+ * PAGE HEADING — Serif heading per Qalam
+ * ============================================================ */
+.page-heading {
+  font-family: var(--font-heading);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--text-2xl);
+  color: var(--color-foreground);
+  margin-bottom: var(--spacing-6);
+  padding-bottom: var(--spacing-3);
+  border-bottom: var(--border-width-medium) solid var(--color-primary);
+}
+
+/* ============================================================
+ * GRID LAYOUTS
+ * ============================================================ */
 .grid-2col {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -416,7 +526,9 @@
   margin-bottom: var(--spacing-4);
 }
 
-/* --- Arabic text --- */
+/* ============================================================
+ * ARABIC TEXT
+ * ============================================================ */
 .text-rtl {
   direction: rtl;
   text-align: right;
@@ -443,13 +555,17 @@
   line-height: var(--leading-relaxed);
 }
 
-/* --- Monospace --- */
+/* ============================================================
+ * MONOSPACE
+ * ============================================================ */
 .mono {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
 }
 
-/* --- Status colors --- */
+/* ============================================================
+ * STATUS COLORS
+ * ============================================================ */
 .text-success {
   color: var(--color-success);
 }
@@ -472,20 +588,26 @@
   font-weight: var(--font-weight-semibold);
 }
 
-/* --- Flag content box --- */
+/* ============================================================
+ * FLAG CONTENT BOX
+ * ============================================================ */
 .flag-box {
   margin-bottom: var(--spacing-6);
   padding: var(--spacing-4);
   border: var(--border-width-thin) solid var(--color-border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   background: var(--color-card);
+  box-shadow: var(--shadow-xs);
 }
 
 .flag-box h3 {
   margin-top: 0;
+  font-family: var(--font-heading);
 }
 
-/* --- Save message --- */
+/* ============================================================
+ * SAVE MESSAGE
+ * ============================================================ */
 .save-success {
   margin-inline-start: var(--spacing-3);
   color: var(--color-success);
@@ -496,7 +618,9 @@
   color: var(--color-destructive);
 }
 
-/* --- Audit table cell overflow --- */
+/* ============================================================
+ * AUDIT TABLE
+ * ============================================================ */
 .cell-truncate {
   padding: var(--spacing-2);
   border-bottom: var(--border-width-thin) solid var(--color-border);
@@ -505,11 +629,15 @@
   text-overflow: ellipsis;
 }
 
-/* --- Config audit table --- */
 .audit-th {
   text-align: left;
   padding: var(--spacing-2);
   border-bottom: var(--border-width-thin) solid var(--color-border);
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted-foreground);
 }
 
 .audit-td {
@@ -517,7 +645,9 @@
   border-bottom: var(--border-width-thin) solid var(--color-border);
 }
 
-/* --- Feature flag row --- */
+/* ============================================================
+ * FEATURE FLAG ROW
+ * ============================================================ */
 .flag-row {
   display: flex;
   align-items: center;
@@ -525,7 +655,9 @@
   margin-bottom: var(--spacing-2);
 }
 
-/* --- Graph explorer --- */
+/* ============================================================
+ * GRAPH EXPLORER
+ * ============================================================ */
 .graph-container {
   flex: 1;
   border: var(--border-width-thin) solid var(--color-border);
@@ -557,17 +689,20 @@
 }
 
 .search-dropdown-item {
-  padding: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
   cursor: pointer;
   border-bottom: var(--border-width-thin) solid var(--color-border);
   transition: background-color var(--duration-fast) var(--ease-default);
+  font-size: var(--text-sm);
 }
 
 .search-dropdown-item:hover {
-  background: var(--color-muted);
+  background: var(--color-accent);
 }
 
-/* --- Search result row --- */
+/* ============================================================
+ * SEARCH RESULT ROW
+ * ============================================================ */
 .search-result {
   padding: var(--spacing-3);
   border-bottom: var(--border-width-thin) solid var(--color-border);
@@ -576,10 +711,12 @@
 }
 
 .search-result:hover {
-  background: var(--color-muted);
+  background: var(--color-accent);
 }
 
-/* --- Timeline --- */
+/* ============================================================
+ * TIMELINE
+ * ============================================================ */
 .timeline-controls {
   display: flex;
   gap: var(--spacing-4);
@@ -611,7 +748,9 @@
   font-family: var(--font-heading);
 }
 
-/* --- Collection detail meta --- */
+/* ============================================================
+ * COLLECTION DETAIL
+ * ============================================================ */
 .collection-meta {
   color: var(--color-muted-foreground);
   margin-bottom: var(--spacing-6);
@@ -621,7 +760,9 @@
   margin: 0 var(--spacing-2);
 }
 
-/* --- Narrator detail bio table --- */
+/* ============================================================
+ * NARRATOR DETAIL BIO TABLE
+ * ============================================================ */
 .bio-table {
   border-collapse: collapse;
 }
@@ -629,6 +770,7 @@
 .bio-table td:first-child {
   padding: var(--spacing-1_5) var(--spacing-4) var(--spacing-1_5) 0;
   font-weight: var(--font-weight-semibold);
+  color: var(--color-muted-foreground);
 }
 
 .bio-table td:last-child {
@@ -639,7 +781,9 @@
   border-bottom: var(--border-width-thin) solid var(--color-border);
 }
 
-/* --- Network stat mini-cards --- */
+/* ============================================================
+ * NETWORK STAT MINI-CARDS
+ * ============================================================ */
 .network-stat {
   padding: var(--spacing-3) var(--spacing-4);
   border: var(--border-width-thin) solid var(--color-border);
@@ -653,21 +797,28 @@
 .network-stat-label {
   font-size: var(--text-xs);
   color: var(--color-muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
 }
 
 .network-stat-value {
   font-size: var(--text-xl);
   font-weight: var(--font-weight-semibold);
+  font-family: var(--font-heading);
   color: var(--color-foreground);
 }
 
-/* --- Admin page container --- */
+/* ============================================================
+ * ADMIN PAGE CONTAINER
+ * ============================================================ */
 .admin-page {
   padding: var(--spacing-6);
   max-width: 800px;
 }
 
-/* --- Dark/Light mode toggle --- */
+/* ============================================================
+ * DARK/LIGHT MODE TOGGLE
+ * ============================================================ */
 .theme-toggle {
   display: flex;
   align-items: center;
@@ -680,15 +831,210 @@
   color: var(--color-foreground);
   font-family: var(--font-body);
   font-size: var(--text-sm);
-  transition: background-color var(--duration-fast) var(--ease-default);
+  transition: background-color var(--duration-fast) var(--ease-default),
+    border-color var(--duration-fast) var(--ease-default);
 }
 
 .theme-toggle:hover {
   background: var(--color-muted);
+  border-color: var(--color-primary);
 }
 
-/* --- Selection styling --- */
+/* ============================================================
+ * SELECTION STYLING
+ * ============================================================ */
 ::selection {
   background: var(--color-primary);
   color: var(--color-primary-foreground);
+}
+
+/* ============================================================
+ * SKELETON LOADING — parchment shimmer
+ * Per asset-specifications.md: subtle opacity pulse
+ * ============================================================ */
+.skeleton {
+  background: var(--color-muted);
+  border-radius: var(--radius-md);
+  animation: skeleton-shimmer var(--duration-slower) ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { opacity: 1; }
+  50% { opacity: 0.5; }
+  100% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    opacity: 0.7;
+  }
+}
+
+/* Skeleton variants */
+.skeleton-text {
+  height: 1em;
+  margin-bottom: var(--spacing-2);
+}
+
+.skeleton-heading {
+  height: 1.5em;
+  width: 40%;
+  margin-bottom: var(--spacing-3);
+}
+
+.skeleton-row {
+  height: 2.5rem;
+  margin-bottom: var(--spacing-1);
+}
+
+/* ============================================================
+ * EMPTY STATE
+ * ============================================================ */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-16) var(--spacing-6);
+  text-align: center;
+  color: var(--color-muted-foreground);
+}
+
+.empty-state-icon {
+  margin-bottom: var(--spacing-4);
+  color: var(--color-muted-foreground);
+  opacity: 0.5;
+}
+
+.empty-state-heading {
+  font-family: var(--font-heading);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--text-lg);
+  color: var(--color-foreground);
+  margin-bottom: var(--spacing-2);
+}
+
+.empty-state-body {
+  font-size: var(--text-sm);
+  max-width: 320px;
+  line-height: var(--leading-relaxed);
+}
+
+/* ============================================================
+ * ERROR PAGES (404, 500, 403)
+ * ============================================================ */
+.error-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  text-align: center;
+  padding: var(--spacing-8);
+}
+
+.error-page-code {
+  font-family: var(--font-heading);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-2);
+}
+
+.error-page-title {
+  font-family: var(--font-heading);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-foreground);
+  margin-bottom: var(--spacing-3);
+}
+
+.error-page-body {
+  font-size: var(--text-sm);
+  color: var(--color-muted-foreground);
+  max-width: 400px;
+  margin-bottom: var(--spacing-6);
+  line-height: var(--leading-relaxed);
+}
+
+/* ============================================================
+ * ISLAMIC GEOMETRIC ACCENT — CSS-only decorative borders
+ * Subtle octagonal/diamond motif for section dividers
+ * ============================================================ */
+.geo-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin: var(--spacing-6) 0;
+  color: var(--color-border);
+}
+
+.geo-divider::before,
+.geo-divider::after {
+  content: '';
+  flex: 1;
+  height: var(--border-width-thin);
+  background: var(--color-border);
+}
+
+.geo-divider-diamond {
+  width: 8px;
+  height: 8px;
+  background: var(--color-primary);
+  transform: rotate(45deg);
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+/* Geometric border accent — top or bottom of a container */
+.geo-border-top {
+  border-top: var(--border-width-thick) solid transparent;
+  border-image: repeating-linear-gradient(
+    90deg,
+    var(--color-primary) 0px,
+    var(--color-primary) 8px,
+    transparent 8px,
+    transparent 12px,
+    var(--color-border) 12px,
+    var(--color-border) 14px,
+    transparent 14px,
+    transparent 18px
+  ) 4;
+}
+
+.geo-border-bottom {
+  border-bottom: var(--border-width-thick) solid transparent;
+  border-image: repeating-linear-gradient(
+    90deg,
+    var(--color-primary) 0px,
+    var(--color-primary) 8px,
+    transparent 8px,
+    transparent 12px,
+    var(--color-border) 12px,
+    var(--color-border) 14px,
+    transparent 14px,
+    transparent 18px
+  ) 4;
+}
+
+/* ============================================================
+ * SCROLLBAR — Subtle, Qalam-palette
+ * ============================================================ */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-background);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-muted-foreground);
 }


### PR DESCRIPTION
## Summary

Comprehensive UI polish pass applying the Qalam brand (Proposal A) design system fully across all frontend pages and components.

- **Login page**: centered card with octagonal graph icon, geometric manuscript-inspired border accents, parchment background
- **Sidebar**: navigation icons for all items, active state with inline-start sienna border accent, proper hover states
- **Layout header**: sienna-colored IBM Plex Serif heading with Islamic geometric repeating border-bottom pattern
- **Tables**: uppercase serif column headers, alternating row striping with Qalam palette, accent-colored hover rows
- **Cards/Badges/Buttons**: consistent sizing, pill-shaped badges, proper focus-visible rings, active press states
- **Loading states**: skeleton shimmer screens with `prefers-reduced-motion` fallback
- **Empty states**: structured component (icon + heading + body) per asset specifications
- **Error pages**: styled 404/500/403 pages with manuscript-inspired SVG icons (disconnected graph nodes, broken edges, lock)
- **Islamic geometric patterns**: CSS-only diamond dividers and `repeating-linear-gradient` border-image accents
- **Graph explorer**: replaced all hardcoded hex colors with design token custom properties for dark mode support
- **Page headings**: IBM Plex Serif font with sienna underline consistently across all list pages
- **Scrollbar styling**: subtle Qalam-palette scrollbars
- **Catch-all 404 route** added to React Router

Closes #635

## Test plan

- [ ] Verify login page renders centered card with geometric accents
- [ ] Verify sidebar shows icons and active border accent on current page
- [ ] Verify table striping on Narrators, Hadiths, Collections, Comparative pages
- [ ] Verify skeleton loading shimmer appears before data loads
- [ ] Verify empty state on Narrators page with no search results
- [ ] Navigate to `/nonexistent` and verify styled 404 page
- [ ] Toggle dark mode and verify all pages maintain contrast
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)