### PR TITLE
fix: Correct Neo4j label casing in admin queries — all stats returning zeros

### DIFF
--- a/src/api/routes/admin/analytics.py
+++ b/src/api/routes/admin/analytics.py
@@ -20,7 +20,7 @@ log = structlog.get_logger(logger_name=__name__)
 # Redis key prefixes for analytics counters
 _SEARCH_COUNTER_KEY = "analytics:search_count"
 _API_CALL_COUNTER_KEY = "analytics:api_call_count"
-_NARRATOR_QUERY_ZSET_KEY = "analytics:narrator_queries"
+_Narrator_QUERY_ZSET_KEY = "analytics:narrator_queries"
 
 # Time-range lookback windows in seconds
 _TIME_RANGE_SECONDS: dict[str, int] = {
@@ -61,13 +61,13 @@ def _get_popular_narrators(neo4j: Neo4jClient, limit: int = 10) -> list[PopularN
     if client is not None:
         try:
             # zrevrange returns [(member, score), ...] with withscores=True
-            top_entries = client.zrevrange(_NARRATOR_QUERY_ZSET_KEY, 0, limit - 1, withscores=True)
+            top_entries = client.zrevrange(_Narrator_QUERY_ZSET_KEY, 0, limit - 1, withscores=True)
             if top_entries:
                 narrators: list[PopularNarrator] = []
                 for narrator_id, score in top_entries:
                     # Look up name from Neo4j
                     records = neo4j.execute_read(
-                        "MATCH (n:NARRATOR {id: $nid}) RETURN n.name_en AS name",
+                        "MATCH (n:Narrator {id: $nid}) RETURN n.name_en AS name",
                         {"nid": narrator_id},
                     )
                     name = records[0]["name"] if records else narrator_id
@@ -86,7 +86,7 @@ def _get_popular_narrators(neo4j: Neo4jClient, limit: int = 10) -> list[PopularN
     try:
         records = neo4j.execute_read(
             """
-            MATCH (n:NARRATOR)<-[r:TRANSMITTED_TO]-()
+            MATCH (n:Narrator)<-[r:TRANSMITTED_TO]-()
             WITH n, count(r) AS degree
             ORDER BY degree DESC
             LIMIT $limit

--- a/src/api/routes/admin/reports.py
+++ b/src/api/routes/admin/reports.py
@@ -19,21 +19,21 @@ def _graph_validation_metrics(neo4j: Neo4jClient) -> GraphValidationMetrics | No
     """Query Neo4j for graph validation results."""
     try:
         query = """
-            OPTIONAL MATCH (n:NARRATOR)
+            OPTIONAL MATCH (n:Narrator)
             WHERE NOT (n)-[:TRANSMITTED_TO]-() AND NOT (n)-[:NARRATED]-()
             WITH count(n) AS orphan_narrators
-            OPTIONAL MATCH (h:HADITH)
-            WHERE NOT (h)-[:APPEARS_IN]->(:COLLECTION)
+            OPTIONAL MATCH (h:Hadith)
+            WHERE NOT (h)-[:APPEARS_IN]->(:Collection)
             WITH orphan_narrators, count(h) AS orphan_hadiths
-            OPTIONAL MATCH (c:CHAIN)
+            OPTIONAL MATCH (c:Chain)
             WITH orphan_narrators, orphan_hadiths, count(c) AS total_chains
-            OPTIONAL MATCH (c2:CHAIN) WHERE c2.is_complete = true
+            OPTIONAL MATCH (c2:Chain) WHERE c2.is_complete = true
             WITH orphan_narrators, orphan_hadiths, total_chains,
                  count(c2) AS complete_chains
-            OPTIONAL MATCH (h2:HADITH)
+            OPTIONAL MATCH (h2:Hadith)
             WITH orphan_narrators, orphan_hadiths, total_chains, complete_chains,
                  count(h2) AS total_hadiths
-            OPTIONAL MATCH (h3:HADITH)-[:APPEARS_IN]->(:COLLECTION)
+            OPTIONAL MATCH (h3:Hadith)-[:APPEARS_IN]->(:Collection)
             WITH orphan_narrators, orphan_hadiths, total_chains, complete_chains,
                  total_hadiths, count(DISTINCT h3) AS linked_hadiths
             RETURN orphan_narrators, orphan_hadiths,
@@ -62,9 +62,9 @@ def _topic_coverage_metrics(neo4j: Neo4jClient) -> TopicCoverageMetrics | None:
     """Query Neo4j for topic classification coverage."""
     try:
         query = """
-            OPTIONAL MATCH (h:HADITH)
+            OPTIONAL MATCH (h:Hadith)
             WITH count(h) AS total_hadiths
-            OPTIONAL MATCH (h2:HADITH)
+            OPTIONAL MATCH (h2:Hadith)
             WHERE size(h2.topic_tags) > 0
             RETURN total_hadiths, count(h2) AS classified_count,
                    CASE WHEN total_hadiths > 0

--- a/src/api/routes/admin/stats.py
+++ b/src/api/routes/admin/stats.py
@@ -17,11 +17,11 @@ def content_stats(
 ) -> ContentStatsResponse:
     """Return content statistics: hadith count, narrator count, collection count, coverage %."""
     query = """
-        OPTIONAL MATCH (h:HADITH) WITH count(h) AS hadith_count
-        OPTIONAL MATCH (n:NARRATOR) WITH hadith_count, count(n) AS narrator_count
-        OPTIONAL MATCH (c:COLLECTION)
+        OPTIONAL MATCH (h:Hadith) WITH count(h) AS hadith_count
+        OPTIONAL MATCH (n:Narrator) WITH hadith_count, count(n) AS narrator_count
+        OPTIONAL MATCH (c:Collection)
         WITH hadith_count, narrator_count, count(c) AS collection_count
-        OPTIONAL MATCH (h2:HADITH)-[:APPEARS_IN]->(:COLLECTION)
+        OPTIONAL MATCH (h2:Hadith)-[:APPEARS_IN]->(:Collection)
         WITH hadith_count, narrator_count, collection_count,
              count(DISTINCT h2) AS linked_hadiths
         RETURN hadith_count, narrator_count, collection_count,


### PR DESCRIPTION
## Summary
- Fix Neo4j label casing in all admin Cypher queries (NARRATOR → Narrator, HADITH → Hadith, COLLECTION → Collection, CHAIN → Chain)
- All admin stats/reports/analytics were silently returning zeros due to label mismatch
- Affected files: `analytics.py`, `reports.py`, `stats.py` in `src/api/routes/admin/`

## Related Issues
Closes #787

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>