### PR TITLE
tech-debt(frontend): use absolute URLs targeting users.{base} via VITE_USER_SERVICE_ORIGIN (deploy#245 phase 2 part 1)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,22 @@
+# =============================================================================
+# isnad-graph frontend Vite environment configuration
+#
+# Copy to `frontend/.env` for local dev, or wire per-environment via the
+# build pipeline (ARG at `docker build` time) for stg/prod images. Vite
+# reads variables prefixed `VITE_` at build-time and inlines them into the
+# bundle — they are NOT runtime-configurable post-build.
+# =============================================================================
+
+# Origin of the user-service vhost (deploy#220 carve-out, deploy#245 phase 2).
+#
+# - Production:  https://users.noorinalabs.com
+# - Staging:     https://users.stg.noorinalabs.com
+# - Local dev:   leave empty to fall back to same-origin via Vite proxy
+#                (or set to http://localhost:8000 if user-service is run
+#                directly without the Caddy reverse proxy)
+#
+# Setting this empty / unset preserves the legacy same-origin behavior —
+# fetches resolve relative to the page origin, served by Caddy's transitional
+# dual-bind on isnad.{base}. The dual-bind is retired in a separate follow-up
+# PR after this lands and runs in the wild for a stabilization window.
+VITE_USER_SERVICE_ORIGIN=

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -1,6 +1,10 @@
 import { emitSessionExpired } from '../hooks/useAuth'
 
-const API_BASE = '/api/v1/users/me'
+// Absolute URL targeting the user-service vhost (`users.{base}`). See
+// useAuth.ts for the full BASE-constant set; kept duplicated here to avoid
+// a barrel-export refactor inside this PR.
+const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
+const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
 
 function getAuthHeaders(): HeadersInit {
   const token = localStorage.getItem('access_token')

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -79,9 +79,14 @@ export function deriveHighestRole(roleNames: string[]): UserRole {
   return 'viewer'
 }
 
-const AUTH_BASE = '/auth'
-const USER_BASE = '/api/v1/users'
-const SESSIONS_BASE = '/api/v1/sessions'
+// Absolute URLs targeting the user-service vhost (`users.{base}`). Sourced
+// from `VITE_USER_SERVICE_ORIGIN` so a single image works across environments.
+// Empty/undefined falls back to same-origin (transitional dual-bind on
+// `isnad.{base}` — retired in a separate PR per deploy#245 phase 2 part 2).
+const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
+const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
+const USER_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users`
+const SESSIONS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/sessions`
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,7 +4,11 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/Tabs'
 import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
 
-const AUTH_BASE = '/auth'
+// Absolute URL targeting the user-service vhost (`users.{base}`). See
+// useAuth.ts for the full BASE-constant set; kept duplicated here to avoid
+// a barrel-export refactor inside this PR.
+const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
+const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
 
 function GoogleIcon() {
   return (

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // Origin of the user-service vhost (`users.{base}`). Set per-environment
+  // via `frontend/.env*` files. Empty/undefined falls back to same-origin —
+  // see deploy#245 phase 2 for the carve-out context.
+  readonly VITE_USER_SERVICE_ORIGIN?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary

Phase 2 part 1 of the [deploy#220](https://github.com/noorinalabs/noorinalabs-deploy/issues/220) user-service vhost carve-out, scoped per [deploy#245](https://github.com/noorinalabs/noorinalabs-deploy/issues/245). Backend routes moved server-side to `users.{base}` in [deploy#241](https://github.com/noorinalabs/noorinalabs-deploy/pull/241); this PR makes the frontend follow by promoting `AUTH_BASE`, `USER_BASE`, `SESSIONS_BASE` from hardcoded relative paths to absolute URLs sourced from `VITE_USER_SERVICE_ORIGIN`.

Empty/undefined `VITE_USER_SERVICE_ORIGIN` preserves the legacy same-origin behavior — fetches resolve relative to the page origin, served by Caddy's transitional dual-bind on `isnad.{base}`. Dual-bind retirement (phase 2 part 2) is a separate follow-up PR in the deploy repo after this lands and runs in the wild for a stabilization window.

## Changes

- `frontend/src/hooks/useAuth.ts` — promote `AUTH_BASE` / `USER_BASE` / `SESSIONS_BASE` to template-literal absolute URLs prefixed with `import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''`. All fetch call sites in this file (token refresh, sessions GET/DELETE, `/users/me`, signOut, signOutAll) automatically pick up the new URLs — no call-site edits needed because the constants do the work.
- `frontend/src/pages/LoginPage.tsx` — same treatment for `AUTH_BASE`. Affected fetches: `/auth/providers`, `/auth/oauth/{provider}/login`, `/auth/login/email`, `/auth/register`.
- `frontend/src/api/profile-client.ts` — added in fix commit `4bb9d56` after Lucas-review catch. Same template-literal pattern: `const API_BASE = \`${USER_SERVICE_ORIGIN}/api/v1/users/me\``. Affected fetches: `fetchProfile`, `updateProfile`, `fetchSessions`, `revokeSession` (L57/64/72/76 — auto-resolved via the constant).
- `frontend/.env.example` (new) — documents `VITE_USER_SERVICE_ORIGIN` with per-environment values (prod / stg / dev). Vite's `envDir` defaults to the project root, which for this Vite project is `frontend/` — so the file lives there, not at the repo root. Note: per-env `.env.production` / `.env.staging` files are intentionally **not** added — see "Per-environment wiring" below.
- `frontend/src/vite-env.d.ts` — extend with a typed `ImportMetaEnv` interface so TypeScript narrows `import.meta.env.VITE_USER_SERVICE_ORIGIN` to `string | undefined`.

## Per-environment wiring (for the deploy team)

The PR ships `.env.example` only. Concrete per-env values are NOT committed here for two reasons:

1. The deploy#245 issue body (item 1) explicitly suggests "set the values from runtime config (e.g., `/runtime-config.js`) so a single image works across stg + prod" — committing per-env files now would couple the build to one deploy target.
2. Vite reads `VITE_USER_SERVICE_ORIGIN` at **build time** and inlines it into the bundle (it's NOT a runtime variable). So per-env wiring belongs in the deploy pipeline as a `docker build --build-arg` or equivalent, not in this repo.

The deploy team should wire one of:
- (a) Per-env `docker build --build-arg VITE_USER_SERVICE_ORIGIN=https://users.{stg,prod}.noorinalabs.com` (simplest; one image per env)
- (b) Runtime config injection via `/runtime-config.js` script-tag pattern (one image works across all envs; more frontend code to add — out of scope for this PR)

## CORS readiness — checked, evidence-comment filed

Once dual-bind is retired (phase 2 part 2), fetches will be cross-origin (`isnad.*` → `users.*`). I checked the user-service CORS config:

- **Code default** (`noorinalabs-user-service/src/app/config.py:35`) — only allows localhost. Fine; production overrides via env.
- **Deploy env wiring** (`noorinalabs-deploy/compose/docker-compose.prod.yml:324`) — currently set to `["https://isnad-graph.noorinalabs.com"]`, the destroyed legacy domain. Will need to extend to include `https://isnad.noorinalabs.com` (and the stg variant) before phase 2 part 2 lands.

**Already tracked** in [deploy#156](https://github.com/noorinalabs/noorinalabs-deploy/issues/156) (legacy → new hostname migration) — scope item 2 explicitly covers `compose/docker-compose.prod.yml` `CORS_ORIGINS` swap. Per [`feedback_drift_evidence_to_existing_rationalization_issue.md`](../noorinalabs-main/.claude/team/feedback_log.md), I posted an evidence comment ([#156#issuecomment-4367241447](https://github.com/noorinalabs/noorinalabs-deploy/issues/156#issuecomment-4367241447)) attaching this PR as an additional consumer rather than filing a new sibling issue.

## CORP / CSP dependency on deploy#243 (Lucas-243 parallel work)

The isnad.* Caddy vhost currently has `connect-src 'self'` in its CSP, which would block cross-origin fetches to `https://users.{base}` once dual-bind is retired. Lucas-243's parallel PR ([deploy#243](https://github.com/noorinalabs/noorinalabs-deploy/issues/243)) tunes security headers on the users.* vhost, and per the issue body item 3, will also extend `connect-src` on isnad.* to include `https://users.{$BASE_DOMAIN}`.

**Sequencing across the carve-out completion:**

1. **This PR (#245 phase 2 part 1)** — frontend absolute URLs. Non-blocking on Lucas-243 because dual-bind absorbs traffic until phase 2 part 2.
2. **deploy#156** — `CORS_ORIGINS` swap on user-service env wiring to include `isnad.{base}`.
3. **deploy#243** — CSP `connect-src` extension on isnad.* + COOP/CORP on users.*.
4. **deploy#245 phase 2 part 2** (future tiny PR) — drop user-service routes from `isnad.{base}` Caddyfile block. After this lands, fetches become fully cross-origin.

## Acceptance

- [x] All `AUTH_BASE` / `USER_BASE` / `SESSIONS_BASE` references use absolute URLs sourced from `VITE_USER_SERVICE_ORIGIN`
- [x] `frontend/.env.example` documents the new variable
- [x] No leftover relative-URL string literals (`'/auth'` / `'/api/v1/users'` / `'/api/v1/sessions'`) — grep verified clean across `frontend/src` at PR head `4bb9d56`. **Correction (2026-05-04):** the original sweep at commit `1a6f2ae` missed `frontend/src/api/profile-client.ts:3` (`API_BASE = '/api/v1/users/me'` + 4 fetch sites at L57/64/72/76) — Lucas's review caught it. Fixed in commit `4bb9d56` by applying the same `${USER_SERVICE_ORIGIN}/api/v1/users/me` template-literal pattern. Grep now genuinely returns zero hits
- [x] Frontend build passes (`npm run build` — tsc + vite, 0 errors)
- [x] Lint clean (`npm run lint` — 0 errors; pre-existing 11 warnings in `ConfigPage.tsx` unrelated to this PR)
- [x] Test suite passes (`npm run test --run` — 51/51 tests pass across 12 files)
- [x] CORS readiness checked + evidence comment on existing tracking issue
- [x] PR base = `deployments/phase-3/wave-3` in `noorinalabs-isnad-graph`
- [x] Labels: `p3-wave-3 + tech-debt`

## Out-of-scope (deferred)

- **Phase 2 part 2** (drop `/auth/*`, `/api/v1/users*`, `/api/v1/sessions*` route handlers from the `isnad.{base}` Caddyfile block) — separate follow-up PR in `noorinalabs-deploy` after a stabilization window.
- **Cookie-domain handling** — if user-service uses session cookies set on `users.{base}`, frontend on `isnad.{base}` won't send them with cross-origin fetches. Bearer tokens in `Authorization` header (which this code already uses) bypass the issue, but if any cookie-bearing flow is added in the future, the fix is either a parent-domain cookie (`.noorinalabs.com`) or staying with bearer-token auth. Tracked as item 4 of deploy#245 issue body.
- **Concrete per-env Vite values** — see "Per-environment wiring" above; deploy team owns.

## Test plan

- [ ] Reviewer: `gh api repos/noorinalabs/noorinalabs-isnad-graph/contents/frontend/src/hooks/useAuth.ts?ref=<head_sha>` — verify `import.meta.env.VITE_USER_SERVICE_ORIGIN` is the only env source, no leftover hardcoded `/auth` strings
- [ ] Reviewer: same for `frontend/src/pages/LoginPage.tsx`
- [ ] Local dev sanity: `cd frontend && npm run dev` with `VITE_USER_SERVICE_ORIGIN=` (empty) — login flow stays same-origin via the existing Vite proxy
- [ ] Local dev sanity: `VITE_USER_SERVICE_ORIGIN=http://localhost:8000 npm run dev` — login flow hits the absolute URL directly (validates the env-var path)
- [ ] Post-merge to wave branch: visual smoke that the login page loads + provider list renders (validates the same-origin fallback still works behind the dual-bind)

TechDebt: <none>

Co-Authored-By: Jun-Seo Park <parametrization+Jun-Seo.Park@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

