### PR TITLE
Fix brand name NoorinALabs → Noorina Labs

### DIFF
--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -1,8 +1,8 @@
-# Team Charter — NoorinALabs (Organization)
+# Team Charter — Noorina Labs (Organization)
 
 ## Purpose
 
-All work across all NoorinALabs repositories is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
+All work across all Noorina Labs repositories is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
 
 ## Execution Model
 


### PR DESCRIPTION
## Summary
- Replaces "NoorinALabs" with "Noorina Labs" in team charter documentation prose
- No code identifiers, URLs, or package names were changed

Closes #720