### PR TITLE
test: parallels coverage + expanded timeline endpoint tests (#796)

### DIFF
--- a/tests/test_api/test_parallels.py
+++ b/tests/test_api/test_parallels.py
@@ -1,0 +1,160 @@
+"""Tests for parallel hadith endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+SAMPLE_PAIR = {
+    "a_id": "had-001",
+    "a_corpus": "sunnah",
+    "b_id": "had-002",
+    "b_corpus": "shia",
+    "similarity_score": 0.91,
+    "variant_type": "wording",
+    "cross_sect": True,
+}
+
+SAMPLE_PARALLEL = {
+    "id": "had-002",
+    "matn_ar": "نص مشابه",
+    "matn_en": "a parallel narration",
+    "source_corpus": "shia",
+    "grade": "sahih",
+    "similarity_score": 0.91,
+    "variant_type": "wording",
+    "cross_sect": True,
+}
+
+
+def test_list_parallels_empty(client: TestClient) -> None:
+    """GET /api/v1/parallels returns an empty page when no parallel pairs exist."""
+    resp = client.get("/api/v1/parallels")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+    assert body["page"] == 1
+
+
+def test_list_parallels_returns_pairs(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/parallels returns parallel pairs with similarity metadata."""
+    mock_neo4j.execute_read.side_effect = [
+        # count query
+        [{"total": 1}],
+        # data query
+        [SAMPLE_PAIR],
+    ]
+    resp = client.get("/api/v1/parallels")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["hadith_a_id"] == "had-001"
+    assert item["hadith_b_id"] == "had-002"
+    assert item["similarity_score"] == 0.91
+    assert item["cross_sect"] is True
+
+
+def test_list_parallels_total_reflects_full_count(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """total comes from a dedicated COUNT query, not the page-limited item list."""
+    mock_neo4j.execute_read.side_effect = [
+        # count query over the full set
+        [{"total": 175}],
+        # page-limited data query
+        [SAMPLE_PAIR],
+    ]
+    resp = client.get("/api/v1/parallels?limit=1")
+    assert resp.status_code == 200
+    body = resp.json()
+    # total is the true count, not len(items) which is capped at limit
+    assert body["total"] == 175
+    assert len(body["items"]) == 1
+
+    count_query = mock_neo4j.execute_read.call_args_list[0][0][0]
+    assert "count(r)" in count_query
+
+
+def test_list_parallels_pagination_skip(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """page/limit translate into the expected SKIP value on the data query."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 100}],
+        [SAMPLE_PAIR],
+    ]
+    resp = client.get("/api/v1/parallels?page=3&limit=20")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["page"] == 3
+    assert body["limit"] == 20
+
+    data_params = mock_neo4j.execute_read.call_args_list[1][0][1]
+    assert data_params["skip"] == 40
+    assert data_params["limit"] == 20
+
+
+def test_list_parallels_rejects_invalid_limit(client: TestClient) -> None:
+    """GET /api/v1/parallels?limit=0 is rejected by the ge=1 bound."""
+    resp = client.get("/api/v1/parallels?limit=0")
+    assert resp.status_code == 422
+
+
+def test_get_parallels_for_hadith(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/parallels/{hadith_id} returns parallels for an existing hadith."""
+    mock_neo4j.execute_read.side_effect = [
+        # existence check
+        [{"id": "had-001"}],
+        # parallels data query
+        [SAMPLE_PARALLEL],
+    ]
+    resp = client.get("/api/v1/parallels/had-001")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["hadith_id"] == "had-001"
+    assert body["total"] == 1
+    assert len(body["parallels"]) == 1
+    assert body["parallels"][0]["id"] == "had-002"
+    assert body["parallels"][0]["similarity_score"] == 0.91
+
+
+def test_get_parallels_missing_hadith_404(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/parallels/{hadith_id} returns 404 when the hadith does not exist."""
+    # existence check returns no rows
+    mock_neo4j.execute_read.side_effect = [[]]
+    resp = client.get("/api/v1/parallels/had-missing")
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+def test_get_parallels_empty_for_existing_hadith(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """An existing hadith with no PARALLEL_OF edges returns an empty parallels list."""
+    mock_neo4j.execute_read.side_effect = [
+        # existence check passes
+        [{"id": "had-001"}],
+        # no parallels
+        [],
+    ]
+    resp = client.get("/api/v1/parallels/had-001")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["hadith_id"] == "had-001"
+    assert body["parallels"] == []
+    assert body["total"] == 0
+
+
+def test_get_parallels_pagination_skip(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """page/limit translate into the expected SKIP on the per-hadith parallels query."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"id": "had-001"}],
+        [SAMPLE_PARALLEL],
+    ]
+    resp = client.get("/api/v1/parallels/had-001?page=2&limit=5")
+    assert resp.status_code == 200
+
+    data_params = mock_neo4j.execute_read.call_args_list[1][0][1]
+    assert data_params["id"] == "had-001"
+    assert data_params["skip"] == 5
+    assert data_params["limit"] == 5

--- a/tests/test_api/test_timeline.py
+++ b/tests/test_api/test_timeline.py
@@ -64,6 +64,48 @@ def test_timeline_count_respects_year_filter(client: TestClient, mock_neo4j: Mag
     assert count_params["end_year"] == 10
 
 
+def test_timeline_data_query_respects_year_filter(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """The data query receives the same start/end year filter as the count query."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 1}],
+        [SAMPLE_EVENT],
+    ]
+    resp = client.get("/api/v1/timeline?start_year=1&end_year=10")
+    assert resp.status_code == 200
+
+    data_params = mock_neo4j.execute_read.call_args_list[1][0][1]
+    assert data_params["start_year"] == 1
+    assert data_params["end_year"] == 10
+
+
+def test_timeline_pagination_skip(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """page/limit translate into the expected SKIP value on the data query."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 50}],
+        [SAMPLE_EVENT],
+    ]
+    resp = client.get("/api/v1/timeline?page=4&limit=10")
+    assert resp.status_code == 200
+
+    data_params = mock_neo4j.execute_read.call_args_list[1][0][1]
+    assert data_params["skip"] == 30
+    assert data_params["limit"] == 10
+
+
+def test_timeline_rejects_invalid_page(client: TestClient) -> None:
+    """GET /api/v1/timeline?page=0 is rejected by the ge=1 bound."""
+    resp = client.get("/api/v1/timeline?page=0")
+    assert resp.status_code == 422
+
+
+def test_timeline_rejects_limit_over_max(client: TestClient) -> None:
+    """GET /api/v1/timeline?limit=501 is rejected by the le=500 bound."""
+    resp = client.get("/api/v1/timeline?limit=501")
+    assert resp.status_code == 422
+
+
 def test_timeline_range(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/timeline/range returns min/max year from events."""
     mock_neo4j.execute_read.side_effect = [
@@ -73,4 +115,16 @@ def test_timeline_range(client: TestClient, mock_neo4j: MagicMock) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["min_year_ah"] == 1
+    assert body["max_year_ah"] == 300
+
+
+def test_timeline_range_falls_back_when_empty(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/timeline/range returns the 0..300 default when no events exist."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"min_year": None, "max_year": None}],
+    ]
+    resp = client.get("/api/v1/timeline/range")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["min_year_ah"] == 0
     assert body["max_year_ah"] == 300


### PR DESCRIPTION
## Summary

Adds missing test coverage for API endpoints flagged in #796. **Scope note:** the issue listed three modules, but two had drifted since it was filed:

- **Parallels** — genuinely zero coverage. New `tests/test_api/test_parallels.py` with 9 tests.
- **Timeline** — `tests/test_api/test_timeline.py` already existed (4 tests, covering the #792 count-vs-len bug). Expanded with +5 tests for the still-uncovered cases the issue suggested.
- **Profile** — `src/api/routes/profile.py` no longer exists. It was removed as dead code by #887 ("remove dead profile route", merged) — profile data is served by user-service. No profile test file added; nothing to cover here.

## Changes

**`test_parallels.py` (new, 9 tests)**
- `GET /parallels`: empty page, returns pairs with similarity metadata, `total` from dedicated COUNT (not page-length), pagination SKIP math, `limit=0` → 422
- `GET /parallels/{hadith_id}`: returns parallels for existing hadith, 404 for missing hadith, empty list for existing hadith with no edges, pagination SKIP math

**`test_timeline.py` (+5 tests)**
- Data query receives the same year filter as the count query
- Pagination SKIP math
- `page=0` → 422, `limit=501` → 422 (query-bound rejection)
- `/timeline/range` empty fallback returns the `0..300` default

## Test plan

- [x] `pytest tests/test_api/test_parallels.py tests/test_api/test_timeline.py` — 18 passed
- [x] `ruff check` + `ruff format --check` on both files — clean
- [x] Full backend unit suite — 511 passed (no regressions)

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)
