### PR TITLE
feat(frontend): branding imagery and iconography

### DIFF
--- a/frontend/public/illustrations/empty-graph.svg
+++ b/frontend/public/illustrations/empty-graph.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Empty graph illustration — disconnected nodes -->
+  <circle cx="20" cy="24" r="4" opacity="0.3"/>
+  <circle cx="48" cy="16" r="4" opacity="0.3"/>
+  <circle cx="76" cy="28" r="4" opacity="0.3"/>
+  <circle cx="28" cy="56" r="4" opacity="0.3"/>
+  <circle cx="60" cy="52" r="4" opacity="0.3"/>
+  <circle cx="44" cy="76" r="4" opacity="0.3"/>
+  <circle cx="72" cy="68" r="4" opacity="0.3"/>
+  <path d="M24 26l20-8" stroke-dasharray="3 4" opacity="0.15"/>
+  <path d="M52 18l20 8" stroke-dasharray="3 4" opacity="0.15"/>
+  <path d="M32 56l24-4" stroke-dasharray="3 4" opacity="0.15"/>
+  <text x="48" y="48" text-anchor="middle" dominant-baseline="central" fill="currentColor" stroke="none" font-size="18" opacity="0.25">?</text>
+</svg>

--- a/frontend/public/illustrations/no-data.svg
+++ b/frontend/public/illustrations/no-data.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- No data illustration — empty manuscript scroll -->
+  <rect x="20" y="14" width="56" height="62" rx="3" stroke-width="1.5"/>
+  <ellipse cx="48" cy="14" rx="28" ry="4" stroke-width="1.5"/>
+  <ellipse cx="48" cy="76" rx="28" ry="4" stroke-width="1.5"/>
+  <path d="M30 30h36" opacity="0.15"/>
+  <path d="M30 38h28" opacity="0.15"/>
+  <path d="M30 46h32" opacity="0.15"/>
+  <path d="M30 54h24" opacity="0.15"/>
+  <path d="M30 62h30" opacity="0.15"/>
+  <path d="M48 42l4 4-4 4-4-4z" fill="currentColor" opacity="0.12" stroke="none"/>
+</svg>

--- a/frontend/public/illustrations/no-results.svg
+++ b/frontend/public/illustrations/no-results.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- No search results illustration -->
+  <g opacity="0.15">
+    <rect x="16" y="16" width="24" height="24" transform="rotate(45 28 28)"/>
+    <rect x="48" y="16" width="24" height="24" transform="rotate(45 60 28)"/>
+    <rect x="16" y="48" width="24" height="24" transform="rotate(45 28 60)"/>
+    <rect x="48" y="48" width="24" height="24" transform="rotate(45 60 60)"/>
+  </g>
+  <circle cx="40" cy="40" r="18" stroke-width="2"/>
+  <path d="M53 53l16 16" stroke-width="3"/>
+  <path d="M34 34l12 12M46 34l-12 12" stroke-width="1.5" opacity="0.5"/>
+</svg>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom'
 import Sidebar from './Sidebar'
 import UserMenu from './UserMenu'
