### PR TITLE
Phase 2 Wave 10 → main (isnad-graph)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -145,13 +145,30 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image }}
+          # Tag scheme (isnad-graph#815 Contract v5 = option C, 2026-04-23):
+          #   sha-<short>   — immutable, one per push; written here on every event
+          #   latest        — mutable pointer; written here on main + semver tags
+          #   stg-<short>   — immutable per-push, stg namespace; written here ONLY
+          #                   on push to main. Tag history = stg deploy log.
+          #   stg-latest    — moving pointer to most-recent stg-<short>; written
+          #                   here ONLY on push to main. Consumers pull this for
+          #                   a stable target without chasing SHAs.
+          #   prod-<short>  — immutable per-promotion, prod namespace; written by
+          #                   deploy#84 ONLY, NOT this file. Tag history = promotion log.
+          #   prod-latest   — moving pointer; written by deploy#84 ONLY.
+          # deploy#84 writes both prod-* tags in one `docker buildx imagetools
+          # create` invocation — registry-side manifest rewrite, no rebuild.
           tags: |
             # Git tag (e.g., v1.2.3 or phase12-wave1)
             type=ref,event=tag
-            # Short SHA (e.g., sha-a1b2c3d) on every event
+            # Short SHA (e.g., sha-a1b2c3d) on every event — IMMUTABLE anchor
             type=sha,prefix=sha-,format=short
             # Latest on main-branch push or semver tags
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            # stg-<short> per-push in stg namespace — IMMUTABLE, push-to-main only
+            type=sha,prefix=stg-,format=short,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            # stg-latest moving pointer — push-to-main only
+            type=raw,value=stg-latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         id: build
@@ -172,9 +189,10 @@ jobs:
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           # Scan by digest — guaranteed to exist immediately after push and
-          # immune to tag-resolution races. The previous tag-based form broke
-          # on main pushes because metadata-action only emits :latest + :sha-*
-          # (no :main). See user-service#61 retro.
+          # immune to tag-resolution races. metadata-action emits :latest,
+          # :sha-*, and (on main) :stg-* + :stg-latest — never :main.
+          # Digest is the one stable handle across all of them. See
+          # user-service#61 retro.
           image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: table
           exit-code: "1"

--- a/uv.lock
+++ b/uv.lock
@@ -731,11 +731,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Phase 2 Wave 10 → main (isnad-graph)

Final wave merge for isnad-graph wave-10 work.

### Scope (2 unique commits + main pull-forward)

- `b893184` — `ci(ghcr): emit stg-<short> + stg-latest for same-SHA promotion (#815) (#844)` — image-tag Contract v6 alignment (canonical per `project_w10_image_tag_contract.md`)
- `7426306` — `security(deps): bump pip 26.0.1 -> 26.1 to clear CVE-2026-3219 (#847)` — wave-side pip CVE bump

Main-pulled-forward (already there, idempotent):
- `e7ad31f` — Hook 14 sync (#845)
- `a6134d4` — pip cherry-pick to main (#850, same content as #847)

### Coordination

Part of the org-wide W10 close-out (parent merged as `noorinalabs-main#229`, landing-page as `landing-page#74`). Pip CVE bump landed twice (wave + main cherry-pick); the merge collapses both into a single line.

Single-Reviewer Exception applies — coordination merge of already-merged PRs into main.
