### PR TITLE
Fix search results narrow column layout

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -381,7 +381,7 @@ export default function SearchPage() {
   )
 
   return (
-    <div className="max-w-7xl mx-auto">
+    <div className="w-full max-w-7xl mx-auto">
       <h2 className="page-heading">Search</h2>
 
       {/* Search bar */}


### PR DESCRIPTION
## Summary
- The search page outer container used `max-w-7xl mx-auto` without `w-full`, causing it to shrink to content width instead of filling the available main content area.
- Added `w-full` class so the container stretches to use full available width, allowing the sidebar + results flex layout to render at proper widths.

Fixes #670

## Test plan
- [ ] Verify search results use the full available content width on desktop
- [ ] Verify the filter sidebar + results layout renders correctly at lg breakpoint and above
- [ ] Verify the search bar width is unaffected
- [ ] Test responsive behavior at mobile/tablet widths (filter sidebar hidden, results full-width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)