### PR TITLE
security(deps): bump pip 26.0.1 -> 26.1 to clear CVE-2026-3219 (closes #846)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -731,11 +731,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `pip` from 26.0.1 to 26.1 in `uv.lock` to clear **CVE-2026-3219** (GHSA-58qw-9mgm-455v).

| Field | Value |
|---|---|
| CVE | CVE-2026-3219 |
| GHSA | GHSA-58qw-9mgm-455v |
| Package | `pip` (transitive dep via `pip-api`) |
| Before | 26.0.1 |
| After | 26.1 |
| Last affected | 26.0.1 |
| Fixed in | 26.1 |
| Severity | Per advisory: file-format ambiguity → potential install of incorrect files |

### Vulnerability

`pip <= 26.0.1` handles concatenated tar+ZIP polyglot files as ZIP archives regardless of filename or whether the file is *both* a tar and a ZIP. This can result in installing "incorrect" files according to the archive name. Pip 26.1 only proceeds with installation if the file identifies uniquely as ZIP or tar, not both.

### Why a targeted bump

`pip` is not a direct dep of this project — it's pulled in transitively by `pip-api`. A targeted `uv lock --upgrade-package pip` cleanly resolves to 26.1 with **zero cascading bumps to any other package**. Lockfile diff is 3 lines (`version`, `sdist` URL, `wheel` URL).

### Validation

- `uv lock --upgrade-package pip` — single line update: `pip 26.0.1 -> 26.1`
- `uv sync` — clean
- Reproduces CI invocation locally:
  ```
  uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
  uv run pip-audit --strict --desc -r /tmp/requirements.txt \
    --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645
  ```
  Result: `No known vulnerabilities found, 1 ignored` ✓
- `uv run pytest tests/ -m "not integration and not e2e"` — **496 passed**

### Impact

- Unblocks the `security-audit` CI lane on `main` and any branch built from `main` since 2026-04-23.
- Unblocks **#845** (Aino's Hook 14 sync — was failing pip-audit despite making zero Python dependency changes).
- Confirms Hook 14 (`validate_pr_ci_status.py`) is working as designed: it correctly blocked merge of #845 until the unrelated red CI was addressed. First self-test of Hook 14 in this repo passed.

## Test plan

- [x] Local `pip-audit` clean (above)
- [x] Lockfile diff scoped to `pip` only — no unrelated upgrades
- [x] `uv sync` succeeds
- [x] Unit tests pass (496/496)
- [ ] CI `security-audit` lane goes green
- [ ] CI `lint-and-typecheck`, `test`, `frontend-lint-and-test`, `hooks-lint`, `scripts-lint`, `lockfile-validation` all green

## References

- Advisory: https://github.com/advisories/GHSA-58qw-9mgm-455v
- OSV record: https://api.osv.dev/v1/vulns/GHSA-58qw-9mgm-455v
- Failing CI run that surfaced this: https://github.com/noorinalabs/noorinalabs-isnad-graph/actions/runs/25053893674/job/73388743013
- Originating issue: #846
- Blocked PR (now unblocks): #845
- Parent meta-issue: noorinalabs/noorinalabs-main#194 (Hook 14 fan-out)

Closes #846
