### PR TITLE
fix(frontend): admin bypass + retry:false on /subscriptions/me (#830)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -195,8 +195,22 @@ export async function flagContent(
 
 // --- Subscription ---
 
-export async function fetchSubscription(): Promise<SubscriptionResponse> {
-  return fetchJson(`${API_BASE}/subscriptions/me`)
+// 404 from /subscriptions/me is a terminal "no subscription" data state
+// (free tier / admin), not an error. Resolve it to null and let callers
+// branch on `subscription === null`. Other non-OK statuses throw as usual.
+export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | null> {
+  const res = await fetch(`${API_BASE}/subscriptions/me`, {
+    headers: getAuthHeaders(),
+    credentials: 'include',
+  })
+  if (res.status === 404) return null
+  if (!res.ok) {
+    if (res.status === 401) {
+      emitSessionExpired()
+    }
+    throw new Error(`API error: ${res.status} ${res.statusText}`)
+  }
+  return res.json() as Promise<SubscriptionResponse>
 }
 
 // --- Admin: Reports ---

--- a/frontend/src/hooks/__tests__/useSubscription.test.tsx
+++ b/frontend/src/hooks/__tests__/useSubscription.test.tsx
@@ -1,0 +1,125 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+import { useSubscription } from "../useSubscription"
+
+vi.mock("../../api/client", () => ({
+  fetchSubscriptionOrNull: vi.fn(),
+}))
+
+vi.mock("../useAuth", () => ({
+  useAuth: vi.fn(),
+}))
+
+import { fetchSubscriptionOrNull } from "../../api/client"
+import { useAuth } from "../useAuth"
+
+const mockFetch = fetchSubscriptionOrNull as ReturnType<typeof vi.fn>
+const mockUseAuth = useAuth as ReturnType<typeof vi.fn>
+
+function wrapper({ children }: { children: ReactNode }) {
+  // New client per test so queries don't share cache between cases.
+  // Match app defaults (retry: 1) to prove the hook's own retry:false wins.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: 1 } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function authAs(opts: { user: unknown; isAdmin: boolean }) {
+  mockUseAuth.mockReturnValue({
+    user: opts.user,
+    loading: false,
+    isAdmin: opts.isAdmin,
+    role: opts.isAdmin ? "admin" : "viewer",
+    hasRole: () => opts.isAdmin,
+    sessionExpired: false,
+    isNewUser: false,
+    logout: vi.fn(),
+    signOut: vi.fn(),
+    signOutAll: vi.fn(),
+    dismissSessionExpired: vi.fn(),
+    dismissOnboarding: vi.fn(),
+    refreshUser: vi.fn(),
+  })
+}
+
+describe("useSubscription", () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockUseAuth.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not fetch when user is admin (bypass — admins have no subscription)", async () => {
+    authAs({ user: { id: "u1", email: "a@b.c" }, isAdmin: true })
+
+    const { result } = renderHook(() => useSubscription(), { wrapper })
+
+    // Let any pending microtasks flush — the query must stay disabled.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(result.current.subscription).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("does not fetch when no user is authenticated", async () => {
+    authAs({ user: null, isAdmin: false })
+
+    renderHook(() => useSubscription(), { wrapper })
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("fetches for non-admin authenticated users", async () => {
+    authAs({ user: { id: "u1", email: "a@b.c" }, isAdmin: false })
+    mockFetch.mockResolvedValue({
+      tier: "trial",
+      status: "trial",
+      days_remaining: 5,
+      trial_start: "2026-01-01",
+      trial_expires: "2026-01-15",
+    })
+
+    const { result } = renderHook(() => useSubscription(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.current.isTrial).toBe(true)
+    expect(result.current.daysRemaining).toBe(5)
+  })
+
+  it("treats a 404 (no subscription) as null without retrying", async () => {
+    authAs({ user: { id: "u1", email: "a@b.c" }, isAdmin: false })
+    // The fetch helper resolves null on 404 — the hook must surface that as
+    // `subscription: null` (terminal state, no retry storm).
+    mockFetch.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useSubscription(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.current.subscription).toBeNull()
+    expect(result.current.error).toBeNull()
+  })
+
+  it("does not retry on a 500 error (proves retry:false applies to real errors too)", async () => {
+    authAs({ user: { id: "u1", email: "a@b.c" }, isAdmin: false })
+    mockFetch.mockRejectedValue(new Error("API error: 500 Internal Server Error"))
+
+    const { result } = renderHook(() => useSubscription(), { wrapper })
+
+    await waitFor(() => expect(result.current.error).toBeTruthy())
+    // retry:false on the hook overrides the global retry:1 default — exactly
+    // one call, and the error surfaces rather than being swallowed.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.current.subscription).toBeNull()
+  })
+})

--- a/frontend/src/hooks/useSubscription.ts
+++ b/frontend/src/hooks/useSubscription.ts
@@ -1,15 +1,19 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchSubscription } from '../api/client'
+import { fetchSubscriptionOrNull } from '../api/client'
 import type { SubscriptionResponse } from '../types/api'
 import { useAuth } from './useAuth'
 
 export function useSubscription() {
-  const { user } = useAuth()
+  const { user, isAdmin } = useAuth()
 
-  const { data, isLoading, error } = useQuery<SubscriptionResponse>({
+  // Admins have no subscription concept — skip the call entirely. A 404 from
+  // /subscriptions/me is a terminal "no subscription" data state, so we treat
+  // it as `null` instead of an error and disable retry (see #830).
+  const { data, isLoading, error } = useQuery<SubscriptionResponse | null>({
     queryKey: ['subscription'],
-    queryFn: fetchSubscription,
-    enabled: !!user,
+    queryFn: fetchSubscriptionOrNull,
+    enabled: !!user && !isAdmin,
+    retry: false,
     staleTime: 60 * 1000,
     refetchInterval: 5 * 60 * 1000,
   })


### PR DESCRIPTION
## Summary

Fixes #830. Post-login infinite spin — the frontend hammered `GET /api/v1/subscriptions/me` ~70 times in 20 seconds (all 404), locking the project owner (admin) out of the app.

Two defects, fixed together:

1. **Admin bypass** — admins have no subscription concept; the call was fired anyway. Now `useSubscription` reads `isAdmin` (from the `useAuth` derivation that landed in #829) and sets `enabled: !!user && !isAdmin`.
2. **404-as-terminal** — a 404 response meant "no subscription → free tier", but TanStack Query inherited the app-level `retry: 1` and treated it as a retryable error. Now `retry: false` is set on the hook and the fetch helper resolves 404 → `null` (caught in `fetchSubscriptionOrNull` so the existing `fetchJson` contract is untouched).

Backend is correct — user-service returns 404 for missing subscriptions intentionally (`noorinalabs-user-service/src/app/routers/subscriptions.py:23-35`). No backend change.

## Files changed

- `frontend/src/hooks/useSubscription.ts` — admin bypass + `retry: false`; widened return type to `SubscriptionResponse | null`
- `frontend/src/api/client.ts` — new `fetchSubscriptionOrNull` (404 → null, other non-2xx throw); the 404-is-data-state stays scoped to this one endpoint
- `frontend/src/hooks/__tests__/useSubscription.test.tsx` *(new)* — 5 cases: admin skip, unauthenticated skip, non-admin enabled, 404→null, 500→error with exactly one fetch call (proves retry is off)

Consumers (`UserMenu`, `TrialBanner`, `PricingPage`) already branch on `subscription === null`; public return shape is unchanged.

## Verification

- `npm test -- --run` — 51/51 passing (5 new, 46 existing)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors on changed files

## Related

- #829 (RBAC derivation — just landed; supplies the `isAdmin` helper consumed here)
- #831 (latent `ProtectedRoute` re-mount amplifier — tracked separately; this PR fixes the trigger, #831 fixes the amplifier)
- #161 (role union divergence — same class of admin-fallthrough bug; distinct fix path)

## Reviewers

Requesting Anya Kowalczyk and Jelani Mwangi (frontend peers).

Closes #830
