### PR TITLE
Add B2 upload/download scripts for pipeline artifacts

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,8 +8,9 @@
 #   - SUNNAH_API_KEY    — Sunnah.com API key for hadith acquisition
 #   - KAGGLE_USERNAME   — Kaggle account username for dataset downloads
 #   - KAGGLE_KEY        — Kaggle API key for dataset downloads
-#   - B2_APPLICATION_KEY_ID  — (future) Backblaze B2 key ID for artifact upload
-#   - B2_APPLICATION_KEY     — (future) Backblaze B2 application key for artifact upload
+#   - B2_APPLICATION_KEY_ID  — Backblaze B2 key ID for artifact upload
+#   - B2_APPLICATION_KEY     — Backblaze B2 application key for artifact upload
+#   - B2_BUCKET_NAME         — Backblaze B2 bucket name for artifact storage
 
 name: Pipeline
 
@@ -97,10 +98,9 @@ jobs:
           name: pipeline-manifest
           path: .manifest.json
 
-      # TODO: #685 will implement B2 upload
-      # This step will upload staging/curated data and the manifest to
-      # Backblaze B2 for durable storage and VPS-side restore.
-      # Required secrets: B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY
-      - name: "Upload to Backblaze B2 (placeholder)"
-        if: false
-        run: echo "B2 upload not yet implemented — see issue #685"
+      - name: "Stage 6: Upload to Backblaze B2"
+        run: scripts/b2_upload.sh
+        env:
+          B2_APPLICATION_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
+          B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+          B2_BUCKET_NAME: ${{ secrets.B2_BUCKET_NAME }}

