### PR TITLE
fix(docker): copy design-system tarball before npm ci (#818)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,12 @@
 FROM node:24-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
+# package-lock.json references @noorinalabs/design-system via a file: path
+# pointing at /noorinalabs-design-system-0.0.1.tgz. The deploy script stages
+# this tarball into the build context root before docker build (see #818).
+# Long-term: switch to GHCR-published image (#817) or npm registry
+# (design-system#57) and drop this implicit-contract copy.
+COPY noorinalabs-design-system-0.0.1.tgz /
 RUN npm ci
 # Cache-bust: ARG changes invalidate all subsequent layers
 ARG CACHEBUST=1


### PR DESCRIPTION
## Summary

Adds a single `COPY noorinalabs-design-system-0.0.1.tgz /` line to `frontend/Dockerfile` so `npm ci` can resolve the `@noorinalabs/design-system` `file:` dependency. Closes #818, paired with the noorinalabs-deploy companion PR that stages the tarball into the build context root.

## Background

Tonight's deploy (run 24613819108) failed during the frontend image build with ENOENT on the design-system tarball. Today's earlier landings (Bitnami namespace sunset + GHCR auth) shifted the frontend to local docker-build, which surfaced this latent issue: `package-lock.json` references `@noorinalabs/design-system` via a `file:` path resolving to `/noorinalabs-design-system-0.0.1.tgz`, but nothing was placing the tarball at that location inside the build container.

## Change

Insert `COPY noorinalabs-design-system-0.0.1.tgz /` between the `COPY package.json package-lock.json ./` and `RUN npm ci` lines, with a 5-line comment block citing #818, the long-term retirement paths, and the implicit deploy-side contract.

## Why this approach (not the alternatives in #818)

- **Minimal scope** — one COPY line; no Dockerfile restructuring, no node toolchain on the VPS, no multi-stage juggling.
- **Leverages existing implicit contract** — design-system devs already commit `noorinalabs-design-system-0.0.1.tgz` at the repo root; the deploy-side PR makes the staging step explicit.
- **Doesn't preempt the real fix** — long-term retirement is GHCR publishing (this repo's #817) and npm-registry packaging (`design-system#57`). This PR keeps the door open for both.

## CI note

This repo's CI may attempt to docker-build the frontend image, which will still fail without the tarball staged into the CI build context. CI hardening is part of #817's scope. **Reviewers should approve based on diff inspection, not CI status.**

## Test plan

- [ ] noorinalabs-deploy companion PR (TBD) lands the `cp` of the tarball into the build context root
- [ ] Full verification is end-to-end: post-merge of both PRs, the next deploy run reaches a successful frontend build
- [ ] Local sanity (optional, reviewer): with the tarball present at the frontend build context root, `docker build frontend/` succeeds through `npm ci`

## TechDebt

None — this PR is the fix. Long-term retirement tracked in #817 (GHCR) and `noorinalabs-design-system#57` (npm registry). The cross-repo commit-identity hook quirk that routed this to a real isnad-graph roster member rather than the org TPM is separately tracked.

## Reviewers

- @ Jelani Mwangi (DevOps Architect — Dockerfile + deploy contract)
- @ Anya Kowalczyk (Tech Lead — frontend build chain)
