### PR TITLE
ops: enable ruff autofix on commit + fix broken pre-commit YAML

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -27,10 +27,7 @@ def main() -> None:
     command = input_data.get("tool_input", {}).get("command", "")
 
     # Match pytest, uv run pytest, or make test commands
-    is_test_cmd = bool(
-        re.search(r"\bpytest\b", command)
-        or re.search(r"\bmake\s+test\b", command)
-    )
+    is_test_cmd = bool(re.search(r"\bpytest\b", command) or re.search(r"\bmake\s+test\b", command))
 
     if not is_test_cmd:
         sys.exit(0)

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -50,7 +50,7 @@ def main() -> None:
             "reason": (
                 "BLOCKED: git commit missing `-c user.name=` flag. "
                 "Charter § Commit Identity requires per-commit identity via -c flags. "
-                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+                'Example: git -c user.name="Kwame Asante" -c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."'
             ),
         }
         print(json.dumps(result))
@@ -62,7 +62,7 @@ def main() -> None:
             "reason": (
                 "BLOCKED: git commit missing `-c user.email=` flag. "
                 "Charter § Commit Identity requires per-commit identity via -c flags. "
-                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+                'Example: git -c user.name="Kwame Asante" -c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."'
             ),
         }
         print(json.dumps(result))
@@ -76,7 +76,7 @@ def main() -> None:
         result = {
             "decision": "block",
             "reason": (
-                f"BLOCKED: user.name=\"{name}\" is not a recognized roster member. "
+                f'BLOCKED: user.name="{name}" is not a recognized roster member. '
                 f"Valid names: {', '.join(sorted(ROSTER.keys()))}"
             ),
         }
