### PR TITLE
tech-debt(frontend/api): generalize fetchJson 404-as-data with allowStatuses (#833)

### DIFF
--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { fetchSubscriptionOrNull } from "../client"
+
+vi.mock("../../hooks/useAuth", () => ({
+  emitSessionExpired: vi.fn(),
+}))
+
+import { emitSessionExpired } from "../../hooks/useAuth"
+
+const mockEmit = emitSessionExpired as ReturnType<typeof vi.fn>
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("fetchJson (via fetchSubscriptionOrNull) — allowStatuses", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns parsed body on 200", async () => {
+    const payload = { tier: "trial", status: "trial", days_remaining: 5 }
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, payload))
+
+    const result = await fetchSubscriptionOrNull()
+
+    expect(result).toEqual(payload)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("resolves null on an allowed status (404) instead of throwing", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(404, { detail: "not found" }))
+
+    const result = await fetchSubscriptionOrNull()
+
+    expect(result).toBeNull()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("still throws on non-OK statuses outside the allow list (500)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(500, { detail: "boom" }))
+
+    await expect(fetchSubscriptionOrNull()).rejects.toThrow(/500/)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("emits sessionExpired on 401 and still throws (401 not in allow list)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(401, { detail: "unauthorized" }))
+
+    await expect(fetchSubscriptionOrNull()).rejects.toThrow(/401/)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,11 +25,25 @@ function getAuthHeaders(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+interface FetchJsonOptions {
+  // Statuses that should resolve to `null` instead of throwing.
+  // Use for endpoints where a non-OK status is a terminal data state
+  // (e.g. 404 = "no record" or "free tier") rather than an error.
+  // 401 still triggers `emitSessionExpired`; listing it here is a no-op
+  // for that side effect but suppresses the throw.
+  allowStatuses?: number[]
+}
+
+async function fetchJson<T>(url: string): Promise<T>
+async function fetchJson<T>(url: string, opts: FetchJsonOptions): Promise<T | null>
+async function fetchJson<T>(url: string, opts?: FetchJsonOptions): Promise<T | null> {
   const res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })
   if (!res.ok) {
     if (res.status === 401) {
       emitSessionExpired()
+    }
+    if (opts?.allowStatuses?.includes(res.status)) {
+      return null
     }
     throw new Error(`API error: ${res.status} ${res.statusText}`)
   }
@@ -199,18 +213,9 @@ export async function flagContent(
 // (free tier / admin), not an error. Resolve it to null and let callers
 // branch on `subscription === null`. Other non-OK statuses throw as usual.
 export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | null> {
-  const res = await fetch(`${API_BASE}/subscriptions/me`, {
-    headers: getAuthHeaders(),
-    credentials: 'include',
+  return fetchJson<SubscriptionResponse>(`${API_BASE}/subscriptions/me`, {
+    allowStatuses: [404],
   })
-  if (res.status === 404) return null
-  if (!res.ok) {
-    if (res.status === 401) {
-      emitSessionExpired()
-    }
-    throw new Error(`API error: ${res.status} ${res.statusText}`)
-  }
-  return res.json() as Promise<SubscriptionResponse>
 }
 
 // --- Admin: Reports ---


### PR DESCRIPTION
Closes #833.

## Summary

Generalize `fetchJson`'s 404-as-data handling before a third `*OrNull` wrapper lands. Adds an `allowStatuses: number[]` option that maps specified non-OK statuses to `null` instead of throwing, then migrates `fetchSubscriptionOrNull` to a one-line wrapper.

## Resolved design questions from the issue

- **Return type shape:** `T | null` (not a discriminated union) — matches what `fetchSubscriptionOrNull` already returns and what `useQuery` consumers already destructure. Cheaper to migrate, no churn at call sites.
- **Arbitrary status list vs. just 404:** generalized to `number[]`. Strictly more flexible, no extra complexity at the implementation site, and the issue body explicitly flagged `[404, 410]` as a near-term shape.
- **Keep 401 → `emitSessionExpired`:** yes, orthogonal — preserved unconditionally. If a caller ever puts 401 in `allowStatuses`, the side effect still fires; only the throw is suppressed. That's the only semantically defensible choice — `emitSessionExpired` is a system-wide reaction, not part of the per-call result shape.

## Type-level shape

```ts
async function fetchJson<T>(url: string): Promise<T>
async function fetchJson<T>(url: string, opts: FetchJsonOptions): Promise<T | null>
```

Two overloads keep the no-opts return type tight (`Promise<T>`) so the 25+ existing call sites that don't pass options still see `T`, not `T | null`. Only callers that opt in get the widened return type.

## Diff at a glance

- `frontend/src/api/client.ts`: 28-line implementation change in `fetchJson` + `FetchJsonOptions` interface, plus 13-line → 5-line shrink in `fetchSubscriptionOrNull`.
- `frontend/src/api/__tests__/client.test.ts` (new, 60 lines): covers 200 path, allowed-status null, non-allowed throw, 401-emit-and-throw.

No behavior change for any existing caller: `fetchSubscriptionOrNull` returns the same shape, `useSubscription` is untouched and its 5 existing tests still pass.

## Migration path for future consumers

Detail-page fetches (`fetchNarrator`, `fetchHadith`, `fetchCollection`) are explicitly **not** auto-converted — they correctly throw on 404 today, which routes to the error boundary. When product later wants inline "not found" rendering on any of those, the call site adds `{ allowStatuses: [404] }` and updates its return-type handling. No new wrapper needed.

## TechDebt

This PR resolves charter Item 0 (tech-debt scope from #833). Surfaced during #832 review and filed as a follow-up; this is the planned consolidation before a third consumer of the pattern.

## Test Plan

- [x] `npx vitest run` — 55/55 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/api/client.ts src/api/__tests__/client.test.ts` — clean
- [x] `npm run build` — production build succeeds
- [ ] CI green
- [ ] Two reviewer Approved verdicts with `TechDebt:` in same comment
