### PR TITLE
security(deps): cherry-pick pip 26.0.1 -> 26.1 to clear CVE-2026-3219 on main (closes #849)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -731,11 +731,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Targeted cherry-pick of the `uv.lock` pip section from #847 (`74263069c8fa39800102d5604856a68ea0ac8a88`) onto `main`. Bumps `pip 26.0.1 -> 26.1` to clear **CVE-2026-3219** (GHSA-58qw-9mgm-455v).

`main` was missed in the original wave-10 fix (#847 only landed on `deployments/phase-2/wave-10`), leaving `main` exposed and blocking #845's `security-audit` CI gate.

## Origin-source verification (per memory `feedback_origin_over_local_for_still_has_claims.md`)

Pre-fix state confirmed at HEAD of `main` (sha `43727b8...`):

```
$ gh api 'repos/noorinalabs/noorinalabs-isnad-graph/contents/uv.lock?ref=main' --jq '.content' | base64 -d | grep -A 1 'name = "pip"' | head -3
name = "pip"
version = "26.0.1"
```

After this PR merges, the same query against `main` will show `version = "26.1"`.

## Diff

Exactly 3 lines in `uv.lock` (no transitive cascade):

```
@@ -731,11 +731,11 @@ wheels = [
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/.../pip-26.0.1.tar.gz", hash = "sha256:c4037d8a..." }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/.../pip-26.1.tar.gz", hash = "sha256:81e13ebc..." }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/.../pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f..." }
+    { url = "https://files.pythonhosted.org/packages/70/7a/.../pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d8..." }
```

## Validation evidence

```
$ uv lock --upgrade-package pip
Resolved 104 packages in 445ms
# (no further changes — pip 26.1 is the latest)

$ uv sync
# clean

$ uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
$ uv run pip-audit --strict --desc -r /tmp/requirements.txt \
    --ignore-vuln CVE-2024-23342 \
    --ignore-vuln CVE-2026-4539 \
    --ignore-vuln CVE-2026-25645
No known vulnerabilities found, 1 ignored
```

The pip-audit invocation is **byte-identical** to the `security-audit` step in `.github/workflows/ci.yml` on `main`, so green here means green in CI.

## Closes / refs

- Closes #849
- Refs #845 (Hook 14 sync, blocked by main's pre-bump security-audit)
- Refs #846 / #847 (wave-10 sibling)
- Refs #848 (tracking issue for the `--ignore-vuln` fallback path — superseded by this bump path; should close once this merges)
- Refs noorinalabs/noorinalabs-main#194 (parent fan-out meta)

## Test Plan

- [x] Local `uv lock --upgrade-package pip` is no-op
- [x] Local `uv sync` clean
- [x] Local `uv run pip-audit ...` (byte-identical to CI) returns "No known vulnerabilities found, 1 ignored"
- [ ] CI `security-audit` job GREEN on this PR
- [ ] After merge, #845's CI re-run shows `security-audit` GREEN
- [ ] #848 (tracking issue) closed (superseded by bump path)
