### PR TITLE
ci: Add package-lock.json local path validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,19 @@ jobs:
       - run: uvx ruff check scripts/
       - run: uvx ruff format --check scripts/
 
+  lockfile-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check package-lock.json for local paths
+        run: |
+          if grep -qE '"resolved":\s*"file://((/tmp/|/home/|/Users/|/var/))' frontend/package-lock.json; then
+            echo "::error::package-lock.json contains absolute local paths that break CI"
+            grep -nE '"resolved":\s*"file://((/tmp/|/home/|/Users/|/var/))' frontend/package-lock.json | head -10
+            exit 1
+          fi
+          echo "No local paths found in package-lock.json"
+
   e2e:
     needs: lint-and-typecheck
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,17 @@ repos:
       # Integration tests require Docker (Neo4j, PostgreSQL) — run in CI only.
       # To run locally: make infra && ENVIRONMENT=test uv run pytest tests/integration/ -m integration
 
+  # --- Lockfile validation ---
+  - repo: local
+    hooks:
+      - id: lockfile-no-local-paths
+        name: lockfile-no-local-paths
+        entry: bash -c 'if grep -qE "\"resolved\":\s*\"file://((/tmp/|/home/|/Users/|/var/))" frontend/package-lock.json; then echo "ERROR: package-lock.json contains absolute local paths (file:///tmp/, /home/, etc.)"; echo "These break CI. Run npm install with the correct dependency source."; grep -nE "\"resolved\":\s*\"file://((/tmp/|/home/|/Users/|/var/))" frontend/package-lock.json | head -5; exit 1; fi'
+        language: system
+        pass_filenames: false
+        files: ^frontend/package-lock\.json$
+        stages: [pre-commit]
+
   # --- Frontend (React/TypeScript) ---
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- Add pre-commit hook `lockfile-no-local-paths` that blocks commits when `package-lock.json` contains absolute local paths (`file:///tmp/`, `/home/`, etc.)
- Add CI job `lockfile-validation` that runs the same check in the pipeline as a safety net
- These local paths break CI builds when a developer resolves packages from a local tarball and accidentally commits the lockfile

## Related Issues
Closes #732

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>