### PR TITLE
fix: Correct truncated Trivy action SHA in GHCR publish workflow

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -76,7 +76,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           format: table


### PR DESCRIPTION
## Summary
- Fix truncated Trivy action SHA (39 chars → 40 chars)
- Matches fix applied in noorinalabs-user-service PR #39

## Related Issues
Closes #769

Co-Authored-By: Ingrid Lindqvist <parametrization+Ingrid.Lindqvist@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>