+import { PageHeaderAccent } from './icons/decorative'
 
 export default function Layout() {
   return (
@@ -26,6 +27,7 @@ export default function Layout() {
             flex: 1,
           }}
         >
+          <PageHeaderAccent style={{ display: 'inline-block', verticalAlign: 'middle', marginInlineEnd: 6 }} />
           Isnad Graph
         </h1>
         <span className="small-muted" style={{ fontFamily: 'var(--font-heading)' }}>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,14 +1,26 @@
 import { NavLink } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import {
+  NarratorsIcon,
+  HadithsIcon,
+  CollectionsIcon,
+  SearchIcon,
+  TimelineIcon,
+  CompareIcon,
+  GraphExplorerIcon,
+  AdminIcon,
+  SignOutIcon,
+} from './icons'
+import { GeometricBorder } from './icons/decorative'
 
 const navItems = [
-  { to: '/narrators', label: 'Narrators', icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' },
-  { to: '/hadiths', label: 'Hadiths', icon: 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253' },
-  { to: '/collections', label: 'Collections', icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10' },
-  { to: '/search', label: 'Search', icon: 'M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z' },
-  { to: '/timeline', label: 'Timeline', icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z' },
-  { to: '/compare', label: 'Compare', icon: 'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5' },
-  { to: '/graph', label: 'Graph Explorer', icon: 'M7.5 3.75H6A2.25 2.25 0 003.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0120.25 6v1.5m0 9V18A2.25 2.25 0 0118 20.25h-1.5m-9 0H6A2.25 2.25 0 013.75 18v-1.5M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
+  { to: '/narrators', label: 'Narrators', Icon: NarratorsIcon },
+  { to: '/hadiths', label: 'Hadiths', Icon: HadithsIcon },
+  { to: '/collections', label: 'Collections', Icon: CollectionsIcon },
+  { to: '/search', label: 'Search', Icon: SearchIcon },
+  { to: '/timeline', label: 'Timeline', Icon: TimelineIcon },
+  { to: '/compare', label: 'Compare', Icon: CompareIcon },
+  { to: '/graph', label: 'Graph Explorer', Icon: GraphExplorerIcon },
 ]
 
 export default function Sidebar() {
@@ -49,20 +61,7 @@ export default function Sidebar() {
                 transition: 'all var(--duration-fast) var(--ease-default)',
               })}
             >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-                style={{ flexShrink: 0, opacity: 0.7 }}
-              >
-                <path d={item.icon} />
-              </svg>
+              <item.Icon size={16} style={{ flexShrink: 0, opacity: 0.7 }} />
               {item.label}
             </NavLink>
           </li>
@@ -94,34 +93,18 @@ export default function Sidebar() {
                   : '3px solid transparent',
               })}
             >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-                style={{ flexShrink: 0, opacity: 0.7 }}
-              >
-                <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
+              <AdminIcon size={16} style={{ flexShrink: 0, opacity: 0.7 }} />
               Admin Dashboard
             </NavLink>
           </li>
         )}
       </ul>
 
+      {/* Geometric divider above user section */}
+      <GeometricBorder style={{ marginBottom: 'var(--spacing-3)' }} />
+
       {user && (
-        <div
-          style={{
-            paddingTop: 'var(--spacing-4)',
-            borderTop: 'var(--border-width-thin) solid var(--color-border)',
-          }}
-        >
+        <div>
           <div
             style={{
               fontSize: 'var(--text-xs)',
@@ -160,21 +143,7 @@ export default function Sidebar() {
               e.currentTarget.style.background = 'transparent'
             }}
           >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-              <polyline points="16 17 21 12 16 7" />
-              <line x1="21" y1="12" x2="9" y2="12" />
-            </svg>
+            <SignOutIcon size={16} />
             Sign out
           </button>
         </div>

--- a/frontend/src/components/icons/decorative.tsx
+++ b/frontend/src/components/icons/decorative.tsx
@@ -1,0 +1,108 @@
+/**
+ * Decorative SVG elements — Islamic geometric patterns.
+ *
+ * All elements use currentColor, work in light/dark mode,
+ * and are inline-friendly.
+ */
+import type { SVGProps } from 'react'
+
+/**
+ * Repeating Islamic geometric border pattern.
+ * Renders as a horizontal divider with interlocking octagonal motifs.
+ * Width fills container; height is fixed at 12px.
+ */
+export function GeometricBorder({
+  className,
+  style,
+  ...props
+}: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 200 12"
+      preserveAspectRatio="none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="0.8"
+      aria-hidden="true"
+      className={className}
+      style={{ width: '100%', height: 12, opacity: 0.3, ...style }}
+      {...props}
+    >
+      {/* Repeating octagonal / interlocking diamond pattern */}
+      <defs>
+        <pattern id="geo-border-pat" x="0" y="0" width="20" height="12" patternUnits="userSpaceOnUse">
+          {/* Diamond */}
+          <path d="M10 1l4 5-4 5-4-5z" />
+          {/* Connecting lines */}
+          <path d="M0 6h6M14 6h6" />
+          {/* Small accent squares at intersections */}
+          <rect x="9" y="5" width="2" height="2" fill="currentColor" opacity="0.4" transform="rotate(45 10 6)" />
+        </pattern>
+      </defs>
+      <rect width="200" height="12" fill="url(#geo-border-pat)" stroke="none" />
+    </svg>
+  )
+}
+
+/**
+ * Octagonal frame — wraps content (like a logo) in an octagonal border.
+ * Meant to be sized via CSS on the container.
+ */
+export function OctagonalFrame({
+  className,
+  style,
+  ...props
+}: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      className={className}
+      style={{ opacity: 0.5, ...style }}
+      {...props}
+    >
+      {/* Outer octagon */}
+      <polygon points="30,2 70,2 98,30 98,70 70,98 30,98 2,70 2,30" />
+      {/* Inner octagon */}
+      <polygon points="35,10 65,10 90,35 90,65 65,90 35,90 10,65 10,35" strokeDasharray="4 3" strokeWidth="1" />
+      {/* Corner accent diamonds */}
+      <path d="M15 15l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+      <path d="M85 15l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+      <path d="M15 85l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+      <path d="M85 85l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+    </svg>
+  )
+}
+
+/**
+ * Page header geometric accent — small decorative element
+ * that sits beside page titles. Renders an interlocking
+ * geometric motif inspired by Islamic tilework.
+ */
+export function PageHeaderAccent({
+  className,
+  style,
+  ...props
+}: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 32 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1"
+      aria-hidden="true"
+      className={className}
+      style={{ width: 32, height: 24, opacity: 0.35, ...style }}
+      {...props}
+    >
+      {/* Interlocking squares forming 8-pointed star fragment */}
+      <rect x="8" y="4" width="16" height="16" rx="1" transform="rotate(0 16 12)" />
+      <rect x="8" y="4" width="16" height="16" rx="1" transform="rotate(45 16 12)" />
+      {/* Center dot */}
+      <circle cx="16" cy="12" r="1.5" fill="currentColor" stroke="none" opacity="0.5" />
+    </svg>
+  )
+}

--- a/frontend/src/components/icons/empty-states.tsx
+++ b/frontend/src/components/icons/empty-states.tsx
@@ -1,0 +1,156 @@
+/**
+ * Empty state illustrations for Isnad Graph.
+ *
+ * Larger SVG illustrations (80-120px) for empty/error/no-data states.
+ * Use currentColor for automatic theme adaptation.
+ */
+import type { SVGProps } from 'react'
+
+type IllustrationProps = SVGProps<SVGSVGElement> & { size?: number }
+
+function Illustration({ size = 96, ...props }: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 96 96"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    />
+  )
+}
+
+/** No search results — magnifying glass over empty geometric pattern */
+export function NoResultsIllustration(props: IllustrationProps) {
+  return (
+    <Illustration {...props}>
+      {/* Background geometric pattern (faded) */}
+      <g opacity="0.15">
+        <rect x="16" y="16" width="24" height="24" transform="rotate(45 28 28)" />
+        <rect x="48" y="16" width="24" height="24" transform="rotate(45 60 28)" />
+        <rect x="16" y="48" width="24" height="24" transform="rotate(45 28 60)" />
+        <rect x="48" y="48" width="24" height="24" transform="rotate(45 60 60)" />
+      </g>
+      {/* Magnifying glass */}
+      <circle cx="40" cy="40" r="18" strokeWidth="2" />
+      <path d="M53 53l16 16" strokeWidth="3" />
+      {/* X inside lens */}
+      <path d="M34 34l12 12M46 34l-12 12" strokeWidth="1.5" opacity="0.5" />
+    </Illustration>
+  )
+}
+
+/** Empty graph — disconnected nodes with no edges */
+export function EmptyGraphIllustration(props: IllustrationProps) {
+  return (
+    <Illustration {...props}>
+      {/* Scattered nodes */}
+      <circle cx="20" cy="24" r="4" opacity="0.3" />
+      <circle cx="48" cy="16" r="4" opacity="0.3" />
+      <circle cx="76" cy="28" r="4" opacity="0.3" />
+      <circle cx="28" cy="56" r="4" opacity="0.3" />
+      <circle cx="60" cy="52" r="4" opacity="0.3" />
+      <circle cx="44" cy="76" r="4" opacity="0.3" />
+      <circle cx="72" cy="68" r="4" opacity="0.3" />
+      {/* Dashed lines suggesting missing connections */}
+      <path d="M24 26l20-8" strokeDasharray="3 4" opacity="0.15" />
+      <path d="M52 18l20 8" strokeDasharray="3 4" opacity="0.15" />
+      <path d="M32 56l24-4" strokeDasharray="3 4" opacity="0.15" />
+      {/* Central question mark */}
+      <text
+        x="48"
+        y="48"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="currentColor"
+        stroke="none"
+        fontSize="18"
+        fontFamily="var(--font-heading)"
+        opacity="0.25"
+      >
+        ?
+      </text>
+    </Illustration>
+  )
+}
+
+/** No data — empty scroll/manuscript */
+export function NoDataIllustration(props: IllustrationProps) {
+  return (
+    <Illustration {...props}>
+      {/* Scroll body */}
+      <rect x="20" y="14" width="56" height="62" rx="3" strokeWidth="1.5" />
+      {/* Scroll top roll */}
+      <ellipse cx="48" cy="14" rx="28" ry="4" strokeWidth="1.5" />
+      {/* Scroll bottom roll */}
+      <ellipse cx="48" cy="76" rx="28" ry="4" strokeWidth="1.5" />
+      {/* Empty text lines (ghosted) */}
+      <path d="M30 30h36" opacity="0.15" />
+      <path d="M30 38h28" opacity="0.15" />
+      <path d="M30 46h32" opacity="0.15" />
+      <path d="M30 54h24" opacity="0.15" />
+      <path d="M30 62h30" opacity="0.15" />
+      {/* Decorative diamond in center */}
+      <path d="M48 42l4 4-4 4-4-4z" fill="currentColor" opacity="0.12" stroke="none" />
+    </Illustration>
+  )
+}
+
+/**
+ * Empty state container — wraps an illustration with a message.
+ * Pure layout component, no styling opinions beyond centering.
+ */
+export function EmptyState({
+  illustration,
+  title,
+  description,
+}: {
+  illustration: React.ReactNode
+  title: string
+  description?: string
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 'var(--spacing-4)',
+        padding: 'var(--spacing-12) var(--spacing-6)',
+        textAlign: 'center',
+        color: 'var(--color-muted-foreground)',
+      }}
+    >
+      {illustration}
+      <h3
+        style={{
+          margin: 0,
+          fontSize: 'var(--text-lg)',
+          fontFamily: 'var(--font-heading)',
+          fontWeight: 500,
+          color: 'var(--color-foreground)',
+        }}
+      >
+        {title}
+      </h3>
+      {description && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--text-sm)',
+            maxWidth: 320,
+            lineHeight: 'var(--leading-relaxed)',
+          }}
+        >
+          {description}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -1,0 +1,185 @@
+/**
+ * Qalam-aesthetic icon set for Isnad Graph.
+ *
+ * All icons:
+ *  - 24x24 viewBox, stroke-based with currentColor
+ *  - Work in light and dark mode
+ *  - Inline-friendly (no external references)
+ *  - Include Islamic geometric accents where appropriate
+ */
+import type { SVGProps } from 'react'
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number }
+
+function Icon({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    />
+  )
+}
+
+/** Narrators — scholar/person with turban silhouette accent */
+export function NarratorsIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Head */}
+      <circle cx="12" cy="7" r="4" />
+      {/* Shoulders */}
+      <path d="M5 21v-2a7 7 0 0 1 14 0v2" />
+      {/* Small diamond accent at collar — Islamic geometric motif */}
+      <path d="M12 15l1.2 1.2L12 17.4l-1.2-1.2z" fill="currentColor" stroke="none" />
+    </Icon>
+  )
+}
+
+/** Hadiths — open manuscript/scroll */
+export function HadithsIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Open book body */}
+      <path d="M2 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />
+      <path d="M12 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />
+      {/* Spine */}
+      <path d="M12 4v16" />
+      {/* Text lines on left page */}
+      <path d="M5 8h3" strokeWidth="1" opacity="0.5" />
+      <path d="M5 11h3" strokeWidth="1" opacity="0.5" />
+    </Icon>
+  )
+}
+
+/** Collections — library/bookshelf with geometric shelf brackets */
+export function CollectionsIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Shelf */}
+      <path d="M3 21h18" />
+      <path d="M3 13h18" />
+      {/* Books on top shelf */}
+      <rect x="5" y="5" width="3" height="8" rx="0.5" />
+      <rect x="9" y="3" width="2.5" height="10" rx="0.5" />
+      <rect x="12.5" y="6" width="3" height="7" rx="0.5" />
+      <rect x="16.5" y="4" width="2.5" height="9" rx="0.5" />
+      {/* Books on bottom shelf */}
+      <rect x="5" y="14" width="4" height="7" rx="0.5" />
+      <rect x="10" y="15" width="3" height="6" rx="0.5" />
+      <rect x="14" y="14" width="3" height="7" rx="0.5" />
+      {/* Geometric bracket accents */}
+      <path d="M3 13l1-1 1 1" strokeWidth="1" opacity="0.5" />
+      <path d="M19 13l1-1 1 1" strokeWidth="1" opacity="0.5" />
+    </Icon>
+  )
+}
+
+/** Search — magnifying glass with 4-fold star in lens */
+export function SearchIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Lens */}
+      <circle cx="11" cy="11" r="7" />
+      {/* Handle */}
+      <path d="M21 21l-4.35-4.35" />
+      {/* 4-pointed star motif inside lens */}
+      <path
+        d="M11 7l1 2.5L14.5 11l-2.5 1L11 14.5l-1-2.5L7.5 11l2.5-1z"
+        fill="currentColor"
+        stroke="none"
+        opacity="0.35"
+      />
+    </Icon>
+  )
+}
+
+/** Timeline — horizontal timeline with crescent markers */
+export function TimelineIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Horizontal line */}
+      <path d="M3 12h18" />
+      {/* Timeline nodes */}
+      <circle cx="6" cy="12" r="1.5" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />
+      <circle cx="18" cy="12" r="1.5" fill="currentColor" stroke="none" />
+      {/* Crescent accent above center node */}
+      <path d="M10.5 7a2.5 2.5 0 0 1 3 0" />
+      <path d="M11 7.2a1.8 1.8 0 0 0 2 0" />
+      {/* Tick marks */}
+      <path d="M6 9v-2" strokeWidth="1" opacity="0.4" />
+      <path d="M18 9v-2" strokeWidth="1" opacity="0.4" />
+    </Icon>
+  )
+}
+
+/** Compare — split/diff with geometric separator */
+export function CompareIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Left panel */}
+      <rect x="2" y="3" width="8" height="18" rx="1" />
+      {/* Right panel */}
+      <rect x="14" y="3" width="8" height="18" rx="1" />
+      {/* Connecting arrows */}
+      <path d="M10 8h4" />
+      <path d="M14 8l-1.5-1.5M14 8l-1.5 1.5" />
+      <path d="M14 16h-4" />
+      <path d="M10 16l1.5-1.5M10 16l1.5 1.5" />
+      {/* Diamond separator accent */}
+      <path d="M12 11l1 1-1 1-1-1z" fill="currentColor" stroke="none" opacity="0.5" />
+    </Icon>
+  )
+}
+
+/** Graph Explorer — network constellation with nodes and edges */
+export function GraphExplorerIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Central node */}
+      <circle cx="12" cy="12" r="2.5" />
+      {/* Outer nodes */}
+      <circle cx="5" cy="6" r="1.5" />
+      <circle cx="19" cy="6" r="1.5" />
+      <circle cx="5" cy="18" r="1.5" />
+      <circle cx="19" cy="18" r="1.5" />
+      {/* Edges connecting to center */}
+      <path d="M6.3 7.2L9.7 10.2" />
+      <path d="M17.7 7.2L14.3 10.2" />
+      <path d="M6.3 16.8L9.7 13.8" />
+      <path d="M17.7 16.8L14.3 13.8" />
+      {/* Cross-edges for network feel */}
+      <path d="M6.5 6h11" strokeDasharray="2 2" strokeWidth="1" opacity="0.3" />
+    </Icon>
+  )
+}
+
+/** Admin — gear with octagonal geometric accent */
+export function AdminIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      {/* Gear outer — octagonal shape for Islamic geometric feel */}
+      <path d="M12 2l2.2 1.3 2.5-.3 1.3 2.2 2.5.3.3 2.5 2.2 1.3L22 12l1.3 2.2-.3 2.5-2.2 1.3-.3 2.5-2.5.3-1.3 2.2-2.5-.3L12 22l-2.2-1.3-2.5.3-1.3-2.2-2.5-.3-.3-2.5L1 14.7 2 12 .7 9.3l.3-2.5 2.2-1.3.3-2.5 2.5-.3L7.3 2.7l2.5.3z" strokeWidth="1.2" />
+      {/* Inner circle */}
+      <circle cx="12" cy="12" r="3" />
+    </Icon>
+  )
+}
+
+/** Sign out — door with arrow */
+export function SignOutIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </Icon>
+  )
+}