--- a/scripts/b2_download.sh
+++ b/scripts/b2_download.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Download pipeline artifacts from Backblaze B2 to local data directory.
+#
+# Manifest-aware: compares remote .manifest.json against the local copy
+# and only downloads files whose SHA256 hashes have changed.
+#
+# Required env vars:
+#   B2_APPLICATION_KEY_ID  — Backblaze B2 key ID
+#   B2_APPLICATION_KEY     — Backblaze B2 application key
+#   B2_BUCKET_NAME         — Target B2 bucket name
+#
+# Usage:
+#   B2_APPLICATION_KEY_ID=xxx B2_APPLICATION_KEY=yyy B2_BUCKET_NAME=zzz \
+#     scripts/b2_download.sh [--dry-run]
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+  esac
+done
+
+# --- Validate environment ---------------------------------------------------
+for var in B2_APPLICATION_KEY_ID B2_APPLICATION_KEY B2_BUCKET_NAME; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "ERROR: $var is not set" >&2
+    exit 1
+  fi
+done
+
+# --- Paths -------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST_FILE="$REPO_ROOT/.manifest.json"
+B2_MANIFEST_PATH="pipeline/.manifest.json"
+
+TMPDIR_CLEAN=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_CLEAN"' EXIT
+
+# --- Authorize B2 CLI --------------------------------------------------------
+echo "Authorizing B2..."
+b2 account authorize "$B2_APPLICATION_KEY_ID" "$B2_APPLICATION_KEY" > /dev/null
+
+# --- Fetch remote manifest ---------------------------------------------------
+echo "Fetching remote manifest from B2..."
+REMOTE_MANIFEST="$TMPDIR_CLEAN/remote_manifest.json"
+if ! b2 file download "b2://$B2_BUCKET_NAME/$B2_MANIFEST_PATH" "$REMOTE_MANIFEST" 2>/dev/null; then
+  echo "ERROR: No remote manifest found in B2 bucket $B2_BUCKET_NAME" >&2
+  echo "Has the pipeline been run and uploaded to B2?" >&2
+  exit 1
+fi
+echo "  Remote manifest retrieved."
+
+# --- Load local manifest (if exists) -----------------------------------------
+LOCAL_MANIFEST=""
+if [[ -f "$MANIFEST_FILE" ]]; then
+  LOCAL_MANIFEST="$MANIFEST_FILE"
+  echo "  Local manifest found."
+else
+  echo "  No local manifest — will download all files."
+fi
+
+# --- Determine which files need downloading ----------------------------------
+CHANGED_FILES=$(python3 -c "
+import json
+
+remote = json.load(open('$REMOTE_MANIFEST'))
+remote_files = remote.get('files', {})
+
+local_files = {}
+local_path = '$LOCAL_MANIFEST'
+if local_path:
+    try:
+        local_data = json.load(open(local_path))
+        local_files = local_data.get('files', {})
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+changed = []
+for path, info in remote_files.items():
+    local_info = local_files.get(path, {})
+    if info.get('sha256') != local_info.get('sha256'):
+        changed.append(path)
+
+print('\n'.join(changed))
+")
+
+TOTAL_REMOTE=$(python3 -c "
+import json
+m = json.load(open('$REMOTE_MANIFEST'))
+print(len(m.get('files', {})))
+")
+CHANGED_COUNT=$(echo "$CHANGED_FILES" | grep -c '.' || true)
+
+echo ""
+echo "Remote files:  $TOTAL_REMOTE"
+echo "Changed files: $CHANGED_COUNT"
+
+if [[ "$CHANGED_COUNT" -eq 0 ]]; then
+  echo "All files up-to-date locally. Nothing to download."
+  exit 0
+fi
+
+# --- Download changed files --------------------------------------------------
+DOWNLOADED=0
+FAILED=0
+
+while IFS= read -r filepath; do
+  [[ -z "$filepath" ]] && continue
+  local_path="$REPO_ROOT/$filepath"
+  b2_path="pipeline/$filepath"
+
+  # Ensure target directory exists
+  mkdir -p "$(dirname "$local_path")"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [DRY RUN] Would download: $b2_path -> $filepath"
+    DOWNLOADED=$((DOWNLOADED + 1))
+  else
+    echo "  Downloading: $b2_path -> $filepath"
+    if b2 file download "b2://$B2_BUCKET_NAME/$b2_path" "$local_path" 2>/dev/null; then
+      DOWNLOADED=$((DOWNLOADED + 1))
+    else
+      echo "  FAILED: $filepath" >&2
+      FAILED=$((FAILED + 1))
+    fi
+  fi
+done <<< "$CHANGED_FILES"
+
+# --- Update local manifest ---------------------------------------------------
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "  [DRY RUN] Would update local manifest"
+else
+  echo "  Updating local manifest..."
+  cp "$REMOTE_MANIFEST" "$MANIFEST_FILE"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+PREFIX=""
+[[ "$DRY_RUN" == "true" ]] && PREFIX="[DRY RUN] "
+echo "${PREFIX}Download complete: $DOWNLOADED downloaded, $FAILED failed out of $CHANGED_COUNT changed."
+
+if [[ "$FAILED" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/b2_upload.sh
+++ b/scripts/b2_upload.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Upload pipeline artifacts (staging/curated Parquet + manifest) to Backblaze B2.
+#
+# Manifest-aware: compares local .manifest.json against the remote copy in B2
+# and only uploads files whose SHA256 hashes have changed.
+#
+# Required env vars:
+#   B2_APPLICATION_KEY_ID  — Backblaze B2 key ID
+#   B2_APPLICATION_KEY     — Backblaze B2 application key
+#   B2_BUCKET_NAME         — Target B2 bucket name
+#
+# Usage:
+#   B2_APPLICATION_KEY_ID=xxx B2_APPLICATION_KEY=yyy B2_BUCKET_NAME=zzz \
+#     scripts/b2_upload.sh [--dry-run]
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+  esac
+done
+
+# --- Validate environment ---------------------------------------------------
+for var in B2_APPLICATION_KEY_ID B2_APPLICATION_KEY B2_BUCKET_NAME; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "ERROR: $var is not set" >&2
+    exit 1
+  fi
+done
+
+# --- Paths -------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST_FILE="$REPO_ROOT/.manifest.json"
+B2_MANIFEST_PATH="pipeline/.manifest.json"
+
+if [[ ! -f "$MANIFEST_FILE" ]]; then
+  echo "ERROR: Local manifest not found at $MANIFEST_FILE" >&2
+  echo "Run the pipeline manifest generation step first." >&2
+  exit 1
+fi
+
+# --- Authorize B2 CLI --------------------------------------------------------
+echo "Authorizing B2..."
+b2 account authorize "$B2_APPLICATION_KEY_ID" "$B2_APPLICATION_KEY" > /dev/null
+
+# --- Fetch remote manifest for diff -----------------------------------------
+REMOTE_MANIFEST=""
+TMPDIR_CLEAN=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_CLEAN"' EXIT
+
+echo "Fetching remote manifest from B2..."
+if b2 file download "b2://$B2_BUCKET_NAME/$B2_MANIFEST_PATH" "$TMPDIR_CLEAN/remote_manifest.json" 2>/dev/null; then
+  REMOTE_MANIFEST="$TMPDIR_CLEAN/remote_manifest.json"
+  echo "  Remote manifest retrieved."
+else
+  echo "  No remote manifest found — will upload all files."
+fi
+
+# --- Determine which files need uploading ------------------------------------
+# Use Python to compare manifests (SHA256-based, matching pipeline.yml format)
+CHANGED_FILES=$(python3 -c "
+import json, sys
+
+local = json.load(open('$MANIFEST_FILE'))
+local_files = local.get('files', {})
+
+remote_files = {}
+remote_path = '$REMOTE_MANIFEST'
+if remote_path:
+    try:
+        remote = json.load(open(remote_path))
+        remote_files = remote.get('files', {})
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+changed = []
+for path, info in local_files.items():
+    remote_info = remote_files.get(path, {})
+    if info.get('sha256') != remote_info.get('sha256'):
+        changed.append(path)
+
+# Always include manifest itself
+print('\n'.join(changed))
+")
+
+TOTAL_LOCAL=$(python3 -c "
+import json
+m = json.load(open('$MANIFEST_FILE'))
+print(len(m.get('files', {})))
+")
+CHANGED_COUNT=$(echo "$CHANGED_FILES" | grep -c '.' || true)
+
+echo ""
+echo "Local files:   $TOTAL_LOCAL"
+echo "Changed files: $CHANGED_COUNT"
+
+if [[ "$CHANGED_COUNT" -eq 0 ]]; then
+  echo "All files up-to-date in B2. Nothing to upload."
+  exit 0
+fi
+
+# --- Upload changed files ----------------------------------------------------
+UPLOADED=0
+FAILED=0
+
+while IFS= read -r filepath; do
+  [[ -z "$filepath" ]] && continue
+  local_path="$REPO_ROOT/$filepath"
+  b2_path="pipeline/$filepath"
+
+  if [[ ! -f "$local_path" ]]; then
+    echo "  SKIP (missing): $filepath"
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [DRY RUN] Would upload: $filepath -> $b2_path"
+    UPLOADED=$((UPLOADED + 1))
+  else
+    echo "  Uploading: $filepath -> $b2_path"
+    if b2 file upload "$B2_BUCKET_NAME" "$local_path" "$b2_path" > /dev/null; then
+      UPLOADED=$((UPLOADED + 1))
+    else
+      echo "  FAILED: $filepath" >&2
+      FAILED=$((FAILED + 1))
+    fi
+  fi
+done <<< "$CHANGED_FILES"
+
+# --- Upload the manifest itself ----------------------------------------------
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "  [DRY RUN] Would upload: .manifest.json -> $B2_MANIFEST_PATH"
+else
+  echo "  Uploading: .manifest.json -> $B2_MANIFEST_PATH"
+  b2 file upload "$B2_BUCKET_NAME" "$MANIFEST_FILE" "$B2_MANIFEST_PATH" > /dev/null
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+PREFIX=""
+[[ "$DRY_RUN" == "true" ]] && PREFIX="[DRY RUN] "
+echo "${PREFIX}Upload complete: $UPLOADED uploaded, $FAILED failed out of $CHANGED_COUNT changed."
+
+if [[ "$FAILED" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Create `scripts/b2_upload.sh` — manifest-aware upload of staging/curated Parquet files and `.manifest.json` to Backblaze B2, comparing SHA256 hashes to skip unchanged files
- Create `scripts/b2_download.sh` — manifest-aware download from B2 to local data directory with the same incremental logic
- Replace the B2 upload placeholder in `pipeline.yml` with actual Stage 6 invocation of `b2_upload.sh` using `B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`, and `B2_BUCKET_NAME` secrets
- Both scripts are idempotent and support `--dry-run`

## Test plan
- [ ] Verify `scripts/b2_upload.sh --dry-run` runs without errors when manifest exists
- [ ] Verify `scripts/b2_download.sh --dry-run` runs without errors with B2 credentials
- [ ] Confirm pipeline.yml Stage 6 references the correct script and secrets
- [ ] Run `make lint && make typecheck` — all pass
- [ ] Verify `ruff format --check` passes

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)