### PR TITLE
fix(frontend): extract theme-flash IIFE to public/theme-init.js for CSP

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,17 +11,7 @@
       rel="stylesheet"
     />
     <title>Isnad Graph — Hadith Analysis Platform</title>
-    <script>
-      // Set data-theme before first paint to prevent flash of wrong theme
-      (function() {
-        var stored = localStorage.getItem('isnad-graph-theme');
-        var theme = stored === 'light' || stored === 'dark' ? stored
-          : stored === 'system' || !stored
-            ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-            : 'light';
-        document.documentElement.setAttribute('data-theme', theme);
-      })();
-    </script>
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/theme-init.js
+++ b/frontend/public/theme-init.js
@@ -1,0 +1,13 @@
+// Set data-theme before first paint to prevent flash of wrong theme
+(function () {
+  var stored = localStorage.getItem('isnad-graph-theme');
+  var theme =
+    stored === 'light' || stored === 'dark'
+      ? stored
+      : stored === 'system' || !stored
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light'
+        : 'light';
+  document.documentElement.setAttribute('data-theme', theme);
+})();


### PR DESCRIPTION
Closes #838

## Summary

The inline `<script>` block in `frontend/index.html` was silently blocked by the production Caddy CSP (`script-src 'self'`) since 1449e08, causing a flash of incorrect theme on first paint for users whose stored theme differed from OS default. Vite dev server doesn't enforce Caddy's CSP, so the bug only surfaced in production.

Moved the IIFE to `frontend/public/theme-init.js` so it loads from origin and satisfies `'self'`. Vite copies `public/` files to the build output verbatim — no bundling, no hashing, URL stays `/theme-init.js` in dev and prod. No `vite.config` changes needed. No CSP changes needed (avoids brittle hash coupling with the `noorinalabs-deploy` Caddyfile).

Diff: 2 files, +14 / -11 (the new file is 14 lines including the preserved comment; `index.html` drops 11 lines and adds the `<script src>` reference).

## Test Plan

Local validation (all green):
- [x] `npm run build` — succeeded; `dist/theme-init.js` present in build output and `dist/index.html` references `/theme-init.js`
- [x] `npm run lint` — 0 errors (11 pre-existing warnings in unrelated files)
- [x] `npm run test` — 51/51 passed

Post-deploy verification (per issue #838):
- [ ] `curl -I https://<prod-host>/theme-init.js` returns 200 with `Content-Type: application/javascript` (or `text/javascript`)
- [ ] Browser DevTools → Network: `/theme-init.js` loads with no CSP violation
- [ ] Browser DevTools → Console: no `Refused to execute inline script` warnings on first load
- [ ] Set `localStorage['isnad-graph-theme'] = 'dark'` while OS is light (or vice versa), hard-refresh — no flash of incorrect theme on first paint