### PR DESCRIPTION
## Summary
- Add cohesive Qalam-aesthetic icon set for all sidebar navigation items (Narrators, Hadiths, Collections, Search, Timeline, Compare, Graph Explorer, Admin) with Islamic geometric accent motifs (diamonds, stars, octagonal shapes)
- Add decorative SVG components: `GeometricBorder` (repeating interlocking diamond pattern), `OctagonalFrame` (for logo wrapping), `PageHeaderAccent` (tilework-inspired element for page titles)
- Add empty state illustrations: no results (magnifying glass over geometric grid), empty graph (disconnected nodes), no data (empty manuscript scroll) — available as both React components and static SVGs in `public/illustrations/`
- Update Sidebar to use new icon components with geometric border divider above user section
- Add geometric accent to Layout header beside "Isnad Graph" title

All SVGs use `currentColor` for automatic light/dark mode theming, are inline-friendly, and follow WCAG accessibility guidelines (`aria-hidden`, sufficient contrast via opacity).

Closes #653

## Test plan
- [ ] Verify sidebar renders with new icons in both light and dark mode
- [ ] Confirm geometric border divider appears above user section in sidebar
- [ ] Confirm PageHeaderAccent renders beside "Isnad Graph" in header
- [ ] Test empty state illustrations render at correct size and adapt to theme
- [ ] Verify no TypeScript compilation errors (`tsc --noEmit` passes)
- [ ] Visual check that icons scale correctly at 16px default size
- [ ] Test with prefers-reduced-motion — no animations to disable, static SVGs only

Co-Authored-By: Sable Nakamura-Whitfield <parametrization+Sable.Nakamura-Whitfield@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>