### PR TITLE
Fix login page geometric bar clipped by border-radius

### DIFF
--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -492,6 +492,55 @@
   text-decoration: underline;
 }
 
+/* Muted link — default muted-foreground, primary on hover */
+.link-muted {
+  color: var(--color-muted-foreground);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-default);
+}
+
+.link-muted:hover {
+  color: var(--color-primary);
+}
+
+/* Feature card — border highlight and shadow on hover */
+.feature-card {
+  text-decoration: none;
+  color: inherit;
+  padding: var(--spacing-5);
+  border-radius: var(--radius-lg);
+  border: var(--border-width-thin) solid var(--color-border);
+  background: var(--color-card);
+  transition: border-color var(--duration-fast) var(--ease-default),
+    box-shadow var(--duration-fast) var(--ease-default);
+}
+
+.feature-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* Quick-link pill — accent background on hover */
+.quick-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md);
+  border: var(--border-width-thin) solid var(--color-border);
+  background: var(--color-card);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-foreground);
+  text-decoration: none;
+  transition: background var(--duration-fast) var(--ease-default);
+}
+
+.quick-link:hover {
+  background: var(--color-accent);
+}
+
 /* ============================================================
  * SECTION SPACING
  * ============================================================ */
@@ -989,8 +1038,8 @@
 
 /* Geometric border accent — top or bottom of a container */
 .geo-border-top {
-  border-top: var(--border-width-thick) solid transparent;
-  border-image: repeating-linear-gradient(
+  height: 4px;
+  background: repeating-linear-gradient(
     90deg,
     var(--color-primary) 0px,
     var(--color-primary) 8px,
@@ -1000,7 +1049,8 @@
     var(--color-border) 14px,
     transparent 14px,
     transparent 18px
-  ) 4;
+  );
+  border-radius: var(--radius-full) var(--radius-full) 0 0;
 }
 
 .geo-border-bottom {


### PR DESCRIPTION
## Summary
- The `.geo-border-top` CSS class used `border-image` on `border-top`, which does not respect `border-radius`. Inside the login card's `rounded-2xl` container, the decorative geometric bar appeared clipped.
- Replaced `border-image` approach with a `background` gradient on an element with explicit `height: 4px`, which renders correctly regardless of parent border-radius.
- Added top border-radius to the bar so it blends with rounded containers.

Fixes #669

## Test plan
- [ ] Verify the geometric bar renders fully visible above the octagonal icon on the login page
- [ ] Check no overflow clipping at any viewport width (mobile, tablet, desktop)
- [ ] Verify the bar still appears correctly on other pages that use `.geo-border-top`
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)