### PR TITLE
fix: Auth cleanup — verification polling + stub consolidation

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -26,6 +26,7 @@ interface AuthContextValue {
   signOutAll: () => Promise<void>
   dismissSessionExpired: () => void
   dismissOnboarding: () => void
+  refreshUser: () => Promise<void>
 }
 
 const ROLE_HIERARCHY: Record<UserRole, number> = {
@@ -233,6 +234,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsNewUser(false)
   }, [])
 
+  const refreshUser = useCallback(async () => {
+    const token = localStorage.getItem('access_token')
+    if (!token) return
+    try {
+      const res = await fetch(`${USER_BASE}/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        const data: AuthUser = await res.json()
+        setUser(data)
+      }
+    } catch {
+      // Silently ignore — this is a background refresh
+    }
+  }, [])
+
   const userRole: UserRole = user?.role ?? 'viewer'
 
   const hasRole = useCallback(
@@ -255,6 +272,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     signOutAll,
     dismissSessionExpired,
     dismissOnboarding,
+    refreshUser,
   }
 
   return createElement(AuthContext.Provider, { value }, children)

--- a/frontend/src/pages/CheckEmailPage.tsx
+++ b/frontend/src/pages/CheckEmailPage.tsx
@@ -4,8 +4,10 @@ import { useAuth } from '../hooks/useAuth'
 
 const API_BASE = '/api/v1'
 
+const POLL_INTERVAL_MS = 30_000
+
 export default function CheckEmailPage() {
-  const { user, loading, signOut } = useAuth()
+  const { user, loading, signOut, refreshUser } = useAuth()
   const navigate = useNavigate()
   const [resending, setResending] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
@@ -17,6 +19,13 @@ export default function CheckEmailPage() {
       navigate('/', { replace: true })
     }
   }, [user, loading, navigate])
+
+  // Poll for verification status changes (e.g. verified in another tab)
+  useEffect(() => {
+    if (loading || !user || user.email_verified) return
+    const id = setInterval(refreshUser, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [loading, user, refreshUser])
 
   useEffect(() => {
     if (cooldown <= 0) return

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -46,6 +46,7 @@ def session_heartbeat() -> JSONResponse:
 
 
 @router.post("/auth/send-verification")
+@router.post("/auth/resend-verification")
 def send_verification() -> JSONResponse:
     return _gone("/api/v1/verification/send")
 
@@ -53,11 +54,6 @@ def send_verification() -> JSONResponse:
 @router.post("/auth/verify-email")
 def verify_email() -> JSONResponse:
     return _gone("/api/v1/verification/confirm")
-
-
-@router.post("/auth/resend-verification")
-def resend_verification() -> JSONResponse:
-    return _gone("/api/v1/verification/send")
 
 
 # --- Subscription stub (migrated to user-service) ---


### PR DESCRIPTION
## Summary
- Add `refreshUser()` to `AuthProvider` and poll `/users/me` every 30s on `CheckEmailPage` so cross-tab email verification is detected without a full page refresh (#753)
- Consolidate duplicate `send-verification` / `resend-verification` 410 stubs into a single handler with two route decorators (#752)

## Related Issues
Closes #753
Closes #752

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>