### PR TITLE
fix(frontend): use user.display_name (matches API) — fix WelcomeBanner crash (#825)

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -117,7 +117,7 @@ export default function Sidebar() {
             }}
             title={user.email}
           >
-            {user.name || user.email}
+            {user.display_name ?? user.email}
           </div>
           <button
             onClick={signOut}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -47,9 +47,11 @@ export default function UserMenu() {
 
   if (!user) return null
 
-  const initials = user.name
+  // display_name can be null — fall back to email so initials always render.
+  const displayName = user.display_name ?? user.email
+  const initials = displayName
     .split(' ')
-    .map((w) => w[0])
+    .map((w) => w[0] ?? '')
     .join('')
     .toUpperCase()
     .slice(0, 2)
@@ -111,7 +113,7 @@ export default function UserMenu() {
                 color: 'var(--color-foreground)',
               }}
             >
-              {user.name}
+              {user.display_name ?? user.email}
             </div>
             <div
               style={{
@@ -123,9 +125,11 @@ export default function UserMenu() {
               {user.email}
             </div>
             <div style={{ display: 'flex', gap: 'var(--spacing-2)', marginTop: 'var(--spacing-2)' }}>
-              <span style={{ display: 'inline-block', padding: 'var(--spacing-0_5) var(--spacing-2)', fontSize: 'var(--text-xs)', fontWeight: 500, borderRadius: 'var(--radius-full)', background: 'var(--color-accent)', color: 'var(--color-primary)' }}>
-                {providerLabel(user.provider)}
-              </span>
+              {user.provider && (
+                <span style={{ display: 'inline-block', padding: 'var(--spacing-0_5) var(--spacing-2)', fontSize: 'var(--text-xs)', fontWeight: 500, borderRadius: 'var(--radius-full)', background: 'var(--color-accent)', color: 'var(--color-primary)' }}>
+                  {providerLabel(user.provider)}
+                </span>
+              )}
               <span style={{ display: 'inline-block', padding: 'var(--spacing-0_5) var(--spacing-2)', fontSize: 'var(--text-xs)', fontWeight: 600, borderRadius: 'var(--radius-full)', background: 'var(--color-accent)', color: 'var(--color-primary)', textTransform: 'capitalize' }}>
                 {role}
               </span>

--- a/frontend/src/components/WelcomeBanner.tsx
+++ b/frontend/src/components/WelcomeBanner.tsx
@@ -5,6 +5,10 @@ export default function WelcomeBanner() {
 
   if (!isNewUser || !user) return null
 
+  // display_name may be null (per user-service UserRead schema) — fall back to
+  // the local-part of the email so this never crashes (#825).
+  const firstName = user.display_name?.split(' ')[0] ?? user.email.split('@')[0]
+
   return (
     <div
       role="status"
@@ -13,7 +17,7 @@ export default function WelcomeBanner() {
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <h3 className="text-sm font-semibold text-foreground">
-            Welcome to Isnad Graph, {user.name.split(' ')[0]}!
+            Welcome to Isnad Graph, {firstName}!
           </h3>
           <p className="text-sm text-muted-foreground">
             Start exploring hadith chains and narrator networks. Use the search bar to find

--- a/frontend/src/components/__tests__/WelcomeBanner.test.tsx
+++ b/frontend/src/components/__tests__/WelcomeBanner.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import WelcomeBanner from "../WelcomeBanner"
+import type { AuthUser } from "../../hooks/useAuth"
+
+// Mock useAuth — the banner pulls user/isNewUser/dismissOnboarding from context.
+const mockUseAuth = vi.fn()
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+function makeUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: "6cf04f80-ede7-42e6-9756-43f8ce8f220d",
+    email: "jane@example.com",
+    display_name: "Jane Smith",
+    avatar_url: null,
+    email_verified: true,
+    is_active: true,
+    locale: null,
+    created_at: "2026-04-20T03:09:36.076621Z",
+    roles: [],
+    ...overrides,
+  }
+}
+
+describe("WelcomeBanner", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+  })
+
+  it("greets the user by first name when display_name is set", () => {
+    mockUseAuth.mockReturnValue({
+      user: makeUser({ display_name: "Jane Smith" }),
+      isNewUser: true,
+      dismissOnboarding: vi.fn(),
+    })
+
+    render(<WelcomeBanner />)
+
+    expect(
+      screen.getByText("Welcome to Isnad Graph, Jane!"),
+    ).toBeInTheDocument()
+  })
+
+  it("falls back to email local-part when display_name is null (does NOT crash)", () => {
+    mockUseAuth.mockReturnValue({
+      user: makeUser({ display_name: null, email: "jane@example.com" }),
+      isNewUser: true,
+      dismissOnboarding: vi.fn(),
+    })
+
+    // Regression guard for #825: `user.name.split(...)` used to throw
+    // `TypeError: can't access property "split", e.name is undefined`.
+    expect(() => render(<WelcomeBanner />)).not.toThrow()
+    expect(
+      screen.getByText("Welcome to Isnad Graph, jane!"),
+    ).toBeInTheDocument()
+  })
+
+  it("renders nothing when user is not new", () => {
+    mockUseAuth.mockReturnValue({
+      user: makeUser(),
+      isNewUser: false,
+      dismissOnboarding: vi.fn(),
+    })
+
+    const { container } = render(<WelcomeBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders nothing when user is null (unauthenticated)", () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isNewUser: true,
+      dismissOnboarding: vi.fn(),
+    })
+
+    const { container } = render(<WelcomeBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -3,14 +3,30 @@ import { createElement } from 'react'
 
 export type UserRole = 'viewer' | 'editor' | 'moderator' | 'admin'
 
+/**
+ * Shape of `/api/v1/users/me` (user-service UserRead schema).
+ *
+ * `display_name` is the canonical name field from the API. It can legitimately
+ * be null — consumers MUST null-defense every read (prefer `user.display_name ?? user.email`).
+ *
+ * `is_admin`, `provider`, and `role` are NOT returned by the API directly; they
+ * are kept here as optional so code paths that derive them via JWT claims on the
+ * isnad-graph side can still populate them. Treat as best-effort.
+ */
 export interface AuthUser {
   id: string
   email: string
-  name: string
-  is_admin: boolean
-  provider: string
-  role: UserRole | null
+  display_name: string | null
+  avatar_url: string | null
   email_verified: boolean
+  is_active: boolean
+  locale: string | null
+  created_at: string
+  roles: Array<{ id: string; name: string }>
+  // Derived fields (not in user-service /users/me payload — may be undefined).
+  is_admin?: boolean
+  provider?: string
+  role?: UserRole | null
 }
 
 interface AuthContextValue {

--- a/frontend/src/pages/TrialExpiredPage.tsx
+++ b/frontend/src/pages/TrialExpiredPage.tsx
@@ -76,7 +76,7 @@ export default function TrialExpiredPage() {
             marginBottom: 'var(--spacing-8)',
           }}
         >
-          {user?.name ? `${user.name}, your` : 'Your'} 7-day free trial of Isnad Graph has
+          {user?.display_name ? `${user.display_name}, your` : 'Your'} 7-day free trial of Isnad Graph has
           expired. Upgrade to a paid plan to continue exploring hadith chains, narrator networks,
           and scholarly analysis tools.
         </p>


### PR DESCRIPTION
## Summary

Fixes #825. Frontend read `user.name` in 5 places, but user-service `/api/v1/users/me` returns `display_name`. **WelcomeBanner crashed the app post-login** (`TypeError: can't access property "split", e.name is undefined`); `UserMenu`, `Sidebar`, and `TrialExpiredPage` degraded silently (empty initials / fell back to email).

HAR-verified API payload (2026-04-19, owner's first login):

```json
{
  "email": "parametrization@gmail.com",
  "display_name": "Steven French",
  "id": "6cf04f80-ede7-42e6-9756-43f8ce8f220d",
  "email_verified": true,
  "avatar_url": "...",
  "locale": null,
  "is_active": true,
  "created_at": "...",
  "roles": []
}
```

No `name` field. Five consumers were broken.

## Files changed (6; +120 / -13)

| File | Change |
|---|---|
| `frontend/src/hooks/useAuth.ts` | `AuthUser.name: string` -> `display_name: string \| null`, align rest of type with user-service UserRead schema (`avatar_url`, `is_active`, `locale`, `created_at`, `roles[]`). Kept `is_admin`/`provider`/`role` as optional (JWT-derived, not in `/users/me` payload). |
| `frontend/src/components/WelcomeBanner.tsx` | **Crash fix.** `user.display_name?.split(' ')[0] ?? user.email.split('@')[0]`. |
| `frontend/src/components/UserMenu.tsx` | Initials derived from `display_name ?? email`; provider chip rendered only when defined. |
| `frontend/src/components/Sidebar.tsx` | `user.display_name ?? user.email`. |
| `frontend/src/pages/TrialExpiredPage.tsx` | `user?.display_name ? ... : 'Your'`. |
| `frontend/src/components/__tests__/WelcomeBanner.test.tsx` | **New.** 4 tests incl. regression guard for `display_name = null` (must not throw). |

Every site null-defences `display_name` per the user-service schema — the test user had `locale: null`, so `display_name: null` is a live possibility.

## Context / sequencing

App was unusable post-login until this lands. The OAuth login chain now works end-to-end as of today (after #133 / #138 / #139 merged into main this morning), and **this is the next blocker**. The HAR attached to #825 is the immediate repro.

Root cause: frontend was written against a hypothetical older API contract; no OpenAPI-generated client exists yet. Follow-up appetite: generate TypeScript types from user-service's OpenAPI schema so this class of drift is caught at build time — that's a larger ergonomic improvement and should be filed separately.

## Test plan

- [x] `npm run lint` — 0 errors (11 pre-existing warnings in TimelinePage / ConfigPage, unrelated).
- [x] `npm run test` — 36 passed, including 4 new WelcomeBanner tests.
- [x] `npm run build` — clean `tsc && vite build`.
- [ ] Manual smoke: log in via Google OAuth on staging, verify WelcomeBanner renders "Welcome to Isnad Graph, Steven!", UserMenu initials render, Sidebar shows display name, no console errors.

## Reviewers

- **Anya Kowalczyk** (Tech Lead) — type safety + breadth across the 5 consumer sites.
- **Marisol Vega-Cruz** (QA) — test coverage, regression guard shape.

TechDebt: none
