### PR TITLE
hotfix(deploy): double-quote .env values for special characters

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,9 +50,9 @@ jobs:
                        AUTH_GITHUB_CLIENT_ID AUTH_GITHUB_CLIENT_SECRET \
                        GRAFANA_ADMIN_PASSWORD; do
               eval "val=\$$var"
-              echo "$var=$val" >> "$env_file"
+              echo "$var=\"$val\"" >> "$env_file"
             done
-            echo "CACHEBUST=$(date +%s)" >> "$env_file"
+            echo "CACHEBUST=\"$(date +%s)\"" >> "$env_file"
             chmod 600 "$env_file"
 
             echo "==> Building and starting services..."


### PR DESCRIPTION
## Summary
Passwords with & and other shell metacharacters broke source .env on the VPS. Now writes all values double-quoted.

## Test plan
- [ ] Deploy succeeds with NEO4J_PASSWORD containing &
- [ ] source .env works on VPS without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
