### PR TITLE
tech-debt(frontend): stop ProtectedRoute remounting children on subLoading toggle

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -2,17 +2,22 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useSubscription } from '../hooks/useSubscription'
 
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}
+
 export default function ProtectedRoute() {
   const { user, loading } = useAuth()
   const { isExpired, isLoading: subLoading } = useSubscription()
   const location = useLocation()
 
-  if (loading || subLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
-      </div>
-    )
+  // Auth must resolve before we can decide whether to redirect or render.
+  if (loading) {
+    return <LoadingSpinner />
   }
 
   if (!user) {
@@ -27,5 +32,18 @@ export default function ProtectedRoute() {
     return <Navigate to="/check-email" replace />
   }
 
-  return <Outlet />
+  // Once authenticated, the child subtree mounts once and stays mounted.
+  // A `subLoading` toggle renders an overlay alongside <Outlet /> rather than
+  // swapping it out — otherwise React unmounts/remounts the whole subtree on
+  // every toggle, amplifying any re-mount-driven retry loop (see #831, #830).
+  return (
+    <>
+      <Outlet />
+      {subLoading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-sm">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      )}
+    </>
+  )
 }

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react"
+import { useEffect } from "react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import ProtectedRoute from "../ProtectedRoute"
+import type { AuthUser } from "../../hooks/useAuth"
+
+const mockUseAuth = vi.fn()
+const mockUseSubscription = vi.fn()
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}))
+vi.mock("../../hooks/useSubscription", () => ({
+  useSubscription: () => mockUseSubscription(),
+}))
+
+function makeUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: "6cf04f80-ede7-42e6-9756-43f8ce8f220d",
+    email: "jane@example.com",
+    display_name: "Jane Smith",
+    avatar_url: null,
+    email_verified: true,
+    is_active: true,
+    locale: null,
+    created_at: "2026-04-20T03:09:36.076621Z",
+    roles: [],
+    ...overrides,
+  }
+}
+
+let mountCount = 0
+function ChildPage() {
+  useEffect(() => {
+    mountCount += 1
+  }, [])
+  return <div>child page</div>
+}
+
+function renderProtected() {
+  return render(
+    <MemoryRouter initialEntries={["/app"]}>
+      <Routes>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/app" element={<ChildPage />} />
+        </Route>
+        <Route path="/login" element={<div>login page</div>} />
+        <Route path="/trial-expired" element={<div>trial expired page</div>} />
+        <Route path="/check-email" element={<div>check email page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ProtectedRoute", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+    mockUseSubscription.mockReset()
+    mountCount = 0
+  })
+
+  it("redirects to /login when unauthenticated", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("login page")).toBeInTheDocument()
+  })
+
+  it("redirects to /trial-expired when subscription is expired", () => {
+    mockUseAuth.mockReturnValue({ user: makeUser(), loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: true, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("trial expired page")).toBeInTheDocument()
+  })
+
+  it("redirects to /check-email when email is unverified", () => {
+    mockUseAuth.mockReturnValue({
+      user: makeUser({ email_verified: false }),
+      loading: false,
+    })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("check email page")).toBeInTheDocument()
+  })
+
+  it("renders children for an authenticated, verified, non-expired user", () => {
+    mockUseAuth.mockReturnValue({ user: makeUser(), loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("child page")).toBeInTheDocument()
+  })
+
+  it("keeps children mounted across a subLoading toggle (regression for #831)", () => {
+    mockUseAuth.mockReturnValue({ user: makeUser(), loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    const { rerender } = renderProtected()
+    expect(screen.getByText("child page")).toBeInTheDocument()
+    expect(mountCount).toBe(1)
+
+    // subLoading toggles true — e.g. the subscription query refetches.
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: true })
+    rerender(
+      <MemoryRouter initialEntries={["/app"]}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/app" element={<ChildPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    // Child must NOT have unmounted/remounted — still mounted exactly once.
+    expect(screen.getByText("child page")).toBeInTheDocument()
+    expect(mountCount).toBe(1)
+
+    // subLoading toggles back to false.
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+    rerender(
+      <MemoryRouter initialEntries={["/app"]}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/app" element={<ChildPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+    expect(screen.getByText("child page")).toBeInTheDocument()
+    expect(mountCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #831 — `ProtectedRoute` re-mounted its entire child subtree every time `subLoading` toggled, amplifying the retry loop diagnosed in #830.

### Root cause

`ProtectedRoute` returned a spinner element tree when `loading || subLoading` was true and `<Outlet />` otherwise. React diffs those as different element types at the same position, so any `subLoading` transition unmounted and remounted the whole authenticated subtree. Combined with hooks that re-enter their query on mount, this turned a handful of retries into a request storm.

### Fix

- Auth `loading` still gates render — we genuinely cannot choose redirect-vs-render until auth resolves.
- Once authenticated, verified, and non-expired, `<Outlet />` mounts **once and stays mounted**. A `subLoading` toggle now renders a fixed-position overlay spinner *alongside* `<Outlet />` instead of swapping the subtree out.
- This matches the issue's suggested direction (render spinner alongside children / never unmount authenticated routes once entered).

### Scope notes

- `AdminRoute` was audited per the issue's "audit other `*Route` wrappers" note — it only branches on `hasRole('admin')` (derived from already-resolved auth state, no toggling loading boolean), so it has no re-mount foot-gun and is left unchanged.
- Stayed scoped to the re-mount fix; the #830 primary fix (`retry: false` + admin bypass in `useSubscription`) is already merged independently.

## Test plan

- [x] New `ProtectedRoute.test.tsx` — 5 tests covering the redirect branches plus a regression test asserting the child subtree mounts **exactly once** across `subLoading` true→false toggles.
- [x] Verified the regression test **fails** against the pre-fix component (child remounts, `mountCount` hits 2) and **passes** after the fix.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors (11 pre-existing warnings, none in changed files).
- [x] Full frontend suite `npm run test` — 56/56 pass.

Closes #831
