### PR TITLE
fix(frontend): align OAuth callback route with backend redirect target (#824)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,7 +54,7 @@ export default function App() {
           <Routes>
             {/* Public routes */}
             <Route path="login" element={<LoginPage />} />
-            <Route path="auth/callback/:provider" element={<AuthCallbackPage />} />
+            <Route path="auth/callback" element={<AuthCallbackPage />} />
             <Route path="pricing" element={<PricingPage />} />
             <Route path="billing/checkout" element={<CheckoutPage />} />
             <Route path="trial-expired" element={<TrialExpiredPage />} />

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -45,3 +45,61 @@ test.describe('Authentication', () => {
     await expect(page).toHaveURL(/\/login/)
   })
 })
+
+test.describe('OAuth callback redirect', () => {
+  // The backend (user-service AUTH_OAUTH_POST_LOGIN_URL) emits a provider-less
+  // `/auth/callback?token=...` redirect. These tests guard that the frontend
+  // route matches that exact path shape — see issue #824.
+
+  test('success redirect stores token and lands on return URL', async ({ page }) => {
+    await page.route('**/api/v1/users/me', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: '1', email: 'test@example.com', name: 'Test User', roles: [] }),
+      }),
+    )
+    await page.route('**/api/v1/subscriptions/me', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tier: 'trial', status: 'trial', days_remaining: 7 }),
+      }),
+    )
+    await page.route('**/api/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+
+    await page.goto('/auth/callback?token=oauth-access-token&is_new_user=0&needs_verification=0')
+
+    // Route matched (no fall-through to 404) and AuthCallbackPage navigated away.
+    await expect(page).not.toHaveURL(/\/auth\/callback/)
+    await expect(page).not.toHaveURL(/\/login/)
+
+    const token = await page.evaluate(() => localStorage.getItem('access_token'))
+    expect(token).toBe('oauth-access-token')
+  })
+
+  test('new-user redirect lands on email verification', async ({ page }) => {
+    await page.route('**/api/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+
+    await page.goto('/auth/callback?token=oauth-access-token&is_new_user=1&needs_verification=1')
+
+    await expect(page).toHaveURL(/\/check-email/)
+  })
+
+  test('error param renders the sign-in failed UI', async ({ page }) => {
+    await page.goto('/auth/callback?error=oauth_exchange_failed')
+
+    // Route matched and AuthCallbackPage rendered the error branch rather than
+    // navigating away. (toBeAttached, not toBeVisible — the error card's width
+    // utilities collapse under the preview build's Tailwind output.)
+    await expect(page.getByRole('heading', { name: 'Sign-in failed' })).toBeAttached()
+    await expect(
+      page.getByText(/unable to complete sign-in with the provider/i),
+    ).toBeAttached()
+    await expect(page).toHaveURL(/\/auth\/callback/)
+  })
+})


### PR DESCRIPTION
## Summary

The isnad-graph frontend route was registered as `auth/callback/:provider`, requiring a provider path segment. user-service#67 (`AUTH_OAUTH_POST_LOGIN_URL`, default `/auth/callback`) emits a **provider-less** `/auth/callback?token=...&is_new_user=...&needs_verification=...` redirect on OAuth success. React Router treats `:provider` as a required segment, so the redirect failed to match and fell through to the 404 catch-all — the token was never processed.

`AuthCallbackPage.tsx` reads exclusively from `useSearchParams()` and never touched the `:provider` path param (verified: no `useParams` import, no provider read), so the segment was vestigial.

## Change

- **`frontend/src/App.tsx`** — `auth/callback/:provider` → `auth/callback` (issue Option C). One side changed: frontend, because the dead path param made C strictly simpler than parameterizing the backend per-provider (Option B). Backend default stays as-is.
- **`frontend/tests/e2e/auth.spec.ts`** — new `OAuth callback redirect` describe block: success redirect (token stored in localStorage, lands on return URL), new-user flow (lands on `/check-email`), error param (renders the sign-in failed UI).

## Test results

- `npm run lint` — 0 errors (11 pre-existing warnings, none in changed files)
- `npx tsc --noEmit` — clean
- `npm run test` (vitest) — 51 passed
- `npx playwright test` — 22 passed (full suite, incl. 3 new OAuth redirect tests)

## Scope notes

- The error-param e2e test uses `toBeAttached` rather than `toBeVisible`: the error card's Tailwind width utilities (`max-w-md`/`w-full`) collapse to ~0 width under the preview build's CSS output. This is a pre-existing CSS quirk in the error UI, unrelated to the routing fix — flagged here rather than silently worked around.

Closes #824
