### PR TITLE
fix(api): deduplicate fulltext count query in narrator search (#678)

### DIFF
--- a/src/api/routes/narrators.py
+++ b/src/api/routes/narrators.py
@@ -27,25 +27,22 @@ def list_narrators(
     skip = (page - 1) * limit
 
     if q:
-        # Use the fulltext index (narrator_search) on [name_ar, name_en].
-        # Wrap in quotes for phrase matching; escape embedded quotes.
+        # Single fulltext query: collect all matches, return total via size()
+        # and paginated slice to avoid executing the fulltext index twice.
         escaped = q.replace("\\", "\\\\").replace('"', '\\"')
         search_term = f'"{escaped}"'
 
-        count_result = neo4j.execute_read(
-            "CALL db.index.fulltext.queryNodes('narrator_search', $term) "
-            "YIELD node RETURN count(node) AS total",
-            {"term": search_term},
-        )
-        total = count_result[0]["total"] if count_result else 0
-
-        rows = neo4j.execute_read(
+        result = neo4j.execute_read(
             "CALL db.index.fulltext.queryNodes('narrator_search', $term) "
             "YIELD node, score "
-            "RETURN properties(node) AS props "
-            "ORDER BY score DESC SKIP $skip LIMIT $limit",
+            "WITH node, score ORDER BY score DESC "
+            "WITH collect({props: properties(node)}) AS all_rows "
+            "RETURN size(all_rows) AS total, "
+            "all_rows[$skip .. $skip + $limit] AS rows",
             {"term": search_term, "skip": skip, "limit": limit},
         )
+        total = result[0]["total"] if result else 0
+        rows = result[0]["rows"] if result else []
     else:
         count_result = neo4j.execute_read(
             "MATCH (n:Narrator) RETURN count(n) AS total",

--- a/tests/test_api/test_narrators.py
+++ b/tests/test_api/test_narrators.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 SAMPLE_NARRATOR = {
     "id": "nar-001",
-    "name_ar": "أبو هريرة",
+    "name_ar": "\u0623\u0628\u0648 \u0647\u0631\u064a\u0631\u0629",
     "name_en": "Abu Hurayra",
     "generation": "companion",
     "gender": "male",
@@ -54,6 +54,52 @@ def test_list_narrators_pagination(client: TestClient, mock_neo4j: MagicMock) ->
     body = resp.json()
     assert body["page"] == 3
     assert body["limit"] == 10
+
+
+def test_list_narrators_fulltext_search(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/narrators?q=... uses single fulltext query for count and results."""
+    mock_neo4j.execute_read.return_value = [
+        {
+            "total": 1,
+            "rows": [{"props": SAMPLE_NARRATOR}],
+        }
+    ]
+    resp = client.get("/api/v1/narrators?q=Abu")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["name_en"] == "Abu Hurayra"
+
+    # Verify only a single execute_read call (no duplicate fulltext query)
+    assert mock_neo4j.execute_read.call_count == 1
+    query = mock_neo4j.execute_read.call_args[0][0]
+    assert "fulltext.queryNodes" in query
+    assert "size(all_rows)" in query
+
+
+def test_list_narrators_fulltext_search_pagination(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Fulltext search paginates correctly with a single query."""
+    mock_neo4j.execute_read.return_value = [
+        {
+            "total": 25,
+            "rows": [{"props": SAMPLE_NARRATOR}],
+        }
+    ]
+    resp = client.get("/api/v1/narrators?q=Abu&page=2&limit=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 25
+    assert body["page"] == 2
+    assert body["limit"] == 10
+
+    # Single query execution
+    assert mock_neo4j.execute_read.call_count == 1
+    params = mock_neo4j.execute_read.call_args[0][1]
+    assert params["skip"] == 10
+    assert params["limit"] == 10
 
 
 def test_get_narrator_found(client: TestClient, mock_neo4j: MagicMock) -> None:


### PR DESCRIPTION
## Summary

- Refactored `/narrators?q=...` endpoint to execute a single fulltext index query instead of two separate calls (one for count, one for paginated results)
- Uses `collect()` + `size()` with list slicing (`all_rows[$skip .. $skip + $limit]`) to get both total count and paginated results in one Cypher query
- Added two new tests covering the fulltext search path and its pagination behavior

## Test plan

- [x] All 7 narrator endpoint tests pass (5 existing + 2 new)
- [x] New `test_list_narrators_fulltext_search` verifies single `execute_read` call with `size(all_rows)` in query
- [x] New `test_list_narrators_fulltext_search_pagination` verifies correct skip/limit params in single query
- [ ] Verify pagination and count still work correctly against real Neo4j with fulltext index

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)