### PR TITLE
docs(claude-md): branching strategy backslash → slash (closes #852)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ Copy `.env.example` to `.env`. Key variables:
 - **GitHub Issues** — story/task/bug tracking (created by Manager, assigned to team members)
 - **GitHub Actions** — CI/CD pipelines, automated tests, linting, deployment
 - These three (Projects, Issues, Actions) are the **core orchestration layer** — do not introduce alternative tools for these concerns
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `F.Okonkwo\0042-setup-docker-compose`) merged to `main` via PR
+- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `F.Okonkwo/0042-setup-docker-compose`) merged to `main` via PR
 
 ## Key Documentation
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` line 212 used a literal `\` in the branch-naming template and example, which git rejects in refnames. This PR replaces both occurrences with `/` to match the convention already in use across the repo's branch history (e.g., `N.Khoury/0042-update-charter`).

Sync from parent meta-issue [noorinalabs/noorinalabs-main#232](https://github.com/noorinalabs/noorinalabs-main/issues/232), which landed the same fix on the org-level `CLAUDE.md`. Pattern parallel to the W10 Hook 14 fan-out (`noorinalabs-main#194`).

Closes #852.

## Changes

Single-line diff in `CLAUDE.md` L212:

- Template: `{FirstInitial}.{LastName}\{IIII}-{issue-name}` → `{FirstInitial}.{LastName}/{IIII}-{issue-name}`
- Example: `F.Okonkwo\0042-setup-docker-compose` → `F.Okonkwo/0042-setup-docker-compose`

## Why this matters

Spawned implementers reading `CLAUDE.md` verbatim hit `git: 'X.Y\NNNN-...' is not a valid branch name` and have to fall back to repo convention. Two independent confirmations in P3W1 Round 1 (`deploy-aisha #179`, `deploy-lucas #67`).

## Wave-bootstrap class

This PR is labeled `wave-bootstrap` per the W4 kickoff Single-Reviewer Exception (charter § Single-Reviewer Exception, owner-approved at W4 kickoff and logged in `cross-repo-status.json` `wave_4_decisions.single_reviewer_exception`). Single reviewer: Anya Kowalczyk.

## Test plan

- [x] `grep -n 'Branching strategy' CLAUDE.md` shows `/` in both template and example
- [x] No other backslash refname patterns elsewhere in `CLAUDE.md`
- [x] Commit author = `Ingrid Lindqvist <parametrization+Ingrid.Lindqvist@gmail.com>`
- [x] Branched from `deployments/phase-3/wave-4`
