### PR TITLE
fix: bug(api): collections page throws 500 error

### DIFF
--- a/src/api/routes/collections.py
+++ b/src/api/routes/collections.py
@@ -45,13 +45,29 @@ def list_collections(
     count_rows = neo4j.execute_read(
         "MATCH (c:Collection) RETURN count(c) AS total",
     )
-    total = count_rows[0]["total"] if count_rows else 0
+    total = int((count_rows[0] or {}).get("total", 0)) if count_rows else 0
 
     rows = neo4j.execute_read(
-        "MATCH (c:Collection) RETURN properties(c) AS props ORDER BY c.id SKIP $skip LIMIT $limit",
+        """
+        MATCH (c:Collection)
+        OPTIONAL MATCH (c)-[:HAS_BOOK]->(b:Book)
+        OPTIONAL MATCH (c)-[:HAS_HADITH]->(h:Hadith)
+        WITH c, count(DISTINCT b) AS book_count, count(DISTINCT h) AS hadith_count
+        RETURN properties(c) + {
+            book_count: coalesce(c.book_count, book_count),
+            total_hadiths: coalesce(c.total_hadiths, hadith_count),
+            sect: coalesce(c.sect, ''),
+            name_ar: coalesce(c.name_ar, ''),
+            name_en: coalesce(c.name_en, ''),
+            id: coalesce(c.id, '')
+        } AS props
+        ORDER BY c.id
+        SKIP $skip
+        LIMIT $limit
+        """,
         {"skip": skip, "limit": limit},
     )
-    items = [_row_to_response(row["props"]) for row in rows]
+    items = [_row_to_response((row or {}).get("props") or {}) for row in rows]
     return PaginatedResponse[CollectionResponse](items=items, total=total, page=page, limit=limit)
 
 
@@ -62,9 +78,22 @@ def get_collection(
 ) -> CollectionResponse:
     """Return a single collection by ID."""
     rows = neo4j.execute_read(
-        "MATCH (c:Collection {id: $id}) RETURN properties(c) AS props",
+        """
+        MATCH (c:Collection {id: $id})
+        OPTIONAL MATCH (c)-[:HAS_BOOK]->(b:Book)
+        OPTIONAL MATCH (c)-[:HAS_HADITH]->(h:Hadith)
+        WITH c, count(DISTINCT b) AS book_count, count(DISTINCT h) AS hadith_count
+        RETURN properties(c) + {
+            book_count: coalesce(c.book_count, book_count),
+            total_hadiths: coalesce(c.total_hadiths, hadith_count),
+            sect: coalesce(c.sect, ''),
+            name_ar: coalesce(c.name_ar, ''),
+            name_en: coalesce(c.name_en, ''),
+            id: coalesce(c.id, '')
+        } AS props
+        """,
         {"id": collection_id},
     )
     if not rows:
         raise HTTPException(status_code=404, detail=f"Collection '{collection_id}' not found")
-    return _row_to_response(rows[0]["props"])
+    return _row_to_response((rows[0] or {}).get("props") or {})


### PR DESCRIPTION
## Summary
Automated fix for: bug(api): collections page throws 500 error

## Source issue
- Repo: parametrization/isnad-graph
- Issue: https://github.com/parametrization/isnad-graph/issues/655

## Root cause
The endpoint was directly indexing Neo4j row keys (`row["props"]`) and assumed every query result always contains that alias and a non-null dict. In real data/query variations, missing/null alias values can trigger KeyError/TypeError and produce a 500. It also relied only on raw node properties for counts/metadata that may be absent, increasing validation/runtime risk.

## Changes
- Applied patch to `api/routes/collections.py`
- Generated and validated through the coding automation pipeline

## Why this fix
It removes the primary 500 vector by making row/property extraction null-safe everywhere instead of direct indexing. It also guarantees required frontend-facing fields are always present via Cypher `coalesce`, and computes hadith/book counts when not stored on the node. This keeps the existing route signatures/models intact while making list and detail endpoints resilient to partial Neo4j data.

## Validation
- Relevant tests passed locally before PR creation

## Notes
- This PR was opened automatically as a draft for review.
