### PR TITLE
refactor(isnad-graph #794): remove unused layoutMode state from GraphExplorerPage

### DIFF
--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -14,8 +14,6 @@ import type { GraphNode, GraphEdge, Narrator, ChainSummary } from '../types/api'
 const NODE_LIMIT = 5000
 const SUGGESTED_NARRATORS = ['Abu Hurayra', 'al-Zuhri', 'Malik ibn Anas', 'Aisha bint Abi Bakr']
 
-type LayoutMode = 'force' | 'hierarchy' | 'radial'
-
 export default function GraphExplorerPage() {
   // --- State ---
   const [searchInput, setSearchInput] = useState('')
@@ -29,7 +27,6 @@ export default function GraphExplorerPage() {
   const [legendOpen, setLegendOpen] = useState(false)
   const [filterOpen, setFilterOpen] = useState(false)
   const [highlightedChainNodeIds, setHighlightedChainNodeIds] = useState<Set<string> | null>(null)
-  const [layoutMode, setLayoutMode] = useState<LayoutMode>('force')
   const containerRef = useRef<HTMLDivElement | null>(null)
   const searchRef = useRef<HTMLInputElement | null>(null)
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 })
@@ -295,32 +292,6 @@ export default function GraphExplorerPage() {
               }}
             >
               {d}
-            </button>
-          ))}
-        </div>
-
-        {/* Layout toggle */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-          <span style={{ fontSize: '0.875rem', color: 'var(--color-muted-foreground)' }}>Layout:</span>
-          {(['force', 'hierarchy', 'radial'] as LayoutMode[]).map((mode) => (
-            <button
-              key={mode}
-              onClick={() => setLayoutMode(mode)}
-              style={{
-                padding: '0.25rem 0.5rem',
-                border: '1px solid var(--color-border)',
-                borderRadius: 'var(--radius-sm)',
-                background:
-                  mode === layoutMode
-                    ? 'var(--color-primary, oklch(0.55 0.14 45))'
-                    : 'transparent',
-                color: mode === layoutMode ? 'var(--color-primary-foreground)' : 'inherit',
-                cursor: 'pointer',
-                fontSize: '0.8rem',
-                textTransform: 'capitalize',
-              }}
-            >
-              {mode}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary

`frontend/src/pages/GraphExplorerPage.tsx` declared a `layoutMode` state (`force` | `hierarchy` | `radial`) with a button group that set it, but the value was never passed to `ForceGraph` or read anywhere — the toggle changed only its own active styling and had no effect on the rendered graph.

Per #794, this takes the "remove the unused state and its UI control" path. Wiring `layoutMode` into the layout algorithm is the alternative, but that's a feature, not the refactor #794 asks for.

## Changes

`frontend/src/pages/GraphExplorerPage.tsx` (−29 lines, single file):
- Remove the `LayoutMode` type alias.
- Remove the `layoutMode` / `setLayoutMode` `useState`.
- Remove the now-orphaned "Layout toggle" UI block (the only `layoutMode` reader was its own cosmetic active-state styling).

The page is otherwise unchanged.

## Verification it was unconsumed

`grep -rn 'layoutMode\|LayoutMode' frontend/src/` before the change: all 5 hits were inside `GraphExplorerPage.tsx` (type decl, state decl, and the toggle's set/read). Not passed as a prop, not in any effect dep, no child component reads it. After the change: zero hits.

## Test results

- `npm run build` (tsc --noEmit + vite) — clean
- `npm run lint` — 0 errors (11 pre-existing warnings, all in unrelated admin config code)
- `npx vitest run` — 62/62 pass across 15 files

Closes #794
