### PR TITLE
test(e2e): regression guard for OAuth callback provider-segment contract (#890)

### DIFF
--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -45,3 +45,54 @@ test.describe('Authentication', () => {
     await expect(page).toHaveURL(/\/login/)
   })
 })
+
+test.describe('OAuth callback redirect contract', () => {
+  // Regression guard for the cross-repo OAuth callback contract (#890, see #824).
+  // user-service `_build_post_login_url()` ALWAYS appends `/{provider}`, so the
+  // real redirect is `/auth/callback/google?token=...` — WITH the provider
+  // segment. These tests goto the provider-qualified URL so they fail if the
+  // frontend route `auth/callback/:provider` is ever changed to drop `:provider`
+  // (which would make React Router 404 the real redirect — that was #824).
+
+  test('provider-qualified success redirect matches the route and stores token', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+
+    await page.goto('/auth/callback/google?token=oauth-access-token&is_new_user=0&needs_verification=0')
+
+    // Route matched (no fall-through to the `*` 404 catch-all) and
+    // AuthCallbackPage navigated away after processing the token.
+    await expect(page).not.toHaveURL(/\/auth\/callback/)
+    await expect(page).not.toHaveURL(/\/login/)
+
+    const token = await page.evaluate(() => localStorage.getItem('access_token'))
+    expect(token).toBe('oauth-access-token')
+  })
+
+  test('provider-qualified new-user redirect lands on email verification', async ({ page }) => {
+    await page.route('**/api/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+
+    await page.goto('/auth/callback/google?token=oauth-access-token&is_new_user=1&needs_verification=1')
+
+    await expect(page).toHaveURL(/\/check-email/)
+  })
+
+  test('provider-qualified error redirect renders the sign-in failed UI', async ({ page }) => {
+    await page.goto('/auth/callback/google?error=oauth_exchange_failed')
+
+    // Route matched and AuthCallbackPage rendered the error branch rather than
+    // navigating away. (toBeAttached, not toBeVisible — the error card's width
+    // utilities collapse under the preview build's Tailwind output; tracked
+    // separately in #889.)
+    await expect(page.getByRole('heading', { name: 'Sign-in failed' })).toBeAttached()
+    await expect(
+      page.getByText(/unable to complete sign-in with the provider/i),
+    ).toBeAttached()
+    await expect(page).toHaveURL(/\/auth\/callback\/google/)
+  })
+})


### PR DESCRIPTION
## Summary

Tests-only regression guard for the cross-repo OAuth callback provider-segment contract. **No `src/` change** — the frontend route is already correct against user-service HEAD.

## Background

#824 was a real two-sided OAuth contract bug at filing time. user-service #67 resolved it by choosing option (a): `_build_post_login_url()` always appends `/{provider}`, so the real redirect is `/auth/callback/google?token=...` — **with** the provider segment. The isnad-graph route `auth/callback/:provider` already matches that.

PR #885 attempted to "align" by dropping `:provider` — which would have re-introduced #824's exact failure mode (React Router fails to match `/auth/callback/google`, falls through to the `*` 404 catch-all). #885 was closed without merging; its e2e tests passed only because they `goto`'d the *assumed* provider-less URL, not the real one.

This PR adds the contract guard that should have existed: 3 e2e tests that `goto` the **provider-qualified** URL user-service actually emits. If the route is ever changed to drop `:provider` again, these tests fail.

## Changes

- `frontend/tests/e2e/auth.spec.ts` — new `OAuth callback redirect contract` describe block, 3 tests:
  - success: `/auth/callback/google?token=...` → route matched (no 404 fall-through), `access_token` persisted, navigates away.
  - new-user: `/auth/callback/google?token=...&is_new_user=1&needs_verification=1` → lands on `/check-email`.
  - error: `/auth/callback/google?error=oauth_exchange_failed` → error branch renders, URL stays on `/auth/callback/google`.

## Test results

- `npm run build` — clean (tsc check passes)
- `npx eslint tests/e2e/auth.spec.ts` — clean
- `npx playwright test auth.spec.ts` — 9 passed (3 new + 6 existing)
- `npx playwright test` — 22 passed (full suite, no regressions)

## Notes

- The error test uses `toBeAttached` rather than `toBeVisible` — the error card's Tailwind `max-w-md`/`w-full` width utilities collapse under the preview build's CSS output. That quirk is a real latent defect tracked separately in #889; it does not weaken this contract guard (the test's purpose is "route matched + error branch rendered").
- Cross-repo contract reference being guarded: user-service `src/app/routers/auth.py` `_build_post_login_url()` + `tests/test_oauth_callback_get.py` (`assert parsed.path == "/auth/callback/google"`).

Closes #890
