### PR TITLE
ci(pipeline): add pipeline.yml workflow for data ingestion

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,106 @@
+# Data Pipeline — acquire, parse, validate, resolve, and generate manifest
+#
+# Triggers:
+#   - Manual dispatch (workflow_dispatch)
+#   - Tags matching data-v* (e.g., data-v1.0.0)
+#
+# Required secrets:
+#   - SUNNAH_API_KEY    — Sunnah.com API key for hadith acquisition
+#   - KAGGLE_USERNAME   — Kaggle account username for dataset downloads
+#   - KAGGLE_KEY        — Kaggle API key for dataset downloads
+#   - B2_APPLICATION_KEY_ID  — (future) Backblaze B2 key ID for artifact upload
+#   - B2_APPLICATION_KEY     — (future) Backblaze B2 application key for artifact upload
+
+name: Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'data-v*'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: pipeline-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-${{ runner.os }}-
+
+      - run: uv sync --group ml
+
+      - name: "Stage 1: Acquire raw data"
+        run: uv run isnad acquire
+        env:
+          SUNNAH_API_KEY: ${{ secrets.SUNNAH_API_KEY }}
+          KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+          KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+
+      - name: "Stage 2: Parse to staging Parquet"
+        run: uv run isnad parse
+
+      - name: "Stage 3: Validate staging data"
+        run: uv run isnad validate-staging
+
+      - name: "Stage 4: Entity resolution"
+        run: uv run isnad resolve
+
+      - name: "Stage 5: Generate manifest"
+        run: |
+          python3 -c "
+          import hashlib, json, pathlib, datetime
+
+          manifest = {
+              'generated_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'git_sha': '${GITHUB_SHA}',
+              'git_ref': '${GITHUB_REF}',
+              'files': {}
+          }
+
+          for directory in ['data/staging', 'data/curated']:
+              base = pathlib.Path(directory)
+              if not base.exists():
+                  continue
+              for path in sorted(base.rglob('*')):
+                  if not path.is_file():
+                      continue
+                  sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+                  manifest['files'][str(path)] = {
+                      'sha256': sha256,
+                      'size_bytes': path.stat().st_size,
+                  }
+
+          pathlib.Path('.manifest.json').write_text(
+              json.dumps(manifest, indent=2) + '\n'
+          )
+          print(f'Manifest generated: {len(manifest[\"files\"])} files')
+          "
+
+      - name: Upload manifest as artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pipeline-manifest
+          path: .manifest.json
+
+      # TODO: #685 will implement B2 upload
+      # This step will upload staging/curated data and the manifest to
+      # Backblaze B2 for durable storage and VPS-side restore.
+      # Required secrets: B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY
+      - name: "Upload to Backblaze B2 (placeholder)"
+        if: false
+        run: echo "B2 upload not yet implemented — see issue #685"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-hooks hooks infra infra-down infra-reset acquire parse resolve load enrich test test-integration sample-data lint typecheck format clean clean-worktrees pipeline pipeline-full pipeline-bootstrap pipeline-load validate validate-staging validate-pipeline profile-data test-e2e test-e2e-headed check backup restore
+.PHONY: help setup setup-hooks hooks infra infra-down infra-reset acquire parse resolve load enrich test test-integration sample-data lint typecheck format clean clean-worktrees pipeline pipeline-ci pipeline-full pipeline-bootstrap pipeline-load validate validate-staging validate-pipeline profile-data test-e2e test-e2e-headed check backup restore
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -105,6 +105,12 @@ pipeline-full: ## Run full pipeline with orchestration, logging, and error handl
 
 pipeline-bootstrap: ## One-time VPS bootstrap: full pipeline with manifest generation
 	ENVIRONMENT=production bash scripts/run_full_pipeline.sh --generate-manifest
+
+pipeline-ci: ## Run CI pipeline stages (acquire, parse, validate-staging, resolve)
+	$(MAKE) acquire
+	$(MAKE) parse
+	$(MAKE) validate-staging
+	$(MAKE) resolve
 
 pipeline-load: ## VPS-side only: load + enrich from existing staging/curated data
 	ENVIRONMENT=production bash scripts/run_full_pipeline.sh --only-load --generate-manifest


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pipeline.yml` triggered by `workflow_dispatch` and `data-v*` tags
- Runs pipeline stages in order: acquire, parse, validate-staging, resolve
- Generates `.manifest.json` with SHA256 hashes of all staging/curated files, uploaded as artifact
- B2 upload step is a clearly marked placeholder for #685
- Add `make pipeline-ci` Makefile target mirroring the CI pipeline stages

## Secrets required
- `SUNNAH_API_KEY` — Sunnah.com API
- `KAGGLE_USERNAME` / `KAGGLE_KEY` — Kaggle datasets
- `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` — future, for #685

## Test plan
- [x] YAML validates (python yaml.safe_load)
- [x] `make lint` passes
- [x] `make format --check` passes
- [x] `make typecheck` passes
- [ ] CI checks pass on PR

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)