### PR TITLE
fix(frontend): make removed DashboardStats fields optional, render placeholder

### DIFF
--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -99,11 +99,11 @@ export interface RoleCount {
 }
 
 export interface DashboardStats {
-  total_users: number
-  active_users: number
-  suspended_users: number
-  users_by_role: RoleCount[]
-  new_registrations_7d: number
+  total_users?: number
+  active_users?: number
+  suspended_users?: number
+  users_by_role?: RoleCount[]
+  new_registrations_7d?: number
   active_sessions: number
 }
 

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -44,6 +44,12 @@ export default function DashboardPage() {
   if (error) return <p className="error-text">Error: {(error as Error).message}</p>
   if (!data) return null
 
+  const hasUserStats =
+    data.total_users !== undefined ||
+    data.active_users !== undefined ||
+    data.suspended_users !== undefined ||
+    data.new_registrations_7d !== undefined
+
   return (
     <div>
       <h2>Admin Dashboard</h2>
@@ -57,45 +63,66 @@ export default function DashboardPage() {
           marginTop: 'var(--spacing-4)',
         }}
       >
-        <StatCard label="Total Users" value={data.total_users} />
-        <StatCard label="Active Users" value={data.active_users} />
-        <StatCard label="Suspended Users" value={data.suspended_users} />
-        <StatCard label="New (7d)" value={data.new_registrations_7d} />
+        {data.total_users !== undefined && (
+          <StatCard label="Total Users" value={data.total_users} />
+        )}
+        {data.active_users !== undefined && (
+          <StatCard label="Active Users" value={data.active_users} />
+        )}
+        {data.suspended_users !== undefined && (
+          <StatCard label="Suspended Users" value={data.suspended_users} />
+        )}
+        {data.new_registrations_7d !== undefined && (
+          <StatCard label="New (7d)" value={data.new_registrations_7d} />
+        )}
         <StatCard label="Active Sessions" value={data.active_sessions} />
       </div>
 
-      <h3
-        style={{
-          fontFamily: 'var(--font-heading)',
-          fontSize: 'var(--text-base)',
-          marginBottom: 'var(--spacing-3)',
-        }}
-      >
-        Users by Role
-      </h3>
-      <table className="data-table" style={{ maxWidth: 400 }}>
-        <thead>
-          <tr>
-            <th>Role</th>
-            <th>Count</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.users_by_role.map((rc) => (
-            <tr key={rc.role}>
-              <td style={{ textTransform: 'capitalize' }}>{rc.role}</td>
-              <td>{rc.count}</td>
-            </tr>
-          ))}
-          {data.users_by_role.length === 0 && (
-            <tr>
-              <td colSpan={2} style={{ textAlign: 'center', color: 'var(--color-muted-foreground)' }}>
-                No data
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+      {data.users_by_role && data.users_by_role.length > 0 ? (
+        <>
+          <h3
+            style={{
+              fontFamily: 'var(--font-heading)',
+              fontSize: 'var(--text-base)',
+              marginBottom: 'var(--spacing-3)',
+            }}
+          >
+            Users by Role
+          </h3>
+          <table className="data-table" style={{ maxWidth: 400 }}>
+            <thead>
+              <tr>
+                <th>Role</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.users_by_role.map((rc) => (
+                <tr key={rc.role}>
+                  <td style={{ textTransform: 'capitalize' }}>{rc.role}</td>
+                  <td>{rc.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      ) : (
+        !hasUserStats && (
+          <div
+            style={{
+              padding: 'var(--spacing-4)',
+              background: 'var(--color-card)',
+              border: 'var(--border-width-thin) solid var(--color-border)',
+              borderRadius: 'var(--radius-lg)',
+              color: 'var(--color-muted-foreground)',
+              fontSize: 'var(--text-sm)',
+            }}
+          >
+            User statistics have moved to user-service. This panel will return once the
+            cross-service admin API lands (see #806).
+          </div>
+        )
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #834

Backend stripped user-statistics fields from `DashboardStats` during the user-service extraction (`src/api/routes/admin/dashboard.py`), but the frontend types still declared them as required. Result: every admin dashboard load crashed with `Cannot read properties of undefined (reading 'map')` on `users_by_role`.

This PR is a defensive frontend-only fix:

- `frontend/src/api/admin-client.ts` — mark `total_users`, `active_users`, `suspended_users`, `users_by_role`, `new_registrations_7d` optional. `active_sessions` stays required (still returned by backend).
- `frontend/src/pages/admin/DashboardPage.tsx` — guard each removed-field StatCard with `!== undefined`, guard the Users-by-Role table behind `data.users_by_role && length > 0`, and render a one-line placeholder pointing to #806 when no user-stats fields are present.

Backend is correct as-is and is not touched.

## Test Plan

From `frontend/`:

- [x] `npm run build` — passes (TypeScript clean, Vite bundle built)
- [x] `npm run lint` — passes (0 errors; 11 pre-existing warnings in unrelated files)
- [x] `npm run test` — passes (51/51 vitest)
- [ ] Manual browser smoke check post-merge: load `/admin/dashboard` as an admin user, confirm the Active Sessions card renders and the placeholder text appears in place of the user-statistics panels.

## Reviewers

Requested below via comment per charter convention.