### PR TITLE
feat(frontend): NoorinaLabs header + Isnad Graph home page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import UsageAnalyticsPage from './pages/admin/UsageAnalyticsPage'
 import ModerationPage from './pages/admin/ModerationPage'
 import ReportsPage from './pages/admin/ReportsPage'
 import ConfigPage from './pages/admin/ConfigPage'
+import HomePage from './pages/HomePage'
 import NotFoundPage from './pages/NotFoundPage'
 
 const queryClient = new QueryClient({
@@ -48,7 +49,7 @@ export default function App() {
             {/* Authenticated routes */}
             <Route element={<ProtectedRoute />}>
               <Route element={<Layout />}>
-                <Route index element={<Navigate to="/narrators" replace />} />
+                <Route index element={<HomePage />} />
                 <Route path="narrators" element={<NarratorsPage />} />
                 <Route path="narrators/:id" element={<NarratorDetailPage />} />
                 <Route path="hadiths" element={<HadithsPage />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom'
+import { Link, Outlet } from 'react-router-dom'
 import Sidebar from './Sidebar'
 import UserMenu from './UserMenu'
 import { PageHeaderAccent } from './icons/decorative'
@@ -16,20 +16,64 @@ export default function Layout() {
           background: 'var(--color-card)',
         }}
       >
-        <h1
+        <div
           style={{
-            margin: 0,
-            fontSize: 'var(--text-xl)',
-            fontFamily: 'var(--font-heading)',
-            fontWeight: 600,
-            color: 'var(--color-primary)',
-            letterSpacing: 'var(--tracking-tight)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--spacing-3)',
             flex: 1,
           }}
         >
-          <PageHeaderAccent style={{ display: 'inline-block', verticalAlign: 'middle', marginInlineEnd: 6 }} />
-          Isnad Graph
-        </h1>
+          <PageHeaderAccent style={{ display: 'inline-block', verticalAlign: 'middle' }} />
+          <a
+            href="https://www.noorinalabs.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              margin: 0,
+              fontSize: 'var(--text-lg)',
+              fontFamily: 'var(--font-heading)',
+              fontWeight: 400,
+              color: 'var(--color-muted-foreground)',
+              letterSpacing: 'var(--tracking-tight)',
+              textDecoration: 'none',
+              transition: 'color var(--duration-fast) var(--ease-default)',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.color = 'var(--color-primary)'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.color = 'var(--color-muted-foreground)'
+            }}
+          >
+            NoorinaLabs
+          </a>
+          <span
+            style={{
+              color: 'var(--color-border)',
+              fontSize: 'var(--text-lg)',
+              fontWeight: 300,
+              userSelect: 'none',
+            }}
+            aria-hidden="true"
+          >
+            |
+          </span>
+          <Link
+            to="/"
+            style={{
+              margin: 0,
+              fontSize: 'var(--text-xl)',
+              fontFamily: 'var(--font-heading)',
+              fontWeight: 600,
+              color: 'var(--color-primary)',
+              letterSpacing: 'var(--tracking-tight)',
+              textDecoration: 'none',
+            }}
+          >
+            Isnad Graph
+          </Link>
+        </div>
         <span className="small-muted" style={{ fontFamily: 'var(--font-heading)' }}>
           Hadith Analysis Platform
         </span>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,210 @@
+import { Link } from 'react-router-dom'
+import {
+  GraphExplorerIcon,
+  SearchIcon,
+  CompareIcon,
+  TimelineIcon,
+  CollectionsIcon,
+  NarratorsIcon,
+  HadithsIcon,
+} from '../components/icons'
+import { GeometricBorder } from '../components/icons/decorative'
+
+const features = [
+  {
+    to: '/graph',
+    Icon: GraphExplorerIcon,
+    title: 'Graph Explorer',
+    description: 'Visualize narrator networks and isnad chains as interactive graphs.',
+  },
+  {
+    to: '/search',
+    Icon: SearchIcon,
+    title: 'Search',
+    description: 'Full-text and semantic search across hadith texts and narrators.',
+  },
+  {
+    to: '/compare',
+    Icon: CompareIcon,
+    title: 'Comparative Analysis',
+    description: 'Detect parallel hadiths across Sunni and Shia collections.',
+  },
+  {
+    to: '/timeline',
+    Icon: TimelineIcon,
+    title: 'Timeline',
+    description: 'Explore narrators and transmission events across historical periods.',
+  },
+  {
+    to: '/collections',
+    Icon: CollectionsIcon,
+    title: 'Collections',
+    description: 'Browse major hadith compilations and their contents.',
+  },
+]
+
+const quickLinks = [
+  { to: '/narrators', Icon: NarratorsIcon, label: 'Browse Narrators' },
+  { to: '/hadiths', Icon: HadithsIcon, label: 'Browse Hadiths' },
+  { to: '/graph', Icon: GraphExplorerIcon, label: 'Open Graph Explorer' },
+  { to: '/search', Icon: SearchIcon, label: 'Search' },
+]
+
+export default function HomePage() {
+  return (
+    <div style={{ maxWidth: 900, margin: '0 auto' }}>
+      {/* Hero */}
+      <section style={{ marginBottom: 'var(--spacing-8)' }}>
+        <h1
+          style={{
+            fontFamily: 'var(--font-heading)',
+            fontSize: 'var(--text-2xl)',
+            fontWeight: 600,
+            color: 'var(--color-foreground)',
+            marginBottom: 'var(--spacing-3)',
+            letterSpacing: 'var(--tracking-tight)',
+          }}
+        >
+          Isnad Graph &mdash; Hadith Analysis Platform
+        </h1>
+        <p
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 'var(--text-base)',
+            color: 'var(--color-muted-foreground)',
+            lineHeight: 1.6,
+            maxWidth: 680,
+          }}
+        >
+          A computational platform for analyzing hadith chains of narration (isnad).
+          Explore narrator networks, detect cross-collection parallels, and study
+          transmission topology across Sunni and Shia hadith literature using graph
+          analysis and semantic search.
+        </p>
+      </section>
+
+      <GeometricBorder style={{ marginBottom: 'var(--spacing-8)' }} />
+
+      {/* Feature cards */}
+      <section style={{ marginBottom: 'var(--spacing-8)' }}>
+        <h2
+          style={{
+            fontFamily: 'var(--font-heading)',
+            fontSize: 'var(--text-lg)',
+            fontWeight: 600,
+            color: 'var(--color-foreground)',
+            marginBottom: 'var(--spacing-4)',
+          }}
+        >
+          Key Features
+        </h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+            gap: 'var(--spacing-4)',
+          }}
+        >
+          {features.map((f) => (
+            <Link
+              key={f.to}
+              to={f.to}
+              style={{
+                textDecoration: 'none',
+                color: 'inherit',
+                padding: 'var(--spacing-5)',
+                borderRadius: 'var(--radius-lg)',
+                border: 'var(--border-width-thin) solid var(--color-border)',
+                background: 'var(--color-card)',
+                transition: 'border-color var(--duration-fast) var(--ease-default), box-shadow var(--duration-fast) var(--ease-default)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = 'var(--color-primary)'
+                e.currentTarget.style.boxShadow = '0 2px 8px rgba(0,0,0,0.08)'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = 'var(--color-border)'
+                e.currentTarget.style.boxShadow = 'none'
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-2)', marginBottom: 'var(--spacing-2)' }}>
+                <f.Icon size={20} style={{ color: 'var(--color-primary)', opacity: 0.8 }} />
+                <h3
+                  style={{
+                    margin: 0,
+                    fontFamily: 'var(--font-heading)',
+                    fontSize: 'var(--text-base)',
+                    fontWeight: 600,
+                    color: 'var(--color-foreground)',
+                  }}
+                >
+                  {f.title}
+                </h3>
+              </div>
+              <p
+                style={{
+                  margin: 0,
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 'var(--text-sm)',
+                  color: 'var(--color-muted-foreground)',
+                  lineHeight: 1.5,
+                }}
+              >
+                {f.description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <GeometricBorder style={{ marginBottom: 'var(--spacing-8)' }} />
+
+      {/* Getting started */}
+      <section>
+        <h2
+          style={{
+            fontFamily: 'var(--font-heading)',
+            fontSize: 'var(--text-lg)',
+            fontWeight: 600,
+            color: 'var(--color-foreground)',
+            marginBottom: 'var(--spacing-4)',
+          }}
+        >
+          Getting Started
+        </h2>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--spacing-3)' }}>
+          {quickLinks.map((link) => (
+            <Link
+              key={link.to}
+              to={link.to}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 'var(--spacing-2)',
+                padding: 'var(--spacing-2) var(--spacing-4)',
+                borderRadius: 'var(--radius-md)',
+                border: 'var(--border-width-thin) solid var(--color-border)',
+                background: 'var(--color-card)',
+                fontFamily: 'var(--font-body)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 500,
+                color: 'var(--color-foreground)',
+                textDecoration: 'none',
+                transition: 'background var(--duration-fast) var(--ease-default)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'var(--color-accent)'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'var(--color-card)'
+              }}
+            >
+              <link.Icon size={16} style={{ opacity: 0.7 }} />
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Header rebranded: "NoorinaLabs" (external link, IBM Plex Serif lighter weight) | "Isnad Graph" (internal link to `/`)
- New `HomePage` with platform description, feature cards (Graph Explorer, Search, Comparative Analysis, Timeline, Collections), and getting started quick links
- Index route now renders `HomePage` instead of redirecting to `/narrators`
- Sidebar correctly has no highlighted item when on the home page
- Uses Qalam design tokens and decorative geometric borders from PR #659

Closes #654

## Test plan
- [ ] Verify header displays "NoorinaLabs | Isnad Graph" with correct links
- [ ] Verify "NoorinaLabs" opens https://www.noorinalabs.com in a new tab
- [ ] Verify "Isnad Graph" navigates to `/` (home page)
- [ ] Verify home page renders with description, feature cards, and quick links
- [ ] Verify all feature card links navigate to correct pages
- [ ] Verify sidebar has no active item highlighted on home page
- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)