### PR TITLE
fix(ci): notify-deploy event-type matches deploy listener after repo rename

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           token: ${{ secrets.DEPLOY_REPO_PAT }}
           repository: noorinalabs/noorinalabs-deploy
-          event-type: deploy-isnad-graph
+          event-type: deploy-noorinalabs-isnad-graph
           client-payload: >-
             {
               "repo": "noorinalabs-isnad-graph",


### PR DESCRIPTION
## Summary

`ghcr-publish.yml`'s `notify-deploy` job dispatches `repository_dispatch` event-type `deploy-isnad-graph`, but the listener at `noorinalabs-deploy/.github/workflows/deploy-isnad-graph.yml` was renamed to expect `deploy-noorinalabs-isnad-graph` when the repo was renamed in `548ba9f`. GitHub returns 204 to dispatches with no matching listener, so the chain has been silently broken since the rename — every isnad-graph main push has required a manual deploy trigger since #821 folded notify-deploy into ghcr-publish.

This PR is a one-line rename of the `event-type` value to match the listener.

## Why this is the fix (and not a re-register)

Initial diagnosis on noorinalabs/noorinalabs-main#162 framed this as a workflow lifecycle issue — that GH had silently de-registered `notify-deploy.yml`. That framing was wrong: PR #821 (merged 2026-04-19) intentionally deleted the standalone workflow and folded the dispatch into `ghcr-publish.yml` to close a race condition (deploy firing before image publish completed). Restoring the deleted file would have re-introduced that race.

The actual breakage is the event-type mismatch verified by direct `gh api` test:
- `event_type=deploy-isnad-graph` (sender's current value) → no listener fires
- `event_type=deploy-noorinalabs-isnad-graph` (listener's expected value) → listener fires (cancelled diagnostic run `24702204998` in deploy repo confirmed end-to-end wiring)

## Test Plan

- [ ] On merge, `gh run list --workflow=ghcr-publish.yml --branch=main --limit=1` shows a Publish run kicking off.
- [ ] After image publish completes, `gh run list --workflow=deploy-isnad-graph.yml --repo=noorinalabs/noorinalabs-deploy --event=repository_dispatch --limit=1` shows a fresh deploy run (first non-`workflow_dispatch` run in the listener's last 8+ runs).
- [ ] Cancelled diagnostic run `24702204998` in the deploy repo already confirmed the corrected event-type wires through end-to-end.
- [ ] If `DEPLOY_REPO_PAT` has expired, the dispatch step will 401 — that's a separate followup, not a regression of this fix.

## Followup

- Record the literal event-type contract (`deploy-noorinalabs-isnad-graph`) in `ontology/services.yaml` and `ontology/repos/deploy.yaml` so the next rename catches the divergence at edit time.
- Charter § Load-Bearing Followups: file a dedicated issue to add a positive-signal step (commit comment or run-summary annotation) so future silent dispatch failures are visible. Out of scope here per orchestrator's single-purpose-PR direction.

Refs noorinalabs/noorinalabs-main#162