### PR TITLE
frontend: update e2e auth mocks to current contract, re-enable e2e CI job (#812)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,17 +187,6 @@ jobs:
 
   e2e:
     needs: lint-and-typecheck
-    # Disabled pending mock-auth-refresh — see noorinalabs/noorinalabs-isnad-graph#812.
-    # The e2e tests mock `/api/v1/auth/me` and `/api/v1/auth/subscription`, but the
-    # frontend has been refactored to use `/api/v1/sessions` for auth — the mocks
-    # never match, useAuth fails, ProtectedRoute redirects, and `Main navigation`
-    # never renders, so every authenticated-state assertion times out. The npm
-    # install error fixed earlier in this PR was hiding this for weeks.
-    #
-    # Re-enable contract (load-bearing): #812 must update the mocks to match the
-    # new sessions endpoint, re-enable this job (remove the comment block + `if:`),
-    # and verify the job runs green on the same PR — no further silencing.
-    if: false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/frontend/tests/e2e/accessibility.spec.ts
+++ b/frontend/tests/e2e/accessibility.spec.ts
@@ -22,16 +22,23 @@ test.describe('Accessibility', () => {
   })
 
   test('home page (authenticated) has no accessibility violations', async ({ page }) => {
-    // Mock auth
-    await page.route('**/api/v1/auth/me', (route) =>
+    // useAuth calls `/api/v1/users/me` (user-service `UserRead` schema).
+    await page.route('**/api/v1/users/me', (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(authUser) }),
     )
-    // Mock subscription — return active trial so ProtectedRoute renders the app
-    await page.route('**/api/v1/auth/subscription', (route) =>
+    // useSubscription calls `/api/v1/subscriptions/me` — return active trial
+    // so ProtectedRoute sees `isExpired=false` and renders <Outlet/>.
+    await page.route('**/api/v1/subscriptions/me', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ status: 'trial', tier: 'trial', days_remaining: 7 }),
+        body: JSON.stringify({
+          tier: 'trial',
+          status: 'trial',
+          days_remaining: 7,
+          trial_start: '2026-01-01T00:00:00Z',
+          trial_expires: '2026-01-08T00:00:00Z',
+        }),
       }),
     )
     await page.addInitScript(() => {

--- a/frontend/tests/e2e/fixtures/auth-user.json
+++ b/frontend/tests/e2e/fixtures/auth-user.json
@@ -1,8 +1,11 @@
 {
   "id": "test-user-001",
   "email": "test@example.com",
-  "name": "Test User",
-  "is_admin": false,
-  "provider": "email",
-  "email_verified": true
+  "display_name": "Test User",
+  "avatar_url": null,
+  "email_verified": true,
+  "is_active": true,
+  "locale": "en",
+  "created_at": "2026-01-01T00:00:00Z",
+  "roles": ["viewer"]
 }

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -8,17 +8,26 @@ const authUser = JSON.parse(readFileSync(join(__dirname, 'fixtures/auth-user.jso
 const narrators = JSON.parse(readFileSync(join(__dirname, 'fixtures/narrators.json'), 'utf-8'))
 
 async function mockAuthAndData(page: Page) {
-  // Mock auth — return authenticated user
-  await page.route('**/api/v1/auth/me', (route) =>
+  // Mock auth — return authenticated user. useAuth calls `/api/v1/users/me`
+  // (user-service `UserRead` schema). The pre-#812 `/auth/me` path no longer exists.
+  await page.route('**/api/v1/users/me', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(authUser) }),
   )
 
-  // Mock subscription — return active trial so ProtectedRoute renders the app
-  await page.route('**/api/v1/auth/subscription', (route) =>
+  // Mock subscription — useSubscription calls `/api/v1/subscriptions/me` and
+  // treats 404 as "no subscription" (null). Return an active trial so ProtectedRoute
+  // sees `isExpired=false` and renders <Outlet/>.
+  await page.route('**/api/v1/subscriptions/me', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ status: 'trial', tier: 'trial', days_remaining: 7 }),
+      body: JSON.stringify({
+        tier: 'trial',
+        status: 'trial',
+        days_remaining: 7,
+        trial_start: '2026-01-01T00:00:00Z',
+        trial_expires: '2026-01-08T00:00:00Z',
+      }),
     }),
   )
 
@@ -71,7 +80,7 @@ async function mockAuthAndData(page: Page) {
         body: JSON.stringify({ results: [], total: 0 }),
       })
     }
-    if (url.includes('/auth/me')) {
+    if (url.includes('/users/me')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(authUser) })
     }
 

