### PR TITLE
ci-cd: bump 4 remaining Node-20-era action sites to v6 (#874)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           # design-system version. Or, see #810 to remove this whole dance.
           ref: v0.0.1
           path: noorinalabs-design-system
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -205,7 +205,7 @@ jobs:
           # design-system version. Or, see #810 to remove this whole dance.
           ref: v0.0.1
           path: noorinalabs-design-system
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -72,14 +72,14 @@ jobs:
             platforms: linux/amd64
     steps:
       - name: Checkout (isnad-graph)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Frontend only: stage the design-system tarball into the build context
       # so the Dockerfile's `COPY noorinalabs-design-system-0.0.1.tgz /` works.
       # GITHUB_TOKEN works cross-repo because both repos are in the same org.
       - name: Checkout design-system (frontend only)
         if: matrix.component == 'frontend'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: noorinalabs/noorinalabs-design-system
           ref: ${{ env.DESIGN_SYSTEM_REF }}


### PR DESCRIPTION
## Summary

isnad-graph is the named reference repo for the org-wide Node 20 deprecation audit (noorinalabs-main#309), but 4 sites at HEAD still lagged the canonical version set. This bumps all 4.

| File | Line | Before | After |
|---|---|---|---|
| `.github/workflows/ci.yml` | 99 | `actions/setup-node@v4` | `actions/setup-node@v6` |
| `.github/workflows/ci.yml` | 208 | `actions/setup-node@v4` | `actions/setup-node@v6` |
| `.github/workflows/ghcr-publish.yml` | 75 | `actions/checkout@11bd719… # v4.2.2` | `actions/checkout@de0fac2… # v6.0.2` |
| `.github/workflows/ghcr-publish.yml` | 82 | `actions/checkout@11bd719… # v4.2.2` | `actions/checkout@de0fac2… # v6.0.2` |

(Issue table cited `ci.yml:219` — at wave-10 HEAD the second `setup-node` is at L208. Line drift, same site. Count verified: exactly 4, as the issue stated.)

## SHA-pin decision

`ghcr-publish.yml` stays **SHA-pinned** per supply-chain hardening (the issue's acceptance criterion + `feedback_verify_third_party_integrity_claims.md`). Pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` — verified as `actions/checkout` **v6.0.2** via `gh api repos/actions/checkout/git/refs/tags` (v6.0.2 is the latest v6.x; the floating `v6` tag currently points to the same SHA). The `setup-node` sites in `ci.yml` are left as bare `@v6` to match that file's existing `actions/checkout@v6` style (ci.yml does not SHA-pin).

## Scope

- All 12 `actions/checkout` sites across `ci.yml` / `auto-close-issues.yml` / `pipeline.yml` were **already at `@v6`** — only `setup-node` and `ghcr-publish` were missed. Confirmed by grep at wave-10 HEAD.
- Other actions in these files (`actions/cache@v5`, `actions/upload-artifact@v7`) are already on current majors — not Node-20-era, out of scope for #874.
- `actionlint` (with shellcheck on PATH) run on both changed files: the 2 reported shellcheck findings (`ci.yml:241` SC2034, `ghcr-publish.yml:207` SC2129) are **pre-existing in unrelated script blocks** — confirmed identical on the base branch via `git stash`. This PR introduces zero new actionlint issues.

Closes #874
Refs noorinalabs-main#309
