### PR TITLE
fix(security): bump urllib3 2.6.3 → 2.7.0 (CVE-2026-44431 + CVE-2026-44432)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1459,11 +1459,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `urllib3 2.6.3 → 2.7.0` in `uv.lock` to resolve two CVEs currently
failing the `security-audit` lane on wave-10 isnad-graph PRs. `urllib3` is
a transitive dependency (via `docker`, `requests`, `testcontainers`); no
explicit pin in `pyproject.toml`.

## Advisories

| CVE | Severity | Vector | Fix |
|---|---|---|---|
| [CVE-2026-44431](https://nvd.nist.gov/vuln/detail/CVE-2026-44431) | Header-leak on cross-origin redirect | `ProxyManager.connection_from_url().urlopen(..., assert_same_host=False)` forwards `Authorization` / `Cookie` / `Proxy-Authorization` on cross-origin redirect | urllib3 ≥ 2.7.0 |
| [CVE-2026-44432](https://nvd.nist.gov/vuln/detail/CVE-2026-44432) | Decompression CPU/memory blowup (CWE-409) | Brotli `HTTPResponse.read(amt=N)` second call + `HTTPResponse.drain_conn()` after partial read decompress full body | urllib3 ≥ 2.7.0 |

Both advisories list `2.7.0` as the Fix Version per `pip-audit --strict` output on the failing wave-10 security-audit run.

## Lockfile diff scope

Bounded to the `urllib3` package block only — `version`, `sdist`
URL/hash, `wheel` URL/hash:

```
 uv.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

No transitive consumer's resolution shifted. No `import urllib3` in `src/`
(verified by grep).

## Verification

Replicated the CI `security-audit` lane locally with the exact flags:

```
uv export --no-hashes --frozen --no-emit-project > /tmp/req.txt
uv run pip-audit --strict --desc -r /tmp/req.txt \
  --ignore-vuln CVE-2024-23342 \
  --ignore-vuln CVE-2026-4539 \
  --ignore-vuln CVE-2026-25645
```

Result post-bump: **`No known vulnerabilities found, 1 ignored`**
(the 1 ignored = existing CI-allowlisted `CVE-2024-23342`).

## Unblocks

This is the precursor for the wave-10 `security-audit` lane. Once merged
into `deployments/phase-3/wave-10`, the lane will pass on:

- #878 (ghcr/npm-ci tarball)
- #881 (e2e auth mocks)

and any other wave-10 isnad-graph PRs currently red on this lane.

## Test plan

- [x] `uv lock --upgrade-package urllib3` resolves with bounded diff (only urllib3 lines change)
- [x] `pip-audit --strict` (CI invocation, same ignore-list) clean post-bump
- [x] No direct `urllib3` import in `src/` — purely transitive bump
- [ ] CI `security-audit` lane goes green on this PR (will verify on PR run)
- [ ] Reviewer pair (to be assigned by orchestrator) confirms scope
