### PR TITLE
refactor(frontend/api): deduplicate getAuthHeaders() into shared module (#791)

### DIFF
--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -7,13 +7,9 @@ import type {
 } from '../types/admin'
 import type { PaginatedResponse } from '../types/api'
 import { emitSessionExpired } from '../hooks/useAuth'
+import { getAuthHeaders } from './auth-headers'
 
 const API_BASE = '/api/v1/admin'
-
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
 
 async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {

--- a/frontend/src/api/auth-headers.ts
+++ b/frontend/src/api/auth-headers.ts
@@ -1,0 +1,4 @@
+export function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,13 +17,9 @@ import type {
 } from '../types/api'
 
 import { emitSessionExpired } from '../hooks/useAuth'
+import { getAuthHeaders } from './auth-headers'
 
 const API_BASE = '/api/v1'
-
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
 
 interface FetchJsonOptions {
   // Statuses that should resolve to `null` instead of throwing.

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -1,15 +1,11 @@
 import { emitSessionExpired } from '../hooks/useAuth'
+import { getAuthHeaders } from './auth-headers'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
 // useAuth.ts for the full BASE-constant set; kept duplicated here to avoid
 // a barrel-export refactor inside this PR.
 const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
 const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
-
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
 
 async function fetchProfileJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {


### PR DESCRIPTION
## Summary

`getAuthHeaders()` was copy-pasted **byte-for-byte identical** across three frontend API client files:
- `frontend/src/api/client.ts`
- `frontend/src/api/admin-client.ts`
- `frontend/src/api/profile-client.ts`

All three definitions were verified identical:
```ts
function getAuthHeaders(): HeadersInit {
  const token = localStorage.getItem('access_token')
  return token ? { Authorization: `Bearer ${token}` } : {}
}
```

This PR extracts the single definition into a new shared module `frontend/src/api/auth-headers.ts` (exported) and updates all three call sites to import it. No behavior change — net -8 lines.

## Test plan

- [x] `npm run build` (tsc typecheck + vite production build) — passes, 1492 modules transformed
- [x] `npm run test` — 62/62 tests pass across 15 files
- [x] `npm run lint` — 0 errors (11 pre-existing warnings, none in touched files)
- [x] Confirmed exactly one `getAuthHeaders` definition remains repo-wide (the new shared module)

Closes #791
