### PR TITLE
Fix separator graphic clipped in header (#671)

### DIFF
--- a/frontend/src/components/icons/decorative.tsx
+++ b/frontend/src/components/icons/decorative.tsx
@@ -89,13 +89,13 @@ export function PageHeaderAccent({
 }: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      viewBox="0 0 32 24"
+      viewBox="-2 -2 36 28"
       fill="none"
       stroke="currentColor"
       strokeWidth="1"
       aria-hidden="true"
       className={className}
-      style={{ width: 32, height: 24, opacity: 0.35, ...style }}
+      style={{ width: 36, height: 28, opacity: 0.35, overflow: 'visible', ...style }}
       {...props}
     >
       {/* Interlocking squares forming 8-pointed star fragment */}


### PR DESCRIPTION
## Summary
- Expanded the `PageHeaderAccent` SVG `viewBox` from `0 0 32 24` to `-2 -2 36 28` to prevent the 45-degree rotated square from being clipped at the viewBox boundary
- Added `overflow: visible` to the SVG inline style as an additional safeguard
- Updated width/height to match the new viewBox dimensions (36x28)

## Test plan
- [ ] Verify the separator graphic between "NoorinaLabs" and "Isnad Graph" in the header renders fully visible with no clipping
- [ ] Check at multiple viewport widths (mobile, tablet, desktop)
- [ ] Confirm no layout shifts or spacing regressions in the header

Fixes #671

Co-Authored-By: Ingrid Lindqvist <parametrization+Ingrid.Lindqvist@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>