### PR TITLE
ops: Audit .gitignore — comprehensive Python/Node/Docker/Terraform coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ data/test_samples/
 *.parquet
 .env
 __pycache__/
+*.pyc
+*.pyo
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
@@ -16,6 +18,7 @@ build/
 node_modules/
 .coverage
 .hypothesis/
+coverage/
 
 # Playwright
 frontend/test-results/
@@ -26,4 +29,30 @@ terraform/.terraform/
 terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terraform/*.tfvars
+terraform/**/*.tfvars
 terraform/.terraform.lock.hcl
+terraform/**/crash.log
+*.tfplan
+
+# Docker
+docker-compose.override.yml
+
+# Neo4j
+data/neo4j/
+
+# Node.js
+.eslintcache
+*.tsbuildinfo
+npm-debug.log*
+
+# Logs
+*.log
+
+# Temp / Cache
+tmp/
+temp/
+.cache/
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- Adds missing patterns: `*.pyc`, `*.pyo`, `*.log`, `.eslintcache`, `*.tsbuildinfo`, `npm-debug.log*`, `terraform/**/*.tfvars`, `terraform/**/crash.log`, `*.tfplan`, `docker-compose.override.yml`, `data/neo4j/`, `coverage/`, `tmp/`, `temp/`, `.cache/`, `.DS_Store`, `Thumbs.db`
- `__pycache__/` was already present — extended with explicit `*.pyc`/`*.pyo` for completeness
- Verified `.claude/` and `alembic/versions/` are NOT ignored
- No tracked files required removal (`.gitkeep` files correctly retained via negation patterns)

Closes #764, closes #765

## Reviewer
Requestor (author): Santiago Ferreira
Requestee (reviewer): Aino Virtanen

## Test plan
- [ ] Verify new patterns appear in `.gitignore`
- [ ] Confirm `.claude/` directories are still tracked
- [ ] Confirm `alembic/versions/` is still tracked
- [ ] Confirm `data/raw/.gitkeep` and `data/staging/.gitkeep` are still tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)