--- a/frontend/tests/e2e/search.spec.ts
+++ b/frontend/tests/e2e/search.spec.ts
@@ -8,15 +8,23 @@ const authUser = JSON.parse(readFileSync(join(__dirname, 'fixtures/auth-user.jso
 const searchResults = JSON.parse(readFileSync(join(__dirname, 'fixtures/search-results.json'), 'utf-8'))
 
 async function mockAuth(page: Page) {
-  await page.route('**/api/v1/auth/me', (route) =>
+  // useAuth calls `/api/v1/users/me` (user-service `UserRead` schema).
+  await page.route('**/api/v1/users/me', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(authUser) }),
   )
-  // Mock subscription — return active trial so ProtectedRoute renders the app
-  await page.route('**/api/v1/auth/subscription', (route) =>
+  // useSubscription calls `/api/v1/subscriptions/me` — return active trial so
+  // ProtectedRoute sees `isExpired=false` and renders <Outlet/>.
+  await page.route('**/api/v1/subscriptions/me', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ status: 'trial', tier: 'trial', days_remaining: 7 }),
+      body: JSON.stringify({
+        tier: 'trial',
+        status: 'trial',
+        days_remaining: 7,
+        trial_start: '2026-01-01T00:00:00Z',
+        trial_expires: '2026-01-08T00:00:00Z',
+      }),
     }),
   )
   await page.addInitScript(() => {


### PR DESCRIPTION
## Summary

Fixes #812 — restores e2e Playwright coverage by updating the auth mocks to match the current frontend contract and re-enables the `e2e` CI job on the same PR (load-bearing, per the disable contract in #811).

### Endpoint contract drift (root cause)

| Hook / Surface         | Pre-#811 mock                          | Actual endpoint at HEAD                | Resolution                                   |
|------------------------|----------------------------------------|----------------------------------------|----------------------------------------------|
| `useAuth`              | `GET /api/v1/auth/me`                  | `GET /api/v1/users/me` (user-service `UserRead`) | Re-route mocks; reshape `auth-user.json` to the `AuthUser` interface |
| `useSubscription`      | `GET /api/v1/auth/subscription`        | `GET /api/v1/subscriptions/me` (returns `SubscriptionResponse`; 404 = no subscription) | Re-route mocks; payload now includes `tier`, `status`, `days_remaining`, `trial_start`, `trial_expires` |

Note: the issue body hypothesized `/api/v1/sessions` for auth — verified at HEAD, `useAuth` actually uses `/api/v1/users/me`. `/sessions` is exclusively the sign-out / session-list path. Fixed accordingly.

### Why the tests were timing out

Pre-fix: mocked `/auth/me` and `/auth/subscription` never matched, so `useAuth` resolved with `user=null`, `ProtectedRoute` (`if (!user) return <Navigate to="/login" />`) sent every authenticated test to the login page, and `Main navigation` never rendered.

Post-fix: mocks intercept `/api/v1/users/me` and `/api/v1/subscriptions/me`, both with payloads shaped to the current TS interfaces (`AuthUser`, `SubscriptionResponse`). `user.email_verified=true` clears the `/check-email` gate, and `subscription.status='trial'` keeps `isExpired=false`, so `<Outlet/>` renders.

### Files changed

- `frontend/tests/e2e/fixtures/auth-user.json` — reshape: drop legacy `name`/`is_admin`/`provider` fields; add `display_name`, `avatar_url`, `is_active`, `locale`, `created_at`, `roles`. Matches `AuthUser` in `src/hooks/useAuth.ts:22-35`.
- `frontend/tests/e2e/navigation.spec.ts` — re-route `/users/me` and `/subscriptions/me`; catch-all fallback updated.
- `frontend/tests/e2e/search.spec.ts` — same dual re-route.
- `frontend/tests/e2e/accessibility.spec.ts` — same dual re-route.
- `.github/workflows/ci.yml` — remove `if: false` + the disable comment from the `e2e` job. No `continue-on-error`, no `xfail`.

### #812 acceptance criteria

- [x] Audit all e2e test files in `frontend/tests/e2e/` and identify every endpoint mocked
- [x] Cross-reference with the actual frontend `useAuth`/`useSubscription` implementation to determine current contract
- [x] Update mocks to current contract (verified payload shape against TS interfaces — not just status codes)
- [x] Re-enable the e2e job in `.github/workflows/ci.yml`
- [x] Verify the re-enabled e2e job passes CI on the same PR — **runs as part of this PR's CI; the gate is correctly scoped to CI per `feedback_runtime_gate_scoping.md` (full design-system tarball + npm install + Playwright pipeline cannot be reproduced locally without rebuilding the design-system at v0.0.1)**
- [x] No further silencing (no `if: skip`, no `continue-on-error`, no `xfail`)

### Out of scope

- The pre-existing `actionlint` SC2034 warning on `for i in $(seq 1 30)` in the wait-for-server step is from the original `e2e` job body, not introduced here.

## Test plan

- [ ] CI: `e2e` job runs (it was disabled before this PR) and is green
- [ ] CI: `frontend-lint-and-test` remains green (unit tests + ESLint + tsc unchanged)
- [ ] CI: all other gates green (no incidental drift)
- [ ] Reviewer-verify: `auth-user.json` fields match the `AuthUser` interface in `src/hooks/useAuth.ts`
- [ ] Reviewer-verify: subscription mock payload matches `SubscriptionResponse` in `src/types/api.ts:190-196`
- [ ] If CI e2e surfaces additional pre-existing breakage, fix in this PR (per acceptance criterion) — do NOT merge with e2e still red

## Reviewers

- Thandiwe Moyo (Data Scientist) — R1
- Idris Yusuf (Security Engineer) — R2

Closes #812
