### PR TITLE
Extract inline hover styles to CSS classes (#664)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -29,21 +29,13 @@ export default function Layout() {
             href="https://www.noorinalabs.com"
             target="_blank"
             rel="noopener noreferrer"
+            className="link-muted"
             style={{
               margin: 0,
               fontSize: 'var(--text-lg)',
               fontFamily: 'var(--font-heading)',
               fontWeight: 400,
-              color: 'var(--color-muted-foreground)',
               letterSpacing: 'var(--tracking-tight)',
-              textDecoration: 'none',
-              transition: 'color var(--duration-fast) var(--ease-default)',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = 'var(--color-primary)'
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = 'var(--color-muted-foreground)'
             }}
           >
             NoorinaLabs

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -109,23 +109,7 @@ export default function HomePage() {
             <Link
               key={f.to}
               to={f.to}
-              style={{
-                textDecoration: 'none',
-                color: 'inherit',
-                padding: 'var(--spacing-5)',
-                borderRadius: 'var(--radius-lg)',
-                border: 'var(--border-width-thin) solid var(--color-border)',
-                background: 'var(--color-card)',
-                transition: 'border-color var(--duration-fast) var(--ease-default), box-shadow var(--duration-fast) var(--ease-default)',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.borderColor = 'var(--color-primary)'
-                e.currentTarget.style.boxShadow = '0 2px 8px rgba(0,0,0,0.08)'
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.borderColor = 'var(--color-border)'
-                e.currentTarget.style.boxShadow = 'none'
-              }}
+              className="feature-card"
             >
               <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-2)', marginBottom: 'var(--spacing-2)' }}>
                 <f.Icon size={20} style={{ color: 'var(--color-primary)', opacity: 0.8 }} />
@@ -177,27 +161,7 @@ export default function HomePage() {
             <Link
               key={link.to}
               to={link.to}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 'var(--spacing-2)',
-                padding: 'var(--spacing-2) var(--spacing-4)',
-                borderRadius: 'var(--radius-md)',
-                border: 'var(--border-width-thin) solid var(--color-border)',
-                background: 'var(--color-card)',
-                fontFamily: 'var(--font-body)',
-                fontSize: 'var(--text-sm)',
-                fontWeight: 500,
-                color: 'var(--color-foreground)',
-                textDecoration: 'none',
-                transition: 'background var(--duration-fast) var(--ease-default)',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = 'var(--color-accent)'
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = 'var(--color-card)'
-              }}
+              className="quick-link"
             >
               <link.Icon size={16} style={{ opacity: 0.7 }} />
               {link.label}

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -492,6 +492,55 @@
   text-decoration: underline;
 }
 
+/* Muted link — default muted-foreground, primary on hover */
+.link-muted {
+  color: var(--color-muted-foreground);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-default);
+}
+
+.link-muted:hover {
+  color: var(--color-primary);
+}
+
+/* Feature card — border highlight and shadow on hover */
+.feature-card {
+  text-decoration: none;
+  color: inherit;
+  padding: var(--spacing-5);
+  border-radius: var(--radius-lg);
+  border: var(--border-width-thin) solid var(--color-border);
+  background: var(--color-card);
+  transition: border-color var(--duration-fast) var(--ease-default),
+    box-shadow var(--duration-fast) var(--ease-default);
+}
+
+.feature-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* Quick-link pill — accent background on hover */
+.quick-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md);
+  border: var(--border-width-thin) solid var(--color-border);
+  background: var(--color-card);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-foreground);
+  text-decoration: none;
+  transition: background var(--duration-fast) var(--ease-default);
+}
+
+.quick-link:hover {
+  background: var(--color-accent);
+}
+
 /* ============================================================
  * SECTION SPACING
  * ============================================================ */


### PR DESCRIPTION
## Summary
- Extracted 3 inline `onMouseEnter`/`onMouseLeave` hover style mutations to CSS classes in `common.css`
- **`.link-muted`** — NoorinaLabs header link in `Layout.tsx` (color transition from muted-foreground to primary)
- **`.feature-card`** — Feature card links in `HomePage.tsx` (border highlight + box-shadow on hover)
- **`.quick-link`** — Quick-link pill buttons in `HomePage.tsx` (accent background on hover)
- All inline event handlers removed; hover effects now purely CSS-driven

## Test plan
- [ ] Verify NoorinaLabs header link highlights on hover (color changes to primary)
- [ ] Verify feature cards show border highlight and subtle shadow on hover
- [ ] Verify quick-link pills show accent background on hover
- [ ] Confirm hover effects work identically to previous inline behavior
- [ ] Check no visual regressions on homepage at multiple viewport widths

Fixes #664

Co-Authored-By: Ingrid Lindqvist <parametrization+Ingrid.Lindqvist@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>