### PR TITLE
ci(ghcr): emit stg-<short> + stg-latest for same-SHA promotion (#815)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -145,13 +145,25 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image }}
+          # Tag scheme (isnad-graph#815 Contract, 2026-04-22):
+          #   sha-<short>   — immutable, one per push; written here on every event
+          #   latest        — mutable pointer; written here on main + semver tags
+          #   stg           — mutable pointer; written here ONLY on push to main
+          #                   (deploys to staging consume :stg)
+          #   prod          — mutable pointer; written by deploy#84's promotion
+          #                   workflow, NOT this file. Promotion re-tags a
+          #                   :sha-<short> as :prod (registry-side, no rebuild).
           tags: |
             # Git tag (e.g., v1.2.3 or phase12-wave1)
             type=ref,event=tag
-            # Short SHA (e.g., sha-a1b2c3d) on every event
+            # Short SHA (e.g., sha-a1b2c3d) on every event — IMMUTABLE anchor
             type=sha,prefix=sha-,format=short
             # Latest on main-branch push or semver tags
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            # Staging pointer on main-branch push — consumers pull :stg to pick
+            # up the latest main build; promotion (deploy#84) retags a specific
+            # :sha-<short> as :prod without rebuilding.
+            type=raw,value=stg,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         id: build
@@ -172,9 +184,9 @@ jobs:
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           # Scan by digest — guaranteed to exist immediately after push and
-          # immune to tag-resolution races. The previous tag-based form broke
-          # on main pushes because metadata-action only emits :latest + :sha-*
-          # (no :main). See user-service#61 retro.
+          # immune to tag-resolution races. metadata-action emits :latest,
+          # :sha-*, and (on main) :stg — never :main. Digest is the one
+          # stable handle across all of them. See user-service#61 retro.
           image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: table
           exit-code: "1"

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -145,14 +145,19 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image }}
-          # Tag scheme (isnad-graph#815 Contract, 2026-04-22):
+          # Tag scheme (isnad-graph#815 Contract v5 = option C, 2026-04-23):
           #   sha-<short>   — immutable, one per push; written here on every event
           #   latest        — mutable pointer; written here on main + semver tags
-          #   stg           — mutable pointer; written here ONLY on push to main
-          #                   (deploys to staging consume :stg)
-          #   prod          — mutable pointer; written by deploy#84's promotion
-          #                   workflow, NOT this file. Promotion re-tags a
-          #                   :sha-<short> as :prod (registry-side, no rebuild).
+          #   stg-<short>   — immutable per-push, stg namespace; written here ONLY
+          #                   on push to main. Tag history = stg deploy log.
+          #   stg-latest    — moving pointer to most-recent stg-<short>; written
+          #                   here ONLY on push to main. Consumers pull this for
+          #                   a stable target without chasing SHAs.
+          #   prod-<short>  — immutable per-promotion, prod namespace; written by
+          #                   deploy#84 ONLY, NOT this file. Tag history = promotion log.
+          #   prod-latest   — moving pointer; written by deploy#84 ONLY.
+          # deploy#84 writes both prod-* tags in one `docker buildx imagetools
+          # create` invocation — registry-side manifest rewrite, no rebuild.
           tags: |
             # Git tag (e.g., v1.2.3 or phase12-wave1)
             type=ref,event=tag
@@ -160,10 +165,10 @@ jobs:
             type=sha,prefix=sha-,format=short
             # Latest on main-branch push or semver tags
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
-            # Staging pointer on main-branch push — consumers pull :stg to pick
-            # up the latest main build; promotion (deploy#84) retags a specific
-            # :sha-<short> as :prod without rebuilding.
-            type=raw,value=stg,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            # stg-<short> per-push in stg namespace — IMMUTABLE, push-to-main only
+            type=sha,prefix=stg-,format=short,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            # stg-latest moving pointer — push-to-main only
+            type=raw,value=stg-latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         id: build
@@ -185,8 +190,9 @@ jobs:
         with:
           # Scan by digest — guaranteed to exist immediately after push and
           # immune to tag-resolution races. metadata-action emits :latest,
-          # :sha-*, and (on main) :stg — never :main. Digest is the one
-          # stable handle across all of them. See user-service#61 retro.
+          # :sha-*, and (on main) :stg-* + :stg-latest — never :main.
+          # Digest is the one stable handle across all of them. See
+          # user-service#61 retro.
           image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: table
           exit-code: "1"


### PR DESCRIPTION
## Summary

Extend `.github/workflows/ghcr-publish.yml` to emit four tags on push-to-main per Contract v6 (option C, v3 shape restored) — all pointing at the same built digest via a single `docker/build-push-action` step.

This is the **Contract PR** for W10 Section A image-tagging. `user-service#64` and `landing-page#68` replicate this scheme verbatim; `deploy#84` consumes it (reads `stg-latest` or explicit `sha-<short>`, writes `prod-<short>` + `prod-latest` via registry-side retag).

