### PR TITLE
Widen search page empty state to match search bar width

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -579,7 +579,7 @@ export default function SearchPage() {
 
       {/* No query — initial empty state */}
       {query.length < 2 && (
-        <Card className="max-w-lg mx-auto mt-12 text-center">
+        <Card className="mt-12 text-center">
           <CardContent className="py-12">
             <svg
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- Remove `max-w-lg mx-auto` from the search page empty state Card so it fills the same width as the search bar above it, instead of being constrained to 512px.

Closes #699

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (32/32)
- [ ] Visual check: empty state card width matches the search bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)