### PR TITLE
Fetch source corpus options from API instead of hardcoding

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,6 +2,7 @@ import type {
   PaginatedResponse,
   Narrator,
   Hadith,
+  HadithFacetsResponse,
   Collection,
   NarratorChainsResponse,
   SearchResultsResponse,
@@ -67,6 +68,10 @@ export async function fetchHadiths(
 
 export async function fetchHadith(id: string): Promise<Hadith> {
   return fetchJson(`${API_BASE}/hadiths/${encodeURIComponent(id)}`)
+}
+
+export async function fetchHadithFacets(): Promise<HadithFacetsResponse> {
+  return fetchJson(`${API_BASE}/hadiths/facets`)
 }
 
 export async function fetchHadithParallels(id: string): Promise<ParallelsResponse> {

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { fetchHadiths, fetchCollections } from '../api/client'
+import { fetchHadiths, fetchCollections, fetchHadithFacets } from '../api/client'
 
 const PAGE_SIZES = [25, 50, 100] as const
 
@@ -72,11 +72,16 @@ export default function HadithsPage() {
 
   const hasActiveFilters = collection || sourceCorpus || grade || searchQuery
 
+  // Fetch source corpus options from API
+  const { data: facetsData, isLoading: facetsLoading } = useQuery({
+    queryKey: ['hadith-facets'],
+    queryFn: fetchHadithFacets,
+    staleTime: 5 * 60 * 1000,
+  })
+
   // Determine which columns have data
   const hasGrades = data?.items.some((h) => h.grade_composite) ?? false
   const hasTopics = data?.items.some((h) => h.topic_tags && h.topic_tags.length > 0) ?? false
-
-  const sourceCorpusOptions = ['lk', 'sunnah', 'thaqalayn', 'fawaz', 'sanadset', 'open_hadith', 'muhaddithat']
 
   return (
     <div>
@@ -141,6 +146,7 @@ export default function HadithsPage() {
         <select
           value={sourceCorpus}
           onChange={handleFilterChange(setSourceCorpus)}
+          disabled={facetsLoading}
           style={{
             padding: '0.5rem 0.75rem',
             border: '1px solid var(--color-border)',
@@ -149,8 +155,8 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">All Sources</option>
-          {sourceCorpusOptions.map((s) => (
+          <option value="">{facetsLoading ? 'Loading sources...' : 'All Sources'}</option>
+          {facetsData?.source_corpus.map((s) => (
             <option key={s} value={s}>
               {s}
             </option>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -41,6 +41,10 @@ export interface Hadith {
   has_sunni_parallel: boolean
 }
 
+export interface HadithFacetsResponse {
+  source_corpus: string[]
+}
+
 export interface Collection {
   id: string
   name_ar: string

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -106,6 +106,14 @@ class HadithResponse(BaseModel):
     has_sunni_parallel: bool = False
 
 
+class HadithFacetsResponse(BaseModel):
+    """Distinct facet values available for filtering hadiths."""
+
+    model_config = ConfigDict(frozen=True)
+
+    source_corpus: list[str]
+
+
 class CollectionResponse(BaseModel):
     """Collection API response."""
 

--- a/src/api/routes/hadiths.py
+++ b/src/api/routes/hadiths.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
-from src.api.models import HadithResponse, PaginatedResponse
+from src.api.models import HadithFacetsResponse, HadithResponse, PaginatedResponse
 from src.utils.neo4j_client import Neo4jClient
 
 router = APIRouter()
@@ -87,6 +87,18 @@ def _build_hadith_response(props: dict[str, Any]) -> HadithResponse:
         has_shia_parallel=props.get("has_shia_parallel", False),
         has_sunni_parallel=props.get("has_sunni_parallel", False),
     )
+
+
+@router.get("/hadiths/facets", response_model=HadithFacetsResponse)
+def get_hadith_facets(
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> HadithFacetsResponse:
+    """Return distinct facet values for filtering hadiths."""
+    rows = neo4j.execute_read(
+        "MATCH (h:Hadith) WHERE h.source_corpus IS NOT NULL "
+        "RETURN DISTINCT h.source_corpus AS corpus ORDER BY corpus"
+    )
+    return HadithFacetsResponse(source_corpus=[row["corpus"] for row in rows])
 
 
 @router.get("/hadiths", response_model=PaginatedResponse[HadithResponse])

--- a/tests/test_api/test_hadiths.py
+++ b/tests/test_api/test_hadiths.py
@@ -15,6 +15,27 @@ SAMPLE_HADITH = {
 }
 
 
+def test_get_hadith_facets_empty(client: TestClient) -> None:
+    """GET /api/v1/hadiths/facets returns empty list when no data."""
+    resp = client.get("/api/v1/hadiths/facets")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source_corpus"] == []
+
+
+def test_get_hadith_facets_with_data(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/hadiths/facets returns distinct corpus values."""
+    mock_neo4j.execute_read.return_value = [
+        {"corpus": "lk"},
+        {"corpus": "sunnah"},
+        {"corpus": "thaqalayn"},
+    ]
+    resp = client.get("/api/v1/hadiths/facets")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source_corpus"] == ["lk", "sunnah", "thaqalayn"]
+
+
 def test_list_hadiths_empty(client: TestClient) -> None:
     """GET /api/v1/hadiths returns empty paginated response when no data."""
     resp = client.get("/api/v1/hadiths")


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/hadiths/facets` endpoint returning distinct `source_corpus` values from Neo4j
- Add `HadithFacetsResponse` Pydantic model
- Frontend `HadithsPage` now fetches corpus options via TanStack Query with loading state, replacing the hardcoded array
- Add backend tests for the facets endpoint (empty + with data)

## Test plan
- [x] `make lint` passes
- [x] `make format` — no changes
- [x] `make typecheck` passes
- [x] `make test` — all unit tests pass (integration tests require Docker)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run test` — 30/30 pass

Closes #666