### PR TITLE
fix(isnad-graph #862): settings.json matcher parity with noorinalabs-main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,46 @@
         ]
       },
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_context.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_ontology_context.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "SendMessage",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_shutdown_without_retro.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_audit.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
         "matcher": "Edit",
         "hooks": [
           {
@@ -53,6 +93,112 @@
             "type": "command",
             "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
             "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_add_issue_to_board.py",
+            "timeout": 20
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/annunaki_monitor.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_handoff.py",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
Closes #862

## Summary

Phase-2 followup to #861 (which closed Hook 15 / security-tier matchers). This PR closes the **policy-tier** residual coverage gap that was deferred per Arjun's tier framing on #861. Child `.claude/settings.json` is now **byte-identical** to parent canonical `noorinalabs-main/.claude/settings.json`.

## Side-by-side matcher diff (vs parent canonical)

Read at HEAD of this branch and at `noorinalabs-main` HEAD.

| Section | Matcher | Parent (canonical) | Child pre-PR | Child post-PR |
|---|---|---|---|---|
| PreToolUse | Bash | dispatcher | dispatcher | dispatcher |
| PreToolUse | Agent | validate_wave_context, enforce_ontology_context | (none) | **added** (mirrors parent) |
| PreToolUse | SendMessage | block_shutdown_without_retro, validate_edit_completion | (none) | **added** (mirrors parent) |
| PreToolUse | Skill | validate_wave_audit | (none) | **added** (mirrors parent) |
| PreToolUse | Edit | enforce_librarian_consulted, validate_edit_completion | same | unchanged |
| PreToolUse | Write | enforce_librarian_consulted, validate_edit_completion | same | unchanged |
| PreToolUse | NotebookEdit | enforce_librarian_consulted, validate_edit_completion | same | unchanged |
| PostToolUse | Bash (block 1) | auto_add_issue_to_board | (none) | **added** (mirrors parent) |
| PostToolUse | Bash (block 2) | annunaki_monitor | (none) | **added** (mirrors parent) |
| PostToolUse | Edit | ontology_tracker, suggest_generic_prompt, validate_edit_completion | (none) | **added** (mirrors parent) |
| PostToolUse | Write | ontology_tracker, suggest_generic_prompt, validate_edit_completion | (none) | **added** (mirrors parent) |
| PostToolUse | NotebookEdit | validate_edit_completion | (none) | **added** (mirrors parent) |
| SessionStart | startup | session_start | (none) | **added** (mirrors parent) |
| SessionStart | resume | session_start | (none) | **added** (mirrors parent) |
| Stop | "" | session_handoff | (none) | **added** (mirrors parent) |

Parity verified by `diff /home/parameterization/code/noorinalabs-main/.claude/settings.json /tmp/wave6-junseo-ig-862/.claude/settings.json` → byte-identical (no output).

## Smoke tests

Hooks fired cleanly from worktree cwd `/tmp/wave6-junseo-ig-862`:

| Event | Hook | Result |
|---|---|---|
| `Stop` | `session_handoff.py` | exit 0 |
| `PreToolUse Agent` | `validate_wave_context.py` | exit 0 |
| `SessionStart` (startup) | `session_start.py` | exit 0, returned protocol prompt |
| `PostToolUse Edit` | `ontology_tracker.py` | exit 0 |

JSON validity: `python3 -c "import json; json.load(open('.claude/settings.json'))"` → valid.

`pre-commit run --files .claude/settings.json` → ruff/gitleaks/pip-audit/pytest-unit pass; `branch-ownership` failure is OS-committer mismatch (irrelevant under per-commit `-c user.name=` identity).

## Test Plan

- [x] Diff vs parent canonical is empty (byte-identical)
- [x] JSON parses (valid)
- [x] Stop event fires `session_handoff.py` from worktree cwd
- [x] PreToolUse Agent fires `validate_wave_context.py`
- [x] SessionStart (startup) fires `session_start.py`
- [x] PostToolUse Edit fires `ontology_tracker.py`

## Refs

- Closes #862
- Sibling PR #861 (security-tier closure, already merged into wave-5)
- Cross-repo umbrella: noorinalabs/noorinalabs-main#263
- Parent meta-issue: noorinalabs/noorinalabs-main#214
- W6 meta: noorinalabs/noorinalabs-main#284
- Spec: parent `.claude/team/charter/hooks.md § Hook Sync Across Child Repos`

TechDebt: none

R1: @Linh Pham
R2: @Mateo Salazar