**Rework history on this PR:** first commit implemented option A (`:stg` bare mutable pointer) from the stale spawn brief. Second commit (`401e4a5`) reworks to option C per the authoritative Contract. PR body `## Contract` section was then re-synced to **v6** (program-director ruling-language lock-in for retro audit) at https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921 — v6 is substantively identical to v5/v3 (same four-tag emit, same consumer spec); the change is ruling-language only. Preserved commit history (no force-push) so the adjudication trail is auditable.

Closes #815. Refs noorinalabs/noorinalabs-main#141 (W10 meta).

## Contract — v6 (per program-director ruling: v3 shape restored, process-drift correction)

Posted 2026-04-23 on explicit program-director instruction from Nadia Khoury. This is a **process-drift correction, not a technical reconsideration** — v3's audit-symmetry rationale stands unchanged.

### Context for this version

v4 (https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301445174) was an over-correction I (Nadia Boukhari, Contract owner) posted after misreading a paraphrased "#84 spec" description as implicit signal for option A. The program director had not issued a revert ruling; I acted on inferred signal before explicit confirmation arrived. v5 (https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301487132) restored option C with consumer-retraction rationale but without explicitly framing v4 as a process-drift correction per the program director's ruling language.

**v6 marks the v4 revert explicitly** as the program director instructed: "reverted 2026-04-23 on coordinator instruction — process-drift correction, not technical reconsideration; v3's audit-symmetry rationale stands."

v6 content is **substantively identical to v5**, which is substantively identical to v3. The three are all option C / same tag scheme. v6 exists to lock the program director's ruling language into the comment trail for the retro audit.

### Authoritative tag scheme — option C, v3-restored, unchanged across v3/v5/v6

