### PR TITLE
fix(isnad-graph #835): hide User Management nav, stop hitting removed /admin/users

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,6 @@ import SearchPage from './pages/SearchPage'
 import TimelinePage from './pages/TimelinePage'
 import ComparativePage from './pages/ComparativePage'
 import GraphExplorerPage from './pages/GraphExplorerPage'
-import UserManagementPage from './pages/admin/UserManagementPage'
 import SystemHealthPage from './pages/admin/SystemHealthPage'
 import ContentStatsPage from './pages/admin/ContentStatsPage'
 import UsageAnalyticsPage from './pages/admin/UsageAnalyticsPage'
@@ -83,7 +82,7 @@ export default function App() {
                 <Route path="admin" element={<AdminLayout />}>
                   <Route index element={<Navigate to="/admin/dashboard" replace />} />
                   <Route path="dashboard" element={<DashboardPage />} />
-                  <Route path="users" element={<UserManagementPage />} />
+                  <Route path="users" element={<Navigate to="/admin/dashboard" replace />} />
                   <Route path="health" element={<SystemHealthPage />} />
                   <Route path="stats" element={<ContentStatsPage />} />
                   <Route path="analytics" element={<UsageAnalyticsPage />} />

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -3,9 +3,9 @@ import { useAuth } from '../hooks/useAuth'
 import ThemeToggle from './ThemeToggle'
 import styles from './AdminLayout.module.css'
 
+// User Management omitted — backend 501 pending user-service admin API (#835, #806).
 const adminNavItems = [
   { to: '/admin/dashboard', label: 'Dashboard' },
-  { to: '/admin/users', label: 'User Management' },
   { to: '/admin/health', label: 'System Health' },
   { to: '/admin/stats', label: 'Content Stats' },
   { to: '/admin/analytics', label: 'Usage Analytics' },

--- a/frontend/src/components/__tests__/AdminLayout.test.tsx
+++ b/frontend/src/components/__tests__/AdminLayout.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import AdminLayout from "../AdminLayout"
+import type { AuthUser } from "../../hooks/useAuth"
+
+const mockUseAuth = vi.fn()
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock("../ThemeToggle", () => ({
+  default: () => <div data-testid="theme-toggle" />,
+}))
+
+function makeAdmin(): AuthUser {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "admin@example.com",
+    display_name: "Admin",
+    avatar_url: null,
+    email_verified: true,
+    is_active: true,
+    locale: null,
+    created_at: "2026-04-20T03:09:36.076621Z",
+    roles: ["admin"],
+  }
+}
+
+function renderAdminLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/admin/dashboard"]}>
+      <Routes>
+        <Route path="/admin/*" element={<AdminLayout />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("AdminLayout nav", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+    mockUseAuth.mockReturnValue({
+      user: makeAdmin(),
+      loading: false,
+      isAdmin: true,
+    })
+  })
+
+  it("does not render the User Management entry while backend returns 501 (#835)", () => {
+    renderAdminLayout()
+    expect(screen.queryByRole("link", { name: "User Management" })).toBeNull()
+  })
+
+  it("renders the remaining admin nav entries", () => {
+    renderAdminLayout()
+    for (const label of [
+      "Dashboard",
+      "System Health",
+      "Content Stats",
+      "Usage Analytics",
+      "Audit Log",
+    ]) {
+      expect(
+        screen.getByRole("link", { name: label }),
+      ).toBeInTheDocument()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`/admin/users` backend handlers are deliberate 501 stubs — user management has moved to the user-service admin API. The isnad-graph frontend still imported `UserManagementPage`, routed to it, and surfaced a "User Management" nav entry, so admins landed on a broken page on every visit.

This ships option (1) from the issue triage — hide the nav entry and stop landing users on the dead page. Fastest, zero-risk; restoring the feature is tracked under the cross-service admin work (#806).

## Changes

- `frontend/src/components/AdminLayout.tsx` — drop the `User Management` nav item; comment references #835/#806 for the pending user-service admin API.
- `frontend/src/App.tsx` — drop the `UserManagementPage` import; redirect the `/admin/users` route to `/admin/dashboard` so any stale link no longer renders the dead page or fires its removed-endpoint fetch.
- `frontend/src/components/__tests__/AdminLayout.test.tsx` — new test: asserts the `User Management` link is absent and the remaining admin nav entries still render.

`UserManagementPage` and its `admin-client` calls are left in place but are now unreachable (no import, no route, no nav entry).

## Test results

- `tsc --noEmit` — clean
- `vitest run` — 53/53 pass (13 files), including the new `AdminLayout.test.tsx` (2 tests)

## Notes

- Targets `deployments/phase-3/wave-10` per P3W10 scoping.
- Issue assigned to Marisol Vega-Cruz; her on-disk fix was complete and sound — committed under her identity, PR opened on her behalf (throttle-takeover pattern).

Closes #835
