### PR TITLE
fix(api): collections endpoint 500 on missing Neo4j fields

### DIFF
--- a/src/api/routes/collections.py
+++ b/src/api/routes/collections.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
@@ -9,6 +11,26 @@ from src.api.models import CollectionResponse, PaginatedResponse
 from src.utils.neo4j_client import Neo4jClient
 
 router = APIRouter()
+
+
+def _row_to_response(props: dict[str, Any]) -> CollectionResponse:
+    """Build a CollectionResponse from Neo4j node properties.
+
+    Uses ``.get()`` with defaults so that missing or null properties on the
+    Neo4j node don't cause a Pydantic validation error (500).
+    """
+    return CollectionResponse(
+        id=props.get("id", ""),
+        name_ar=props.get("name_ar", ""),
+        name_en=props.get("name_en", ""),
+        compiler_name=props.get("compiler_name"),
+        compiler_id=props.get("compiler_id"),
+        compilation_year_ah=props.get("compilation_year_ah"),
+        sect=props.get("sect", ""),
+        canonical_rank=props.get("canonical_rank"),
+        total_hadiths=props.get("total_hadiths"),
+        book_count=props.get("book_count"),
+    )
 
 
 @router.get("/collections", response_model=PaginatedResponse[CollectionResponse])
@@ -29,7 +51,7 @@ def list_collections(
         "MATCH (c:Collection) RETURN properties(c) AS props ORDER BY c.id SKIP $skip LIMIT $limit",
         {"skip": skip, "limit": limit},
     )
-    items = [CollectionResponse(**row["props"]) for row in rows]
+    items = [_row_to_response(row["props"]) for row in rows]
     return PaginatedResponse[CollectionResponse](items=items, total=total, page=page, limit=limit)
 
 
@@ -45,4 +67,4 @@ def get_collection(
     )
     if not rows:
         raise HTTPException(status_code=404, detail=f"Collection '{collection_id}' not found")
-    return CollectionResponse(**rows[0]["props"])
+    return _row_to_response(rows[0]["props"])

--- a/tests/test_api/test_collections.py
+++ b/tests/test_api/test_collections.py
@@ -45,6 +45,35 @@ def test_get_collection_found(client: TestClient, mock_neo4j: MagicMock) -> None
     assert resp.json()["id"] == "col-001"
 
 
+def test_list_collections_with_extra_and_missing_props(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Collections with extra Neo4j props or missing optional fields don't 500."""
+    props = {
+        "id": "col:bukhari",
+        "name_ar": "صحيح البخاري",
+        "name_en": "Sahih al-Bukhari",
+        "sect": "sunni",
+        "source_corpus": "bukhari",  # extra field not in CollectionResponse
+    }
+    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [{"props": props}]]
+    resp = client.get("/api/v1/collections")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["id"] == "col:bukhari"
+    assert "source_corpus" not in body["items"][0]
+
+
+def test_list_collections_null_sect(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """A collection node missing the sect property should not cause a 500."""
+    props = {"id": "col:test", "name_ar": "اختبار", "name_en": "Test"}
+    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [{"props": props}]]
+    resp = client.get("/api/v1/collections")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["sect"] == ""
+
+
 def test_get_collection_not_found(client: TestClient) -> None:
     """GET /api/v1/collections/{id} returns 404 when not found."""
     resp = client.get("/api/v1/collections/nonexistent")


### PR DESCRIPTION
## Summary
- The collections API endpoint (`GET /api/v1/collections`) threw a 500 Internal Server Error when Neo4j `Collection` nodes had missing or null required fields (e.g. `sect`, `name_ar`, `name_en`)
- Root cause: `properties(c)` was unpacked directly into `CollectionResponse(**row["props"])`, and Pydantic validation failed on missing required `str` fields
- Fixed by extracting a `_row_to_response()` helper that uses `.get()` with safe defaults, matching the defensive pattern already used in `admin/users.py`
- Added two new tests covering the null-field and extra-property scenarios

## Test plan
- [x] Existing 4 collection tests still pass
- [x] New test: collection with extra Neo4j properties (e.g. `source_corpus`) returns 200 without leaking extra fields
- [x] New test: collection missing `sect` property returns 200 with empty string default
- [x] Full test suite: 867 passed
- [x] Lint + format + mypy all pass

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)