| Tag | Mutability | Written by |
|---|---|---|
| `sha-<short>` | Immutable | `ghcr-publish.yml` push-to-main (from #821) |
| `latest` | Mutable | `ghcr-publish.yml` push-to-main (existing) |
| `stg-<short>` | **Immutable per-push, stg namespace** | `ghcr-publish.yml` push-to-main (NEW in #815) |
| `stg-latest` | Moving pointer | `ghcr-publish.yml` push-to-main (NEW in #815) |
| `prod-<short>` | **Immutable per-promotion, prod namespace** | deploy#84 ONLY |
| `prod-latest` | Moving pointer | deploy#84 ONLY |

`<short>` = 7-char short SHA.

### Scope for isnad-graph#815

**This PR emits:** `sha-<short>` + `latest` + `stg-<short>` + `stg-latest` (four tags, same digest, for both `api` and `frontend` matrix components).

**This PR does NOT emit:** any `prod-*` tag. deploy#84 is the exclusive writer of `prod-<short>` and `prod-latest` via registry-side retag at promotion time.

### Rationale (unchanged, program-director-endorsed)

1. **Env-namespace auditability** — `gh api ... tags | grep stg-` or `grep prod-` answers "what was ever in {env}?" as a single query.
2. **Parallel shape** for stg and prod reduces cognitive load for deploy#84 consumers and humans reading the registry.
3. **Moving `-latest` pointers** give consumers a stable pull target without chasing SHAs.
4. **Zero marginal cost** — `docker buildx imagetools create` writes multiple tags per invocation; `docker/metadata-action` does the same on the build side. No extra work.
5. **Rollback log for free** — `prod-<short>` tag history IS the promotion log, no separate record needed.

### Consumer spec for deploy#84 (Bereket)

- Default source on promotion: resolve digest of `stg-latest` (or equivalently `stg-<short>`).
- Optional source: `workflow_dispatch` accepts explicit `sha-<short>` for rollback / specific-SHA promotion.
- Action: single `docker buildx imagetools create` invocation writes BOTH `prod-<short>` AND `prod-latest` against the adjudicated digest.
- Rollback: same mechanism with a historical `sha-<short>` input.

### Divergence allowed (verbatim in user-service#64 and landing-page#68)

- Image name differs: `noorinalabs-user-service`, `noorinalabs-landing-page`.
- Suffix convention identical: `sha-<short>` + `latest` + `stg-<short>` + `stg-latest`.
- Multi-arch platforms may differ (frontend remains amd64-only per #821 side-effect #4).

### Ownership

**Contract owner:** Nadia Boukhari. Divergence requests go to me; I adjudicate or escalate to Nadia Khoury.

**Program-director ruling 2026-04-23:** v3 shape is authoritative. v4 revert was process-drift, not technical reconsideration. v5 restored shape with consumer-retraction framing; v6 re-states with explicit program-director framing for retro audit.

### Charter

- Branch: `L.Pham/0815-image-tagging-stg-prod`
- Commit identity: per-commit flags only (Linh Pham / parametrization+Linh.Pham@gmail.com). Never `--no-verify`. Never modify global/repo identity settings.
- PR body MUST reproduce THIS `## Contract` section verbatim (NOT v1/v2/v3/v4/v5 — all superseded; v6 is current authoritative version).
- 2 named reviewers (Arjun Raghavan + Anya Kowalczyk), charter-format comments (Requestor/Requestee/RequestOrReplied + TechDebt line).
- `/ontology-librarian` mandatory first action per agent (Hook 15).

---

### Version history

- v1 (kickoff, option B): `stg-{SHA}` / `prod-{SHA}` written by ghcr-publish.yml — rejected (cross-repo DRY, separation of concerns).
- v2 (issuecomment-4301408087, option A first lock): moving-pointer-only `stg`/`prod`. Superseded.
- v3 (issuecomment-4301425114, option C first ruling): current tag shape — see table above. Superseded by v4 (my over-correction).
- v4 (issuecomment-4301445174, option A revert): **PROCESS-DRIFT CORRECTION REVERTED** — I posted v4 inferring policy from a paraphrased "#84 spec" that the program director has confirmed was her flattening error, not policy. Superseded by v5.
- v5 (issuecomment-4301487132, option C restored): same tag shape as v3, with consumer-retraction framing. Superseded by v6 for ruling-language explicitness.
- **v6 (this comment): option C, v3 shape restored, with program-director ruling-language explicitly marked for retro audit. Current authoritative version.**

### Retro commitments (Boukhari)

1. Contract owner should not post a revision on implicit signal before explicit program-director confirmation when explicit confirmation has been requested.
2. Contract owner should treat consumer ACKs as closing signals, not mid-flight input.
3. "Cite canonical URL, don't paraphrase" — applied rigorously, including to my own action reports: lead every Contract-state message with `Contract is at vN, URL=X` regardless of what I think the recipient has seen.
4. Before proposing a revert, verify whether the signal driving it is independent evidence or a downstream echo of my own earlier paraphrase.

### Retro commitment (shared, per program-director)

Latency in Contract-authority response is also a process issue; "I didn't reply fast enough" is not a license for Contract-owner to act on inferred signal. Both sides addressed in W10 retro.

## What changed in this PR

One file: `.github/workflows/ghcr-publish.yml`.

### Commit 1 (`3c1371e`, superseded by rework)

Initial option-A implementation — added a single bare `type=raw,value=stg,enable=push-to-main-only` entry. Kept in history for audit (no force-push).

### Commit 2 (`401e4a5`, current — option C per Contract v6)

Reworked tag emit to option C (v3-restored shape; v6 language):
- **Added** `type=sha,prefix=stg-,format=short,enable=push-to-main-only` → emits `stg-<short>` (immutable per-push).
- **Added** `type=raw,value=stg-latest,enable=push-to-main-only` → emits `stg-latest` (moving pointer).
- **Removed** `type=raw,value=stg,...` (bare `:stg` from commit 1 — option A shape, now superseded).
- **Updated** tags-block comment to document the full scheme (sha / latest / stg-<short> / stg-latest + deploy#84's prod-<short> / prod-latest).
- **Updated** Trivy comment to reflect the expanded tag set emitted on main (`:stg-*` + `:stg-latest` replace the old `:stg`).

No change to build logic, platforms, `DESIGN_SYSTEM_REF` (`v0.0.1`), Trivy scan (still digest-based — zero-risk for security gate), notify-deploy, or the matrix. Gate is purely additive relative to #821.

Contract v5 → v6 transition was **PR-body-only** (no additional workflow commit). v6 is substantively identical to v5 (same four-tag emit, same consumer spec); v6 adds explicit program-director ruling language for the retro audit.

## Acceptance

- [x] Push to `main` will publish `:sha-<short>` + `:latest` + `:stg-<short>` + `:stg-latest` for BOTH `api` and `frontend` matrix components — all referencing the same built digest.
- [x] No `:prod-*` tag is written by this workflow (deploy#84 owns the prod-write path).
- [x] Trivy-by-digest scan retained from #821 pattern — unaffected by new tags.
- [x] Tag push events (`v*`, `phase*-wave*`) and `workflow_dispatch` do NOT emit `:stg-*` or `:stg-latest` (guarded by `github.event_name == 'push' && github.ref == 'refs/heads/main'`).
- [ ] CI green (Hook 14 not yet synced — manual `gh pr checks` verification).

## Out of scope

- Promotion workflow implementation (deploy#84).
- Rollback tooling (deploy#84 or follow-up).
- Environment-specific secrets / auth changes.
- user-service#64 and landing-page#68 replication (tracked separately).

## Reviewers

- Primary: **Arjun Raghavan** (System Architect) — Contract v6 correctness, W10 pathway coherence.
- Secondary: **Anya Kowalczyk** (Tech Lead) — workflow file mechanics, regression risk against #821, metadata-action `type=sha,enable=` semantics.

Charter-format comments required (`Requestor:` / `Requestee:` / `RequestOrReplied:` header + `TechDebt: <none|#N>` line).

## Charter compliance

- Branch: `L.Pham/0815-image-tagging-stg-prod` (from `main`, targeting `deployments/phase-2/wave-10`).
- Commit identity: per-commit `-c` flags (Linh Pham / `parametrization+Linh.Pham@gmail.com`). No global/repo `git config` writes. No `--no-verify`.
- Ontology librarian consulted (Hook 15 sentinel in place).
- No `gh pr review --approve` — reviewer approvals via `gh pr comment` per charter.
- Rework pushed as additional commit (no force-push) so the v4→v5→v6 adjudication signal is preserved in PR history.
