### PR TITLE
ci(ghcr): use npm ci for design-system tarball build (#823)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -17,7 +17,7 @@
 #
 # The frontend build needs the design-system tarball staged into the frontend
 # build context. We check out noorinalabs-design-system @ v0.0.1, run
-# `npm install --omit=dev && npm pack`, and move the .tgz into ./frontend/
+# `npm ci && npm run build && npm pack`, and move the .tgz into ./frontend/
 # before docker/build-push-action runs. The frontend Dockerfile's
 # `COPY noorinalabs-design-system-0.0.1.tgz /` step (fixed in #820) expects
 # the tarball at the root of its build context.
@@ -93,11 +93,14 @@ jobs:
         # v0.0.1's package.json declares `files: ["dist"]` with NO prepack /
         # prepare hook, and `dist/` is not committed. A fresh clone packs an
         # empty 172-byte tarball (just package.json metadata) unless we run
-        # the build first. We also MUST use plain `npm install` — NOT
-        # `--omit=dev` — because Vite (the builder) is a devDependency.
-        # Sequence: install ALL deps → run build (populates dist/) → pack.
+        # the build first. We also MUST install ALL deps (no `--omit=dev`)
+        # because Vite (the builder) is a devDependency.
+        # Sequence: install ALL deps from lockfile → run build (populates dist/) → pack.
+        # `npm ci` (not `npm install`) is used to install exact locked versions
+        # from package-lock.json — reproducible release artifact, fails fast if
+        # lockfile and package.json drift (#823).
         run: |
-          npm install
+          npm ci
           npm run build
           npm pack
           ls -lh ./*.tgz


### PR DESCRIPTION
## Summary

Switch the cross-repo design-system build-and-pack step in `.github/workflows/ghcr-publish.yml` from `npm install` to `npm ci`. The release tarball is now reproducible across CI runs — `npm ci` fails fast if `package.json` and `package-lock.json` drift, eliminating the correctness hazard called out in #823.

The full sequence stays `install all deps → run build (populates dist/) → npm pack` because Vite is a devDependency and v0.0.1's `package.json` declares `files: ["dist"]` with no prepack hook — `--omit=dev` is still not applicable here. Only the install verb changes.

## Why

Per #823, `npm install` happily updates `package-lock.json` and resolves dependencies loosely from `package.json`. For a CI build pinned to `v0.0.1`, this lets transitive-dep churn drift the tarball contents from what was locked at release time. `npm ci`:

- Requires `package-lock.json` to be in sync with `package.json`
- Installs exact locked versions
- Typically faster on CI (skips dependency resolution)

## Test plan

- [x] Local validation: fresh `git clone --depth 1 --branch v0.0.1 https://github.com/noorinalabs/noorinalabs-design-system.git` + `npm ci && npm run build && npm pack`
  - `npm ci`: 572 packages installed in 13s, lockfile honored
  - `npm run build`: dist/ populated (styles.css 28.30 kB, index.js 113.88 kB, index.cjs 53.10 kB, dts emitted)
  - `npm pack`: `noorinalabs-design-system-0.0.1.tgz` 137 KB, 73 files
- [x] actionlint on workflow — no new findings (only pre-existing SC2129 style hint at line 207, unrelated)
- [ ] CI: GHCR publish workflow runs on merge to wave-10 → main; frontend image build succeeds with `npm ci`-packed tarball
- [ ] Live trace verification: the resulting tarball integrity is reproducible across consecutive CI runs (`shasum` of two artifact runs matches, modulo timestamp-driven differences already handled by the integrity-strip step downstream)

## Out of scope

- #822 (DESIGN_SYSTEM_REF + Dockerfile COPY + package-lock triple-pin) — separate PR.
- The downstream `Fix design-system lockfile integrity` step is unaffected; the integrity-strip pattern still applies because timestamps/filesystem ordering on the freshly-packed tarball differ from the release-time integrity hash.

Closes #823

🤖 Co-authored: Jelani Mwangi