@@ -88,7 +88,7 @@ def main() -> None:
         result = {
             "decision": "block",
             "reason": (
-                f"BLOCKED: user.email=\"{email}\" does not match roster for {name}. "
+                f'BLOCKED: user.email="{email}" does not match roster for {name}. '
                 f"Expected: {expected_email}"
             ),
         }

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -10,9 +10,9 @@ Exit codes:
 """
 
 import json
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 
 # Load roster from shared JSON file — single source of truth for all hooks
 _ROSTER_PATH = Path(__file__).resolve().parent.parent / "team" / "roster.json"
@@ -44,13 +44,17 @@ def main() -> None:
     name_match = re.search(r'-c\s+user\.name=["\']?([^"\']+)["\']?', command)
     email_match = re.search(r'-c\s+user\.email=["\']?([^"\']+)["\']?', command)
 
+    _example = (
+        'Example: git -c user.name="Kwame Asante"'
+        ' -c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."'
+    )
+
     if not name_match:
         result = {
             "decision": "block",
             "reason": (
                 "BLOCKED: git commit missing `-c user.name=` flag. "
-                "Charter § Commit Identity requires per-commit identity via -c flags. "
-                'Example: git -c user.name="Kwame Asante" -c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."'
+                "Charter § Commit Identity requires per-commit identity via -c flags. " + _example
             ),
         }
         print(json.dumps(result))
@@ -61,8 +65,7 @@ def main() -> None:
             "decision": "block",
             "reason": (
                 "BLOCKED: git commit missing `-c user.email=` flag. "
-                "Charter § Commit Identity requires per-commit identity via -c flags. "
-                'Example: git -c user.name="Kwame Asante" -c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."'
+                "Charter § Commit Identity requires per-commit identity via -c flags. " + _example
             ),
         }
         print(json.dumps(result))

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -90,9 +90,7 @@ def main() -> None:
         sys.exit(0)
 
     # Build helpful error with gh label create suggestions
-    suggestions = "\n".join(
-        f'  gh label create "{label}"' for label in missing
-    )
+    suggestions = "\n".join(f'  gh label create "{label}"' for label in missing)
     result = {
         "decision": "block",
         "reason": (

--- a/.claude/team/roster.json
+++ b/.claude/team/roster.json
@@ -13,5 +13,10 @@
   "Farhan Malik": "parametrization+Farhan.Malik@gmail.com",
   "Aisling Brennan": "parametrization+Aisling.Brennan@gmail.com",
   "Thandiwe Moyo": "parametrization+Thandiwe.Moyo@gmail.com",
-  "Ravi Wickramasinghe": "parametrization+Ravi.Wickramasinghe@gmail.com"
+  "Ravi Wickramasinghe": "parametrization+Ravi.Wickramasinghe@gmail.com",
+
+  "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+  "Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com",
+  "Santiago Ferreira": "parametrization+Santiago.Ferreira@gmail.com",
+  "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,19 @@
 
 repos:
   # --- Ruff formatter & linter ---
+  # ruff-format runs first so format fixes don't trigger re-lint.
+  # `.claude/worktrees/` is excluded because it contains scratch checkouts of
+  # other branches; reformatting them would silently overwrite work in progress.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.6
     hooks:
       - id: ruff-format
-        args: [--check]
         name: ruff-format
+        exclude: ^\.claude/worktrees/
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix]
         name: ruff-lint
+        exclude: ^\.claude/worktrees/
 
   # --- Secret detection ---
   - repo: https://github.com/gitleaks/gitleaks
@@ -87,7 +91,7 @@ repos:
     hooks:
       - id: lockfile-no-local-paths
         name: lockfile-no-local-paths
-        entry: bash -c 'if grep -qE "\"resolved\":\s*\"file://((/tmp/|/home/|/Users/|/var/))" frontend/package-lock.json; then echo "ERROR: package-lock.json contains absolute local paths (file:///tmp/, /home/, etc.)"; echo "These break CI. Run npm install with the correct dependency source."; grep -nE "\"resolved\":\s*\"file://((/tmp/|/home/|/Users/|/var/))" frontend/package-lock.json | head -5; exit 1; fi'
+        entry: scripts/lockfile_no_local_paths.sh
         language: system
         pass_filenames: false
         files: ^frontend/package-lock\.json$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ build-backend = "hatchling.build"
 [tool.ruff]
 line-length = 100
 target-version = "py313"  # ruff doesn't support py314 yet; py313 is the closest
+# Worktree dirs are scratch checkouts of other branches — never lint/format these.
+extend-exclude = [".claude/worktrees"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "PD"]

--- a/scripts/data_profile.py
+++ b/scripts/data_profile.py
@@ -39,9 +39,7 @@ def _match_schema(filename: str) -> object | None:
     return None
 
 
-def _check_schema_conformance(
-    actual_names: list[str], expected_schema: object
-) -> list[str]:
+def _check_schema_conformance(actual_names: list[str], expected_schema: object) -> list[str]:
     """Compare actual column names against expected schema fields."""
     import pyarrow as pa
 

--- a/scripts/lockfile_no_local_paths.sh
+++ b/scripts/lockfile_no_local_paths.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Fail if frontend/package-lock.json contains absolute local paths (file:///tmp/, /home/, etc.).
+# These break CI because the resolved paths only exist on the developer's machine.
+set -euo pipefail
+
+LOCKFILE="frontend/package-lock.json"
+PATTERN='"resolved":[[:space:]]*"file://(/tmp/|/home/|/Users/|/var/)'
+
+if [[ ! -f "$LOCKFILE" ]]; then
+  exit 0
+fi
+
+if grep -qE "$PATTERN" "$LOCKFILE"; then
+  echo "ERROR: $LOCKFILE contains absolute local paths (file:///tmp/, /home/, /Users/, /var/)."
+  echo "These break CI. Run npm install with the correct dependency source."
+  grep -nE "$PATTERN" "$LOCKFILE" | head -5
+  exit 1
+fi

--- a/src/api/routes/admin/config.py
+++ b/src/api/routes/admin/config.py
@@ -59,7 +59,7 @@ def _load_config(pg: PgClient) -> SystemConfig:
     for field_name, default_value in defaults.items():
         if field_name in db_values:
             raw = db_values[field_name]
-            if isinstance(default_value, (dict, list)):
+            if isinstance(default_value, dict | list):
                 merged[field_name] = json.loads(raw)
             elif isinstance(default_value, int):
                 merged[field_name] = int(raw)
@@ -73,7 +73,7 @@ def _load_config(pg: PgClient) -> SystemConfig:
 
 def _serialize_value(value: object) -> str:
     """Serialize a config value for storage."""
-    if isinstance(value, (dict, list)):
+    if isinstance(value, dict | list):
         return json.dumps(value)
     return str(value)
 


### PR DESCRIPTION
## Summary

Implements [`noorinalabs/noorinalabs-main#110`](https://github.com/noorinalabs/noorinalabs-main/issues/110) for `noorinalabs-isnad-graph`: lint and format errors now autofix at commit time instead of failing CI.

## Changes

1. **`.pre-commit-config.yaml`** — drop `args: [--check]` from `ruff-format` and `args: [--exit-non-zero-on-fix]` from `ruff` so the hooks rewrite files instead of just reporting. ruff-format runs first so format fixes don't trigger re-lint. Also adds `exclude: ^\.claude/worktrees/` to both ruff hooks (worktree dirs are scratch checkouts of other branches; reformatting them would silently overwrite work in progress — see #807).

2. **`scripts/lockfile_no_local_paths.sh`** (new) — extracts the `lockfile-no-local-paths` hook's inline `bash -c '...'` one-liner into a script. The previous inline form contained an unescaped `:` inside an unquoted YAML scalar, which made PyYAML reject the file with `mapping values are not allowed in this context`. Pre-commit could not load the config at all on `main`. The script preserves identical behavior.

3. **`pyproject.toml`** — add `extend-exclude = [".claude/worktrees"]` to `[tool.ruff]` so direct `ruff check` / `ruff format` invocations (e.g., `make lint`, `make format`) honor the same exclude as pre-commit.

4. **Format diff** — `pre-commit run ruff-format --all-files` reformatted 4 files: `.claude/hooks/auto_set_env_test.py`, `.claude/hooks/validate_commit_identity.py`, `.claude/hooks/validate_labels.py`, `scripts/data_profile.py`. Cosmetic only (mostly Q-style quote normalization).

5. **Lint autofixes** — `pre-commit run ruff --all-files` produced fixes for `.claude/hooks/validate_commit_identity.py` (I001 import re-order; E501 by extracting a long example string to a local var) and `src/api/routes/admin/config.py` (UP038 ×2: `isinstance(x, (T1, T2))` → `isinstance(x, T1 | T2)`). After this, `pre-commit run ruff --all-files` is clean across the repo, leaving Wanjiku's #111 sweep with nothing to do here.

## Prerequisite commit

The branch starts with `infra: Add org-level coordinators to roster` (Aino Virtanen, sha `f927dda`), which adds Nadia Khoury, Wanjiku, Santiago, and Aino to `.claude/team/roster.json` so org-level coordinators can land repo-spanning ops PRs. Steven approved this expansion. A separate W9 tech-debt issue will track making the cross-repo roster detection automatic so we don't have to sync names by hand.

## Test plan

- [x] `uvx pre-commit run ruff-format --all-files` → Passed
- [x] `uvx pre-commit run ruff --all-files` → Passed
- [ ] CI green
- [ ] Reviewer to spot-check that reformatted files contain no logic changes

## TechDebt

- #807 — `.claude/worktrees/` (5,987 files) is tracked in git and should be gitignored. Once that's fixed, the `extend-exclude` and pre-commit `exclude` entries added here can be removed.

## Issue

Refs noorinalabs/noorinalabs-main#110

🤖 Generated with [Claude Code](https://claude.com/claude-code)