### PR TITLE
refactor(frontend): move LoginPage OAuth hover to CSS :hover

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -253,14 +253,7 @@ export default function LoginPage() {
               <button
                 onClick={() => handleOAuth('google')}
                 disabled={isLoading}
-                className="flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
-                style={{
-                  border: `1px solid var(--color-oauth-google-border)`,
-                  backgroundColor: 'var(--color-oauth-google-bg)',
-                  color: 'var(--color-oauth-google-text)',
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-google-bg-hover)')}
-                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-google-bg)')}
+                className="oauth-button-google flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
               >
                 <GoogleIcon />
                 {oauthLoading === 'google' ? 'Redirecting...' : 'Sign in with Google'}
@@ -271,13 +264,7 @@ export default function LoginPage() {
               <button
                 onClick={() => handleOAuth('github')}
                 disabled={isLoading}
-                className="flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
-                style={{
-                  backgroundColor: 'var(--color-oauth-github-bg)',
-                  color: 'var(--color-oauth-github-text)',
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-github-bg-hover)')}
-                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-github-bg)')}
+                className="oauth-button-github flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
               >
                 <GitHubIcon />
                 {oauthLoading === 'github' ? 'Redirecting...' : 'Sign in with GitHub'}

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -1088,3 +1088,24 @@
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-muted-foreground);
 }
+
+/* OAuth sign-in buttons — per-provider colors with CSS :hover
+   (replaces inline onMouseEnter/onMouseLeave handlers) */
+.oauth-button-google {
+  border: var(--border-width-thin) solid var(--color-oauth-google-border);
+  background-color: var(--color-oauth-google-bg);
+  color: var(--color-oauth-google-text);
+}
+
+.oauth-button-google:hover {
+  background-color: var(--color-oauth-google-bg-hover);
+}
+
+.oauth-button-github {
+  background-color: var(--color-oauth-github-bg);
+  color: var(--color-oauth-github-text);
+}
+
+.oauth-button-github:hover {
+  background-color: var(--color-oauth-github-bg-hover);
+}


### PR DESCRIPTION
## Summary

`LoginPage`'s Google and GitHub OAuth buttons implemented hover styling via inline `onMouseEnter` / `onMouseLeave` handlers that mutated `e.currentTarget.style.backgroundColor` in JS. This moves it to native CSS `:hover`.

## Changes

- **`frontend/src/styles/common.css`** — added `.oauth-button-google` / `.oauth-button-github` classes, each carrying the per-provider `border` / `background-color` / `color` plus a native `:hover` rule that swaps to the `--color-oauth-*-bg-hover` var. This matches the existing component-class + `:hover` pattern already in `common.css` (`.stat-card:hover`, `.data-table tbody tr.clickable-row:hover`).
- **`frontend/src/pages/LoginPage.tsx`** — removed the inline `style={{...}}` per-provider colors and both `onMouseEnter`/`onMouseLeave` handlers from the two OAuth buttons; added the new class names. Structural Tailwind utilities (`flex w-full ...`) are unchanged.

The hover-target CSS vars (`--color-oauth-google-bg-hover`, `--color-oauth-github-bg-hover`) already existed in `theme.css` for both light and dark themes — no new tokens needed. Rendered hover behavior is visually identical.

## Test plan

- [x] `npm run lint` — 0 errors (11 pre-existing warnings, none in changed files)
- [x] `npm run build` — clean (`tsc` + `vite build` both pass)
- [x] `npm run test` — 62 passed (15 files)
- No unit test exists for `LoginPage`, and the `auth.spec.ts` e2e does not select the OAuth buttons by style/hover — pure visual-equivalence refactor, no test change required.

Closes #803