### PR TITLE
refactor(health): route DB connectivity checks through app accessors (#793)

### DIFF
--- a/src/api/routes/admin/health.py
+++ b/src/api/routes/admin/health.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, Depends
 from src.api.deps import get_neo4j
 from src.api.models import SystemHealthResponse
 from src.utils.neo4j_client import Neo4jClient
+from src.utils.pg_client import PgClient
+from src.utils.redis_client import get_redis_client
 
 router = APIRouter(prefix="/health")
 
@@ -26,7 +28,14 @@ def liveness() -> SystemHealthResponse:
 def readiness(
     neo4j: Neo4jClient = Depends(get_neo4j),
 ) -> SystemHealthResponse:
-    """Readiness probe — check Neo4j, PostgreSQL, and Redis connectivity."""
+    """Readiness probe — check Neo4j, PostgreSQL, and Redis connectivity.
+
+    Verifies each service through the same accessor the application uses for
+    real traffic — the ``app.state.neo4j`` driver, the ``PgClient`` wrapper,
+    and ``get_redis_client`` — rather than constructing throwaway connections
+    by hand. The accessors are still invoked inside per-service guards so an
+    unreachable dependency yields a ``degraded`` response rather than a 500.
+    """
     neo4j_ok = False
     pg_ok = False
     redis_ok = False
@@ -38,27 +47,16 @@ def readiness(
         pass
 
     try:
-        from src.config import get_settings
-
-        settings = get_settings()
-        if settings.postgres.dsn:
-            import psycopg
-
-            conn = psycopg.connect(str(settings.postgres.dsn))
-            conn.close()
-            pg_ok = True
+        with PgClient() as pg:
+            pg.execute("SELECT 1")
+        pg_ok = True
     except Exception:
         pass
 
     try:
-        from src.config import get_settings
-
-        settings = get_settings()
-        if settings.redis.url:
-            import redis
-
-            r = redis.from_url(str(settings.redis.url))
-            r.ping()
+        client = get_redis_client()
+        if client is not None:
+            client.ping()
             redis_ok = True
     except Exception:
         pass

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import time
 
-import psycopg
-import redis as redis_lib
 from fastapi import APIRouter, Depends, Response
 
 from src.api.deps import get_neo4j
 from src.api.models import HealthResponse, ServiceStatus, StatusResponse
-from src.config import get_settings
 from src.utils.neo4j_client import Neo4jClient
+from src.utils.pg_client import PgClient
+from src.utils.redis_client import get_redis_client
 
 router = APIRouter()
 
@@ -32,19 +31,18 @@ def _check_neo4j(neo4j: Neo4jClient) -> ServiceStatus:
 
 
 def _check_postgres() -> ServiceStatus:
-    """Check PostgreSQL connectivity and return status."""
+    """Check PostgreSQL connectivity and return status.
+
+    Uses the application's ``PgClient`` wrapper — the same accessor used for
+    real traffic — instead of hand-rolling a raw ``psycopg.connect`` call.
+    """
     start = time.monotonic()
     try:
-        settings = get_settings()
-        conn = psycopg.connect(settings.postgres.dsn)
-        try:
-            with conn.cursor() as cur:
-                cur.execute("SELECT version()")
-                row = cur.fetchone()
-                version = str(row[0]).split(",")[0] if row else None
-        finally:
-            conn.close()
+        with PgClient() as pg:
+            rows = pg.execute("SELECT version() AS version")
         latency = (time.monotonic() - start) * 1000
+        raw = rows[0]["version"] if rows else None
+        version = str(raw).split(",")[0] if raw else None
         return ServiceStatus(status="up", latency_ms=round(latency, 1), version=version)
     except Exception as exc:
         latency = (time.monotonic() - start) * 1000
@@ -52,15 +50,21 @@ def _check_postgres() -> ServiceStatus:
 
 
 def _check_redis() -> ServiceStatus:
-    """Check Redis connectivity and return status."""
+    """Check Redis connectivity and return status.
+
+    Uses the shared ``get_redis_client`` helper — the same accessor used for
+    real traffic — instead of hand-rolling a raw ``redis.from_url`` call.
+    """
     start = time.monotonic()
     try:
-        settings = get_settings()
-        r = redis_lib.from_url(str(settings.redis.url))
-        r.ping()
-        info: dict[str, object] = r.info("server")  # type: ignore[assignment]
+        client = get_redis_client()
+        if client is None:
+            latency = (time.monotonic() - start) * 1000
+            return ServiceStatus(
+                status="down", latency_ms=round(latency, 1), error="redis unavailable"
+            )
+        info: dict[str, object] = client.info("server")
         version = str(info.get("redis_version", "")) or None
-        r.close()
         latency = (time.monotonic() - start) * 1000
         return ServiceStatus(status="up", latency_ms=round(latency, 1), version=version)
     except Exception as exc:

--- a/tests/test_api/test_admin.py
+++ b/tests/test_api/test_admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -132,14 +132,64 @@ class TestAdminHealth:
         assert data["status"] == "ok"
 
     def test_readiness(self, admin_client: TestClient, mock_neo4j: MagicMock) -> None:
+        """Readiness reports ok when every service is reachable via its accessor.
+
+        Postgres is mocked at the ``PgClient`` wrapper and Redis at the
+        ``get_redis_client`` helper — both imported into the admin health
+        module — so the probe exercises the same accessors the application
+        uses for real traffic. ``PgClient`` is used as a context manager.
+        """
         mock_neo4j.execute_read.return_value = [{"ok": 1}]
-        resp = admin_client.get("/api/v1/admin/health/ready")
+
+        mock_pg = MagicMock()
+        mock_pg.execute.return_value = [{"?column?": 1}]
+        mock_pg_cls = MagicMock()
+        mock_pg_cls.return_value.__enter__.return_value = mock_pg
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+
+        with (
+            patch("src.api.routes.admin.health.PgClient", mock_pg_cls),
+            patch(
+                "src.api.routes.admin.health.get_redis_client",
+                return_value=mock_redis,
+            ),
+        ):
+            resp = admin_client.get("/api/v1/admin/health/ready")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] in ("ok", "degraded")
-        assert "neo4j" in data
-        assert "postgres" in data
-        assert "redis" in data
+        assert data["status"] == "ok"
+        assert data["neo4j"] is True
+        assert data["postgres"] is True
+        assert data["redis"] is True
+
+    def test_readiness_degraded_when_pg_down(
+        self, admin_client: TestClient, mock_neo4j: MagicMock
+    ) -> None:
+        """Readiness reports degraded (not 500) when a service accessor fails."""
+        mock_neo4j.execute_read.return_value = [{"ok": 1}]
+
+        mock_pg = MagicMock()
+        mock_pg.execute.side_effect = RuntimeError("connection refused")
+        mock_pg_cls = MagicMock()
+        mock_pg_cls.return_value.__enter__.return_value = mock_pg
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+
+        with (
+            patch("src.api.routes.admin.health.PgClient", mock_pg_cls),
+            patch(
+                "src.api.routes.admin.health.get_redis_client",
+                return_value=mock_redis,
+            ),
+        ):
+            resp = admin_client.get("/api/v1/admin/health/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["postgres"] is False
+        assert data["neo4j"] is True
+        assert data["redis"] is True
 
 
 # --- Stats endpoint ---

--- a/tests/test_api/test_health.py
+++ b/tests/test_api/test_health.py
@@ -8,29 +8,33 @@ from fastapi.testclient import TestClient
 
 
 def _patch_pg_and_redis():
-    """Return context managers that mock PostgreSQL and Redis in the health module."""
-    mock_conn = MagicMock()
-    mock_cur = MagicMock()
-    mock_cur.fetchone.return_value = ("PostgreSQL 16.2",)
-    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cur
-    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    """Return context managers that mock PostgreSQL and Redis for the health checks.
+
+    Both are mocked at the names imported into the health module — the
+    ``PgClient`` wrapper and the ``get_redis_client`` helper — so the route
+    exercises the same accessors the application uses for real traffic.
+    ``PgClient`` is used as a context manager, so the mock's ``__enter__``
+    returns the connection mock.
+    """
+    mock_pg = MagicMock()
+    mock_pg.execute.return_value = [{"version": "PostgreSQL 16.2"}]
+    mock_pg_cls = MagicMock()
+    mock_pg_cls.return_value.__enter__.return_value = mock_pg
 
     mock_r = MagicMock()
     mock_r.ping.return_value = True
     mock_r.info.return_value = {"redis_version": "7.2.4"}
 
-    pg_patch = patch("src.api.routes.health.psycopg")
-    redis_patch = patch("src.api.routes.health.redis_lib")
-    return pg_patch, redis_patch, mock_conn, mock_r
+    pg_patch = patch("src.api.routes.health.PgClient", mock_pg_cls)
+    redis_patch = patch("src.api.routes.health.get_redis_client", return_value=mock_r)
+    return pg_patch, redis_patch, mock_pg, mock_r
 
 
 def test_health_check_all_up(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /health returns 200 with healthy status when all services are up."""
     mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/health")
     assert resp.status_code == 200
     body = resp.json()
@@ -43,10 +47,8 @@ def test_health_check_all_up(client: TestClient, mock_neo4j: MagicMock) -> None:
 def test_health_check_neo4j_down(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /health returns 503 when Neo4j is down."""
     mock_neo4j.execute_read.side_effect = RuntimeError("connection refused")
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/health")
     assert resp.status_code == 503
     body = resp.json()
@@ -55,13 +57,38 @@ def test_health_check_neo4j_down(client: TestClient, mock_neo4j: MagicMock) -> N
     assert body["services"]["neo4j"]["error"] is not None
 
 
+def test_health_check_postgres_down(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /health returns 503 when PostgreSQL is unreachable via get_pg."""
+    mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
+    pg_patch, redis_patch, mock_pg, _mock_r = _patch_pg_and_redis()
+    mock_pg.execute.side_effect = RuntimeError("connection refused")
+    with pg_patch, redis_patch:
+        resp = client.get("/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["services"]["postgres"]["status"] == "down"
+    assert body["services"]["postgres"]["error"] is not None
+
+
+def test_health_check_redis_unavailable(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /health returns 503 when get_redis_client yields None."""
+    mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
+    pg_patch, _redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    redis_none = patch("src.api.routes.health.get_redis_client", return_value=None)
+    with pg_patch, redis_none:
+        resp = client.get("/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["services"]["redis"]["status"] == "down"
+
+
 def test_root_serves_health(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET / serves the same health check as /health."""
     mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/")
     assert resp.status_code == 200
     body = resp.json()
@@ -71,10 +98,8 @@ def test_root_serves_health(client: TestClient, mock_neo4j: MagicMock) -> None:
 def test_status_all_operational(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /status returns operational when all services are up."""
     mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/status")
     assert resp.status_code == 200
     body = resp.json()
@@ -85,10 +110,8 @@ def test_status_all_operational(client: TestClient, mock_neo4j: MagicMock) -> No
 def test_status_degraded(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /status returns degraded when a service is down."""
     mock_neo4j.execute_read.side_effect = RuntimeError("connection refused")
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/status")
     assert resp.status_code == 200
     body = resp.json()


### PR DESCRIPTION
## Summary

`src/api/routes/admin/health.py` (readiness probe) and `src/api/routes/health.py` (`/health`, `/status`) hand-rolled raw `psycopg.connect()` and `redis.from_url()` calls on every request. This added connection overhead on every probe, risked exhausting connection limits under frequent health checking (e.g. Kubernetes liveness probes at short intervals), and exercised a different code path than real application traffic.

Both files now verify connectivity through the application's canonical accessors — the `PgClient` wrapper for PostgreSQL and the shared `get_redis_client()` helper for Redis. Neo4j was already checked via the pooled `app.state.neo4j` driver and is unchanged.

## Changes

- `src/api/routes/admin/health.py` — `readiness()` checks Postgres via `PgClient` and Redis via `get_redis_client()` instead of inline `psycopg.connect()` / `redis.from_url()`.
- `src/api/routes/health.py` — `_check_postgres()` uses `PgClient`; `_check_redis()` uses `get_redis_client()`. Removed the now-unused `psycopg` / `redis_lib` / `get_settings` imports.
- The accessors are invoked inside per-service `try/except` guards so an unreachable dependency still yields a `degraded` response rather than a 500 — health-check semantics are preserved.
- Tests updated to patch the new accessors (`PgClient`, `get_redis_client` at the health-module import sites), plus new coverage for the `postgres`-down and `redis`-unavailable degraded branches.

## Honest scope note

`PgClient` still opens a connection per instantiation — **there is no Postgres connection pool in this codebase today**. This PR aligns the health checks with the application's canonical access path (the issue's third bullet — "tests a different code path than what the application actually uses"), rather than literally eliminating per-request connects for Postgres. Introducing a real PG pool is a separate, larger change and out of scope here. Neo4j genuinely is pooled (`app.state.neo4j`) and was already used correctly.

Considered injecting `get_pg` as a FastAPI route dependency (as the issue text suggests) but rejected it: `get_pg` constructs `PgClient` outside its `try` block, so a PG outage during dependency resolution would 500 the entire health request instead of reporting `degraded`. Constructing `PgClient` inside the per-service guard keeps the canonical accessor while preserving graceful degradation.

## Test plan

- [x] `ruff check` + `ruff format --check` on all 4 changed files — clean
- [x] `mypy src/api/routes/health.py src/api/routes/admin/health.py` — Success, no issues
- [x] `pytest tests/test_api/` — 163 passed
- [x] `pytest tests/test_auth/test_security.py tests/test_api/test_admin_auth.py tests/test_security/` (health-adjacent suites) — 211 passed
- [ ] CI green
- [ ] Two reviewer Approved verdicts

Closes #793
