### PR TITLE
fix(frontend): give AuthCallbackPage error card a real width (#889)

### DIFF
--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -52,8 +52,15 @@ export default function AuthCallbackPage() {
 
   if (error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="w-full max-w-md space-y-4 rounded-2xl border border-border bg-card p-8 shadow-xl text-center">
+      <div className="flex min-h-screen items-center justify-center bg-background p-4">
+        {/* max-width is set inline, not via Tailwind's `max-w-md`: the design
+            system defines no `--container-*` theme namespace, so Tailwind 4
+            resolves `max-w-md` against `--spacing-md` (1rem) and collapses the
+            card to 16px wide. See #889. */}
+        <div
+          className="w-full space-y-4 rounded-2xl border border-border bg-card p-8 shadow-xl text-center"
+          style={{ maxWidth: '28rem' }}
+        >
           <div
             className="mx-auto flex items-center justify-center rounded-full"
             style={{

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -86,13 +86,11 @@ test.describe('OAuth callback redirect contract', () => {
     await page.goto('/auth/callback/google?error=oauth_exchange_failed')
 
     // Route matched and AuthCallbackPage rendered the error branch rather than
-    // navigating away. (toBeAttached, not toBeVisible — the error card's width
-    // utilities collapse under the preview build's Tailwind output; tracked
-    // separately in #889.)
-    await expect(page.getByRole('heading', { name: 'Sign-in failed' })).toBeAttached()
+    // navigating away.
+    await expect(page.getByRole('heading', { name: 'Sign-in failed' })).toBeVisible()
     await expect(
       page.getByText(/unable to complete sign-in with the provider/i),
-    ).toBeAttached()
+    ).toBeVisible()
     await expect(page).toHaveURL(/\/auth\/callback\/google/)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #889 — the `AuthCallbackPage` OAuth error card collapsed to ~16px wide, making the sign-in-failure UI effectively invisible in the preview/production build.

## Root cause

The error card used Tailwind's `max-w-md` utility. In **Tailwind CSS 4**, `max-w-*` utilities resolve from the `--container-*` theme namespace — but the design system (`@noorinalabs/design-system/styles.css`) defines **no `--container-*` namespace** in its `@theme` block. It only defines `--spacing-*`, including `--spacing-md: var(--spacing-4)` (1rem). With no `--container-md` available, Tailwind 4 resolves `max-w-md` against `--spacing-md`, so the compiled CSS is:

```css
.max-w-md { max-width: var(--spacing-md) }   /* = 1rem = 16px */
```

Combined with `w-full` (`width: 100%`), the card was capped at 16px wide. That is why PR #885's e2e error test had to use `toBeAttached` instead of `toBeVisible` — the element was in the DOM but had no visible box.

## Fix

`frontend/src/pages/AuthCallbackPage.tsx`:
- Replace the `max-w-md` utility with an inline `style={{ maxWidth: '28rem' }}` (28rem is the value `max-w-md` is *supposed* to be). The card no longer depends on a theme namespace the design system doesn't provide.
- Add `p-4` to the outer flex container so the now-full-width card has breathing room on narrow viewports.

`frontend/tests/e2e/auth.spec.ts`:
- Revert the error test's `toBeAttached` back to `toBeVisible`. That was only ever a workaround for this bug; `toBeVisible` is the correct assertion now that the card actually renders at a real width.

## Scope note

This is an isnad-graph-side fix scoped to the one affected component. The deeper gap — the design system shipping no `--container-*` namespace — is a design-system concern; if other consumers hit `max-w-*` collapse, that warrants a separate DS issue. This PR does not widen scope into the DS.

## Test results

- `npm run build` (tsc + Vite) — clean.
- `npx eslint` on changed files — 0 errors (1 pre-existing `set-state-in-effect` warning on the unchanged `setError` line, not introduced here).
- `npx playwright test auth.spec.ts` against the `vite preview` build — **9/9 pass**, including the error test now asserting `toBeVisible`. This is the direct proof the card renders at a real width.

Closes #889
