### PR TITLE
fix(frontend): derive RBAC role + isAdmin from user.roles, fix roles type (#828)

### DIFF
--- a/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest"
+
+import { deriveHighestRole } from "../useAuth"
+
+describe("deriveHighestRole", () => {
+  it("returns 'admin' when roles contains 'admin'", () => {
+    expect(deriveHighestRole(["admin"])).toBe("admin")
+  })
+
+  it("returns 'viewer' when roles is empty", () => {
+    expect(deriveHighestRole([])).toBe("viewer")
+  })
+
+  it("returns the highest tier when multiple frontend-known roles are present", () => {
+    // moderator (rank 2) beats editor (rank 1)
+    expect(deriveHighestRole(["editor", "moderator"])).toBe("moderator")
+    // admin (rank 3) beats everything
+    expect(deriveHighestRole(["viewer", "editor", "moderator", "admin"])).toBe(
+      "admin",
+    )
+  })
+
+  it("ignores backend role names that are not in the UserRole union", () => {
+    // user-service DB roles `researcher`, `reader`, `trial` aren't in
+    // the frontend UserRole union yet — they should be skipped.
+    expect(deriveHighestRole(["researcher", "reader", "trial"])).toBe("viewer")
+  })
+
+  it("picks the highest matching tier even when unknown roles are mixed in", () => {
+    expect(deriveHighestRole(["researcher", "admin"])).toBe("admin")
+    expect(deriveHighestRole(["reader", "editor"])).toBe("editor")
+  })
+
+  it("returns the single matching tier when only one known role is present", () => {
+    expect(deriveHighestRole(["editor"])).toBe("editor")
+    expect(deriveHighestRole(["moderator"])).toBe("moderator")
+    expect(deriveHighestRole(["viewer"])).toBe("viewer")
+  })
+})
+
+// isAdmin derivation mirrors what AuthProvider does inline:
+//   const isAdmin = (user?.roles ?? []).includes('admin')
+// These guard the contract: admin UI should light up iff 'admin' is present.
+describe("isAdmin derivation (AuthProvider contract)", () => {
+  const isAdminFrom = (roles: string[] | undefined): boolean =>
+    (roles ?? []).includes("admin")
+
+  it("is true when roles contains 'admin'", () => {
+    expect(isAdminFrom(["admin"])).toBe(true)
+  })
+
+  it("is false when roles contains only non-admin roles", () => {
+    expect(isAdminFrom(["reader"])).toBe(false)
+    expect(isAdminFrom(["researcher", "reader", "trial"])).toBe(false)
+  })
+
+  it("is false when roles is empty or undefined", () => {
+    expect(isAdminFrom([])).toBe(false)
+    expect(isAdminFrom(undefined)).toBe(false)
+  })
+
+  it("is true when 'admin' appears alongside other roles", () => {
+    expect(isAdminFrom(["reader", "admin"])).toBe(true)
+  })
+})

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -9,9 +9,15 @@ export type UserRole = 'viewer' | 'editor' | 'moderator' | 'admin'
  * `display_name` is the canonical name field from the API. It can legitimately
  * be null — consumers MUST null-defense every read (prefer `user.display_name ?? user.email`).
  *
- * `is_admin`, `provider`, and `role` are NOT returned by the API directly; they
- * are kept here as optional so code paths that derive them via JWT claims on the
- * isnad-graph side can still populate them. Treat as best-effort.
+ * `roles` is a list of role *names* (strings), matching user-service
+ * `UserRead.roles: list[str]` in `src/app/schemas/user.py`. Serialized from
+ * `[ur.role.name for ur in u.user_roles]` in `src/app/routers/users.py`. Use
+ * `deriveHighestRole(roles)` to map to the `UserRole` union.
+ *
+ * `provider` is NOT part of the user-service `/users/me` payload today; it is
+ * kept here as optional because the OAuth callback path on the isnad-graph
+ * side may populate it from JWT claims before the user is loaded. Readers
+ * (e.g. `UserMenu`) already null-guard it, so it gracefully degrades.
  */
 export interface AuthUser {
   id: string
@@ -22,11 +28,10 @@ export interface AuthUser {
   is_active: boolean
   locale: string | null
   created_at: string
-  roles: Array<{ id: string; name: string }>
-  // Derived fields (not in user-service /users/me payload — may be undefined).
-  is_admin?: boolean
+  roles: string[]
+  // Optional — not returned by /users/me today; may be populated from JWT
+  // claims during OAuth callback. See UserMenu.tsx for the sole reader.
   provider?: string
-  role?: UserRole | null
 }
 
 interface AuthContextValue {
@@ -50,6 +55,28 @@ const ROLE_HIERARCHY: Record<UserRole, number> = {
   editor: 1,
   moderator: 2,
   admin: 3,
+}
+
+/**
+ * Map a list of role names (as returned by user-service) to the highest
+ * matching `UserRole` in the frontend hierarchy. Unknown role names
+ * (e.g. user-service DB roles like `researcher`, `reader`, `trial` that
+ * aren't yet represented in the frontend union) are ignored — callers
+ * default to `viewer` for fully-unknown sets.
+ *
+ * NOTE: if `UserRole` is extended to cover additional backend roles, add
+ * them to `ROLE_HIERARCHY` above and they will automatically participate
+ * in derivation here (we iterate the hierarchy highest-first).
+ */
+export function deriveHighestRole(roleNames: string[]): UserRole {
+  // Iterate ROLE_HIERARCHY from highest rank to lowest; return first match.
+  const ordered = (Object.keys(ROLE_HIERARCHY) as UserRole[]).sort(
+    (a, b) => ROLE_HIERARCHY[b] - ROLE_HIERARCHY[a],
+  )
+  for (const tier of ordered) {
+    if (roleNames.includes(tier)) return tier
+  }
+  return 'viewer'
 }
 
 const AUTH_BASE = '/auth'
@@ -266,7 +293,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  const userRole: UserRole = user?.role ?? 'viewer'
+  const userRole: UserRole = deriveHighestRole(user?.roles ?? [])
+  const isAdmin = (user?.roles ?? []).includes('admin')
 
   const hasRole = useCallback(
     (minRole: UserRole): boolean => {
@@ -278,7 +306,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const value: AuthContextValue = {
     user,
     loading,
-    isAdmin: user?.is_admin ?? false,
+    isAdmin,
     role: userRole,
     hasRole,
     sessionExpired,


### PR DESCRIPTION
## Summary

Closes #828. Anya's review of PR #827 surfaced that `frontend/src/hooks/useAuth.ts` typed `roles` as `Array<{id, name}>` while the user-service `UserRead` API actually returns `list[str]` (role names). On top of that, the provider was reading `user.role` / `user.is_admin` — fields the `/users/me` endpoint never returns — so every authenticated user silently landed on `role = 'viewer'` / `isAdmin = false` regardless of backend-assigned roles.

- `AuthUser.roles` retyped `string[]` to match user-service `UserRead.roles: list[str]` (`src/app/routers/users.py` serializes `[ur.role.name for ur in u.user_roles]`).
- Dropped never-populated optional `is_admin` and `role` fields. Kept `provider?` (sole reader: `UserMenu.tsx`, which already null-guards — documented as JWT-claim-derived, not API-returned).
- New exported `deriveHighestRole(roleNames: string[]): UserRole` walks `ROLE_HIERARCHY` highest-first and returns the first match; unknown backend names (`researcher`/`reader`/`trial`) fall through to `'viewer'` until the frontend `UserRole` union is extended.
- `isAdmin` now derived as `(user?.roles ?? []).includes('admin')` — admin menu items, `AdminRoute`, `AdminLayout` guards, and the `Sidebar` admin section will now correctly reveal for users who have the `admin` role in the user-service DB.

## Operational urgency

The orchestrator granted the owner account the `admin` role in user-service today. Without this fix the admin UI is invisible to owner. **Requesting we combine the frontend deploy with #827's publish for one deploy cycle** rather than two.

## Cross-refs

- Issue: #828
- Discovered during: #827 review (Anya Kowalczyk)
- Related user-service sources cited in issue body

## Test plan

- [x] `npm run lint` — 0 errors (11 pre-existing warnings on `TimelinePage`/`ConfigPage`, unrelated)
- [x] `npm run test` — 46 passed, 10 new in `src/hooks/__tests__/useAuth.test.ts`
- [x] `npm run build` — tsc strict + vite production build clean
- [ ] Manual: after deploy, log in as owner, verify admin sidebar section + `/admin` routes are accessible
- [ ] Manual: verify non-admin users (empty roles) still see only non-admin nav (regression guard)

## Notes for reviewers

- Admin UI guards that consume this hook (`AdminRoute.tsx`, `AdminLayout.tsx`, `Sidebar.tsx`) are **unchanged** — they already delegate to `isAdmin` / `hasRole` from context, so they pick up the fix automatically. No additional surgery needed here.
- Unknown role tiers (`researcher`/`reader`/`trial`) intentionally collapse to `viewer` for now. Extending the `UserRole` union is a separate decision; tests guard the collapse behavior so it's explicit, not accidental.

TechDebt: none

Reviewers: @Anya-Kowalczyk (Tech Lead — type safety + derivation correctness; filed #828) and @Marisol-Vega-Cruz (QA — test coverage of new derivation paths).

Generated with Claude Code.