### PR TITLE
test(frontend): add hook, API client, and page test coverage (#798)

### DIFF
--- a/frontend/src/api/__tests__/admin-client.test.ts
+++ b/frontend/src/api/__tests__/admin-client.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import {
+  fetchAdminUsers,
+  updateAdminUser,
+  fetchSystemHealth,
+  fetchDashboardStats,
+  bulkUserAction,
+  getUsersExportUrl,
+} from "../admin-client"
+
+// admin-client funnels every request through `fetchAdminJson`, which has
+// distinct branches for 401 (emit + throw), 403 (throw, no emit), other
+// non-OK (throw), plus auth-header injection and `credentials: include`.
+// We mock the session-expired emitter and `fetch` to cover each branch.
+vi.mock("../../hooks/useAuth", () => ({
+  emitSessionExpired: vi.fn(),
+}))
+
+import { emitSessionExpired } from "../../hooks/useAuth"
+
+const mockEmit = emitSessionExpired as ReturnType<typeof vi.fn>
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("admin-client — fetchAdminJson behavior", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    localStorage.clear()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns the parsed body on 200", async () => {
+    const payload = { items: [], total: 0, page: 1, limit: 20 }
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, payload))
+
+    await expect(fetchAdminUsers()).resolves.toEqual(payload)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("attaches the bearer token and credentials:include on every request", async () => {
+    localStorage.setItem("access_token", "admin-token")
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { active_sessions: 3 }))
+
+    await fetchDashboardStats()
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect((init as RequestInit).credentials).toBe("include")
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer admin-token",
+    })
+  })
+
+  it("omits the Authorization header when no token is stored", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, {}))
+
+    await fetchSystemHealth()
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect((init as RequestInit).headers).not.toHaveProperty("Authorization")
+  })
+
+  it("emits sessionExpired and throws on 401", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(401, { detail: "unauthorized" }))
+
+    await expect(fetchAdminUsers()).rejects.toThrow(/admin access required/)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws on 403 WITHOUT emitting sessionExpired (forbidden != expired)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(403, { detail: "forbidden" }))
+
+    await expect(fetchSystemHealth()).rejects.toThrow(/admin access required/)
+    // 403 means "you're authed but not allowed" — re-auth wouldn't help, so
+    // the session-expired modal must NOT fire.
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("throws a status-bearing error on other non-OK responses (500)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(500, { detail: "boom" }))
+
+    await expect(fetchDashboardStats()).rejects.toThrow(/500/)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("forwards method, JSON body, and merges Content-Type with auth headers on mutations", async () => {
+    localStorage.setItem("access_token", "admin-token")
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { id: "u1" }))
+
+    await updateAdminUser("u1", { is_suspended: true })
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("/api/v1/admin/users/u1")
+    const ri = init as RequestInit
+    expect(ri.method).toBe("PATCH")
+    expect(ri.body).toBe(JSON.stringify({ is_suspended: true }))
+    expect(ri.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer admin-token",
+    })
+  })
+
+  it("encodes path params to guard against id-injection in the URL", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { id: "weird id" }))
+
+    await updateAdminUser("weird id/../x", { is_suspended: false })
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain(encodeURIComponent("weird id/../x"))
+    expect(url).not.toContain("weird id/../x")
+  })
+
+  it("sends a POST with the user-id list for bulk actions", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { affected: 2, action: "suspend" }),
+    )
+
+    const res = await bulkUserAction(["a", "b"], "suspend")
+
+    expect(res).toEqual({ affected: 2, action: "suspend" })
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("/api/v1/admin/users/bulk")
+    expect((init as RequestInit).method).toBe("POST")
+    expect((init as RequestInit).body).toBe(
+      JSON.stringify({ user_ids: ["a", "b"], action: "suspend", role: undefined }),
+    )
+  })
+})
+
+describe("admin-client — getUsersExportUrl (pure URL builder)", () => {
+  it("returns the bare export path when no filters are given", () => {
+    expect(getUsersExportUrl()).toBe("/api/v1/admin/users/export/csv")
+  })
+
+  it("appends search and role as query params when provided", () => {
+    const url = getUsersExportUrl("jane", "admin")
+    expect(url).toContain("/api/v1/admin/users/export/csv?")
+    expect(url).toContain("search=jane")
+    expect(url).toContain("role=admin")
+  })
+
+  it("omits empty filters from the query string", () => {
+    const url = getUsersExportUrl(undefined, "editor")
+    expect(url).toContain("role=editor")
+    expect(url).not.toContain("search=")
+  })
+})

--- a/frontend/src/api/__tests__/client.error-paths.test.ts
+++ b/frontend/src/api/__tests__/client.error-paths.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import {
+  fetchNarrator,
+  fetchNarrators,
+  searchAll,
+  updateModerationItem,
+  flagContent,
+} from "../client"
+
+// The existing client.test.ts covers fetchSubscriptionOrNull's allowStatuses
+// branch. This file covers the rest of `client.ts`: the default (no-opts)
+// fetchJson path that always throws on non-OK + emits on 401, the
+// auth-header/credentials wiring, query-string construction, and the two
+// hand-rolled mutation helpers (updateModerationItem, flagContent) which
+// have their own non-OK guards separate from fetchJson.
+vi.mock("../../hooks/useAuth", () => ({
+  emitSessionExpired: vi.fn(),
+}))
+
+import { emitSessionExpired } from "../../hooks/useAuth"
+
+const mockEmit = emitSessionExpired as ReturnType<typeof vi.fn>
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("client — fetchJson default path (no allowStatuses)", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    localStorage.clear()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns the parsed body on 200", async () => {
+    const narrator = { id: "n1", name_ar: "فلان" }
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, narrator))
+
+    await expect(fetchNarrator("n1")).resolves.toEqual(narrator)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("sends credentials:include and the bearer token when present", async () => {
+    localStorage.setItem("access_token", "tok")
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { id: "n1" }))
+
+    await fetchNarrator("n1")
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect((init as RequestInit).credentials).toBe("include")
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer tok" })
+  })
+
+  it("throws a status-bearing error on 404 (no allowStatuses -> not swallowed)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(404, { detail: "missing" }))
+
+    await expect(fetchNarrator("nope")).rejects.toThrow(/404/)
+    // 404 is not 401 — no session-expired side effect.
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("emits sessionExpired and throws on 401", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(401, { detail: "expired" }))
+
+    await expect(fetchNarrators()).rejects.toThrow(/401/)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws on 500", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(500))
+
+    await expect(fetchNarrators()).rejects.toThrow(/500/)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("encodes path params (guards against id-injection in the URL)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { id: "x" }))
+
+    await fetchNarrator("ibn/../malik")
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain(encodeURIComponent("ibn/../malik"))
+    expect(url).not.toContain("ibn/../malik")
+  })
+
+  it("builds pagination + search query params for list endpoints", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { items: [], total: 0, page: 2, limit: 5 }),
+    )
+
+    await fetchNarrators(2, 5, "malik")
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("page=2")
+    expect(url).toContain("limit=5")
+    // Free-text search is passed as `q`.
+    expect(url).toContain("q=malik")
+  })
+
+  it("omits the search param when no search term is given", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { items: [], total: 0, page: 1, limit: 20 }),
+    )
+
+    await fetchNarrators()
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).not.toContain("q=")
+  })
+
+  it("URL-encodes search queries with reserved characters", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { results: [] }))
+
+    await searchAll("ibn & sons")
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    // URLSearchParams encodes spaces (+) and ampersands (%26) so they don't
+    // leak into the query structure.
+    expect(url).toContain("q=ibn+%26+sons")
+  })
+})
+
+describe("client — updateModerationItem (hand-rolled mutation guard)", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    localStorage.clear()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("PATCHes with a JSON body and returns the parsed item on success", async () => {
+    localStorage.setItem("access_token", "tok")
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { id: "m1", status: "approved" }),
+    )
+
+    const res = await updateModerationItem("m1", "approved", "looks fine")
+
+    expect(res).toEqual({ id: "m1", status: "approved" })
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("/api/v1/admin/moderation/m1")
+    const ri = init as RequestInit
+    expect(ri.method).toBe("PATCH")
+    expect(ri.body).toBe(JSON.stringify({ status: "approved", notes: "looks fine" }))
+    expect(ri.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer tok",
+    })
+  })
+
+  it("omits notes from the body when not provided", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, { id: "m1" }))
+
+    await updateModerationItem("m1", "rejected")
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect((init as RequestInit).body).toBe(JSON.stringify({ status: "rejected" }))
+  })
+
+  it("throws a status-bearing error on a non-OK response", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(500, { detail: "boom" }))
+
+    await expect(updateModerationItem("m1", "approved")).rejects.toThrow(/500/)
+  })
+})
+
+describe("client — flagContent (hand-rolled mutation guard)", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("POSTs the entity descriptor and returns the created item", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { id: "m9", status: "pending" }),
+    )
+
+    const res = await flagContent("hadith", "bukhari:1", "mismatched grade")
+
+    expect(res).toEqual({ id: "m9", status: "pending" })
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("/api/v1/admin/moderation/flag")
+    const ri = init as RequestInit
+    expect(ri.method).toBe("POST")
+    expect(ri.body).toBe(
+      JSON.stringify({
+        entity_type: "hadith",
+        entity_id: "bukhari:1",
+        reason: "mismatched grade",
+      }),
+    )
+  })
+
+  it("throws a status-bearing error on a non-OK response", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(403, { detail: "forbidden" }))
+
+    await expect(
+      flagContent("hadith", "bukhari:1", "reason"),
+    ).rejects.toThrow(/403/)
+  })
+})

--- a/frontend/src/api/__tests__/profile-client.test.ts
+++ b/frontend/src/api/__tests__/profile-client.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import {
+  fetchProfile,
+  updateProfile,
+  fetchSessions,
+  revokeSession,
+} from "../profile-client"
+
+// profile-client has two non-OK guards: the shared `fetchProfileJson`
+// (401 -> emit + throw, other -> throw) and a hand-rolled equivalent inside
+// `revokeSession` (which returns void, not JSON). Both must emit on 401.
+vi.mock("../../hooks/useAuth", () => ({
+  emitSessionExpired: vi.fn(),
+}))
+
+import { emitSessionExpired } from "../../hooks/useAuth"
+
+const mockEmit = emitSessionExpired as ReturnType<typeof vi.fn>
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  // 204/304 are null-body statuses — the Response constructor rejects a body
+  // for them. Everything else carries the JSON payload.
+  const nullBody = status === 204 || status === 304
+  return new Response(nullBody ? null : JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const PROFILE = {
+  id: "u1",
+  email: "jane@example.com",
+  display_name: "Jane Smith",
+  email_verified: true,
+  avatar_url: null,
+  locale: null,
+  is_active: true,
+  created_at: "2026-04-20T00:00:00Z",
+  roles: ["viewer"],
+}
+
+describe("profile-client — fetchProfileJson behavior", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    localStorage.clear()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns the parsed profile on 200", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, PROFILE))
+
+    await expect(fetchProfile()).resolves.toEqual(PROFILE)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("attaches the bearer token from localStorage", async () => {
+    localStorage.setItem("access_token", "profile-token")
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(200, PROFILE))
+
+    await fetchProfile()
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("/api/v1/users/me")
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer profile-token",
+    })
+  })
+
+  it("emits sessionExpired and throws Unauthorized on 401", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(401, { detail: "nope" }))
+
+    await expect(fetchProfile()).rejects.toThrow(/Unauthorized/)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws a status-bearing error on other non-OK responses without emitting", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(500, { detail: "boom" }))
+
+    await expect(fetchProfile()).rejects.toThrow(/500/)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("updateProfile sends a PATCH with the JSON body and merged headers", async () => {
+    localStorage.setItem("access_token", "profile-token")
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { ...PROFILE, display_name: "Jane R." }),
+    )
+
+    const res = await updateProfile({ display_name: "Jane R." })
+
+    expect(res.display_name).toBe("Jane R.")
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    const ri = init as RequestInit
+    expect(ri.method).toBe("PATCH")
+    expect(ri.body).toBe(JSON.stringify({ display_name: "Jane R." }))
+    expect(ri.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer profile-token",
+    })
+  })
+
+  it("fetchSessions unwraps the `sessions` array from the list response", async () => {
+    const sessions = [
+      { id: "s1", is_current: true },
+      { id: "s2", is_current: false },
+    ]
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(200, { sessions, count: 2 }),
+    )
+
+    await expect(fetchSessions()).resolves.toEqual(sessions)
+  })
+})
+
+describe("profile-client — revokeSession (void return, own non-OK guard)", () => {
+  beforeEach(() => {
+    mockEmit.mockReset()
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("resolves without a value on a successful DELETE", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(204))
+
+    await expect(revokeSession("s1")).resolves.toBeUndefined()
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain("/api/v1/sessions/s1")
+    expect((init as RequestInit).method).toBe("DELETE")
+  })
+
+  it("encodes the session id in the path", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(204))
+
+    await revokeSession("weird/id")
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(url).toContain(encodeURIComponent("weird/id"))
+  })
+
+  it("emits sessionExpired and throws on 401", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(401, { detail: "nope" }))
+
+    await expect(revokeSession("s1")).rejects.toThrow(/Unauthorized/)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws a status-bearing error on other non-OK responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(500))
+
+    await expect(revokeSession("s1")).rejects.toThrow(/500/)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/__tests__/useAuth.behavior.test.tsx
+++ b/frontend/src/hooks/__tests__/useAuth.behavior.test.tsx
@@ -1,0 +1,345 @@
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { ReactNode } from "react"
+
+import {
+  AuthProvider,
+  useAuth,
+  emitSessionExpired,
+  SESSION_EXPIRED_EVENT,
+} from "../useAuth"
+import type { AuthUser } from "../useAuth"
+
+// AuthProvider drives real `fetch` (no API-client indirection), reads/writes
+// localStorage + sessionStorage, and navigates via `window.location.href`.
+// These tests stub all three so the provider's auth state machine can be
+// exercised in jsdom without a backend.
+
+function makeUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: "6cf04f80-ede7-42e6-9756-43f8ce8f220d",
+    email: "jane@example.com",
+    display_name: "Jane Smith",
+    avatar_url: null,
+    email_verified: true,
+    is_active: true,
+    locale: null,
+    created_at: "2026-04-20T03:09:36.076621Z",
+    roles: [],
+    ...overrides,
+  }
+}
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  // 204/304 are null-body statuses — the Response constructor rejects a body
+  // for them. Everything else carries the JSON payload.
+  const nullBody = status === 204 || status === 304
+  return new Response(nullBody ? null : JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>
+}
+
+/** Last entry of an array (Array.prototype.at isn't in the configured lib). */
+function last<T>(arr: T[]): T {
+  return arr[arr.length - 1]!
+}
+
+/** Render the provider and wait out the initial `loadUser` effect. */
+async function renderAuth() {
+  const view = renderHook(() => useAuth(), { wrapper })
+  await waitFor(() => expect(view.result.current.loading).toBe(false))
+  return view
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+let locationHref: string
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+
+  fetchMock = vi.fn()
+  vi.stubGlobal("fetch", fetchMock)
+
+  // `window.location.href = ...` is the provider's navigation primitive.
+  // Replace location with a plain object so assignment is observable and
+  // jsdom doesn't attempt a real (unimplemented) navigation.
+  locationHref = "http://localhost/app"
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      get href() {
+        return locationHref
+      },
+      set href(v: string) {
+        locationHref = v
+      },
+      pathname: "/app",
+      search: "",
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("useAuth — context guard", () => {
+  it("throws when used outside an AuthProvider", () => {
+    // Suppress React's error-boundary console noise for this expected throw.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    expect(() => renderHook(() => useAuth())).toThrow(
+      /must be used within an AuthProvider/,
+    )
+    spy.mockRestore()
+  })
+})
+
+describe("AuthProvider — initial load", () => {
+  it("stays unauthenticated and does not call /me when no token is stored", async () => {
+    const { result } = await renderAuth()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.user).toBeNull()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("loads the user from /users/me when a valid token is present", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+
+    const { result } = await renderAuth()
+
+    expect(result.current.user?.email).toBe("jane@example.com")
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toContain("/api/v1/users/me")
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer valid-token",
+    })
+  })
+
+  it("refreshes the access token on a 401 and retries /me with the new token", async () => {
+    localStorage.setItem("access_token", "stale-token")
+    // 1) /me -> 401, 2) /auth/token/refresh -> 200 new token, 3) /me retry -> 200
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "expired" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "fresh-token" }))
+      .mockResolvedValueOnce(jsonResponse(200, makeUser({ email: "after@refresh.com" })))
+
+    const { result } = await renderAuth()
+
+    expect(result.current.user?.email).toBe("after@refresh.com")
+    // The refreshed token is persisted for subsequent requests.
+    expect(localStorage.getItem("access_token")).toBe("fresh-token")
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    const refreshCall = fetchMock.mock.calls[1]!
+    expect(refreshCall[0]).toContain("/auth/token/refresh")
+    expect((refreshCall[1] as RequestInit).method).toBe("POST")
+  })
+
+  it("clears auth when the token is expired and the refresh also fails", async () => {
+    localStorage.setItem("access_token", "stale-token")
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "expired" }))
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "refresh rejected" }))
+
+    const { result } = await renderAuth()
+
+    expect(result.current.user).toBeNull()
+    expect(localStorage.getItem("access_token")).toBeNull()
+  })
+})
+
+describe("AuthProvider — role derivation", () => {
+  it("exposes isAdmin/role/hasRole derived from the loaded user's roles", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, makeUser({ roles: ["editor", "admin"] })),
+    )
+
+    const { result } = await renderAuth()
+
+    expect(result.current.isAdmin).toBe(true)
+    expect(result.current.role).toBe("admin")
+    expect(result.current.hasRole("moderator")).toBe(true)
+  })
+
+  it("defaults an unauthenticated session to the viewer role", async () => {
+    const { result } = await renderAuth()
+
+    expect(result.current.isAdmin).toBe(false)
+    expect(result.current.role).toBe("viewer")
+    expect(result.current.hasRole("editor")).toBe(false)
+  })
+})
+
+describe("AuthProvider — session-expired event", () => {
+  it("flips sessionExpired when the event fires for an authenticated user", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    expect(result.current.sessionExpired).toBe(false)
+    act(() => emitSessionExpired())
+    await waitFor(() => expect(result.current.sessionExpired).toBe(true))
+  })
+
+  it("ignores the event when no user was ever authenticated", async () => {
+    const { result } = await renderAuth()
+
+    act(() => {
+      window.dispatchEvent(new Event(SESSION_EXPIRED_EVENT))
+    })
+    // No previously-authenticated user -> no re-auth modal.
+    expect(result.current.sessionExpired).toBe(false)
+  })
+
+  it("dismissSessionExpired stores the return URL, clears auth, and routes to /login", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    act(() => result.current.dismissSessionExpired())
+
+    expect(sessionStorage.getItem("oauth_return_url")).toBe("/app")
+    expect(localStorage.getItem("access_token")).toBeNull()
+    expect(result.current.user).toBeNull()
+    expect(locationHref).toBe("/login")
+  })
+})
+
+describe("AuthProvider — sign-out flows", () => {
+  it("signOut revokes the current session, clears auth, and routes to /login", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    // initial /me
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    // signOut: GET /sessions -> list, DELETE /sessions/{current}
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          sessions: [
+            { id: "sess-1", is_current: false },
+            { id: "sess-2", is_current: true },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(204))
+
+    await act(async () => {
+      await result.current.signOut()
+    })
+
+    const deleteCall = last(fetchMock.mock.calls)
+    expect(deleteCall[0]).toContain("/api/v1/sessions/sess-2")
+    expect((deleteCall[1] as RequestInit).method).toBe("DELETE")
+    expect(localStorage.getItem("access_token")).toBeNull()
+    expect(result.current.user).toBeNull()
+    expect(locationHref).toBe("/login")
+  })
+
+  it("signOut still clears local auth when the revoke request throws", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    // Network failure mid-revoke must not strand the user in a signed-in UI.
+    fetchMock.mockRejectedValueOnce(new Error("network down"))
+
+    await act(async () => {
+      await result.current.signOut()
+    })
+
+    expect(localStorage.getItem("access_token")).toBeNull()
+    expect(result.current.user).toBeNull()
+    expect(locationHref).toBe("/login")
+  })
+
+  it("signOutAll issues a DELETE against the sessions collection", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(204))
+
+    await act(async () => {
+      await result.current.signOutAll()
+    })
+
+    const call = last(fetchMock.mock.calls)
+    expect(call[0]).toContain("/api/v1/sessions")
+    expect((call[1] as RequestInit).method).toBe("DELETE")
+    expect(result.current.user).toBeNull()
+    expect(locationHref).toBe("/login")
+  })
+})
+
+describe("AuthProvider — refreshUser", () => {
+  it("re-fetches /me and updates the user on success", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, makeUser({ display_name: "Jane R. Smith" })),
+    )
+
+    await act(async () => {
+      await result.current.refreshUser()
+    })
+
+    expect(result.current.user?.display_name).toBe("Jane R. Smith")
+  })
+
+  it("is a no-op when no token is stored", async () => {
+    const { result } = await renderAuth()
+    fetchMock.mockClear()
+
+    await act(async () => {
+      await result.current.refreshUser()
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("leaves the existing user intact when the background refresh errors", async () => {
+    localStorage.setItem("access_token", "valid-token")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, makeUser()))
+    const { result } = await renderAuth()
+
+    fetchMock.mockRejectedValueOnce(new Error("network blip"))
+
+    await act(async () => {
+      await result.current.refreshUser()
+    })
+
+    // Background refresh failures are swallowed — the stale-but-valid user stays.
+    expect(result.current.user?.email).toBe("jane@example.com")
+  })
+})
+
+describe("AuthProvider — new-user onboarding flag", () => {
+  it("picks up the is_new_user sessionStorage flag and consumes it", async () => {
+    sessionStorage.setItem("is_new_user", "1")
+
+    const { result } = await renderAuth()
+
+    expect(result.current.isNewUser).toBe(true)
+    // The flag is one-shot — cleared so a reload doesn't re-trigger onboarding.
+    expect(sessionStorage.getItem("is_new_user")).toBeNull()
+  })
+
+  it("dismissOnboarding clears the isNewUser state", async () => {
+    sessionStorage.setItem("is_new_user", "1")
+    const { result } = await renderAuth()
+
+    act(() => result.current.dismissOnboarding())
+    expect(result.current.isNewUser).toBe(false)
+  })
+})

--- a/frontend/src/hooks/__tests__/useTheme.test.ts
+++ b/frontend/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,157 @@
+import { renderHook, act } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { useTheme } from "../useTheme"
+
+const STORAGE_KEY = "isnad-graph-theme"
+
+// jsdom does not implement matchMedia. We install a controllable stub so the
+// tests can drive the `(prefers-color-scheme: dark)` query and fire `change`
+// events at the hook's listener.
+type MQListener = (e: MediaQueryListEvent) => void
+
+function installMatchMedia(initialDark: boolean) {
+  let matches = initialDark
+  const listeners = new Set<MQListener>()
+
+  const mql = {
+    get matches() {
+      return matches
+    },
+    media: "(prefers-color-scheme: dark)",
+    addEventListener: (_: string, cb: MQListener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: MQListener) => listeners.delete(cb),
+  }
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mql),
+  )
+
+  return {
+    /** Flip the system preference and notify subscribers, as a real OS would. */
+    setSystemDark(next: boolean) {
+      matches = next
+      for (const cb of listeners) {
+        cb({ matches } as MediaQueryListEvent)
+      }
+    },
+    get listenerCount() {
+      return listeners.size
+    },
+  }
+}
+
+function dataTheme(): string | null {
+  return document.documentElement.getAttribute("data-theme")
+}
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute("data-theme")
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("defaults to 'system' when nothing is stored, resolving to the OS preference", () => {
+    installMatchMedia(true)
+
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe("system")
+    expect(result.current.resolvedTheme).toBe("dark")
+    // Mount effect applies the resolved theme to the document element.
+    expect(dataTheme()).toBe("dark")
+  })
+
+  it("hydrates an explicit stored theme over the system default", () => {
+    installMatchMedia(true)
+    localStorage.setItem(STORAGE_KEY, "light")
+
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe("light")
+    // Explicit 'light' wins even though the OS prefers dark.
+    expect(result.current.resolvedTheme).toBe("light")
+    expect(dataTheme()).toBe("light")
+  })
+
+  it("ignores a corrupt stored value and falls back to 'system'", () => {
+    installMatchMedia(false)
+    localStorage.setItem(STORAGE_KEY, "neon-banana")
+
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe("system")
+  })
+
+  it("setTheme persists the choice and applies it to the document", () => {
+    installMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    act(() => result.current.setTheme("dark"))
+
+    expect(result.current.theme).toBe("dark")
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark")
+    expect(dataTheme()).toBe("dark")
+  })
+
+  it("toggle flips light <-> dark for explicit themes", () => {
+    installMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    act(() => result.current.setTheme("light"))
+    act(() => result.current.toggle())
+    expect(result.current.theme).toBe("dark")
+
+    act(() => result.current.toggle())
+    expect(result.current.theme).toBe("light")
+  })
+
+  it("toggle from 'system' resolves against the OS preference and lands on the opposite explicit theme", () => {
+    // OS prefers dark -> toggling from 'system' should go to 'light'.
+    installMatchMedia(true)
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe("system")
+    act(() => result.current.toggle())
+    expect(result.current.theme).toBe("light")
+  })
+
+  it("re-applies the resolved theme when the OS preference changes while on 'system'", () => {
+    const mm = installMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.resolvedTheme).toBe("light")
+    expect(dataTheme()).toBe("light")
+
+    // OS flips to dark — the 'system' listener should re-apply.
+    act(() => mm.setSystemDark(true))
+    expect(dataTheme()).toBe("dark")
+  })
+
+  it("does not subscribe to OS changes when an explicit theme is selected", () => {
+    const mm = installMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    act(() => result.current.setTheme("light"))
+    // Explicit theme -> the effect's cleanup removed the 'system' listener.
+    expect(mm.listenerCount).toBe(0)
+
+    // An OS flip must not move an explicitly-pinned theme.
+    act(() => mm.setSystemDark(true))
+    expect(dataTheme()).toBe("light")
+  })
+
+  it("removes its OS-change listener on unmount", () => {
+    const mm = installMatchMedia(false)
+    const { unmount } = renderHook(() => useTheme())
+
+    expect(mm.listenerCount).toBe(1)
+    unmount()
+    expect(mm.listenerCount).toBe(0)
+  })
+})

--- a/frontend/src/pages/__tests__/NarratorDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/NarratorDetailPage.test.tsx
@@ -1,0 +1,206 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+
+import NarratorDetailPage from "../NarratorDetailPage"
+import type { Narrator, NarratorChainsResponse } from "../../types/api"
+
+// NarratorDetailPage fans out three useQuery calls (narrator / chains /
+// network) keyed off the :id route param. We mock the api/client module and
+// drive the page through its loading -> error / not-found / loaded states,
+// plus the client-side hadith pagination.
+vi.mock("../../api/client", () => ({
+  fetchNarrator: vi.fn(),
+  fetchNarratorChains: vi.fn(),
+  fetchGraphNetwork: vi.fn(),
+}))
+
+import {
+  fetchNarrator,
+  fetchNarratorChains,
+  fetchGraphNetwork,
+} from "../../api/client"
+
+const mockFetchNarrator = fetchNarrator as ReturnType<typeof vi.fn>
+const mockFetchChains = fetchNarratorChains as ReturnType<typeof vi.fn>
+const mockFetchNetwork = fetchGraphNetwork as ReturnType<typeof vi.fn>
+
+function makeNarrator(overrides: Partial<Narrator> = {}): Narrator {
+  return {
+    id: "malik",
+    name_ar: "مالك بن أنس",
+    name_en: "Malik ibn Anas",
+    kunya: "Abu Abdullah",
+    nisba: "al-Asbahi",
+    laqab: null,
+    birth_year_ah: 93,
+    death_year_ah: 179,
+    generation: "Tabi al-Tabiin",
+    gender: "male",
+    sect_affiliation: "Sunni",
+    trustworthiness_consensus: "Thiqah",
+    aliases: [],
+    betweenness_centrality: 0.1234,
+    in_degree: 12,
+    out_degree: 8,
+    pagerank: 0.0456,
+    community_id: 3,
+    ...overrides,
+  }
+}
+
+function makeChains(count: number): NarratorChainsResponse {
+  return {
+    narrator_id: "malik",
+    total: count,
+    chains: Array.from({ length: count }, (_, i) => ({
+      chain_id: `c${i}`,
+      hadith_id: `h${i}`,
+      matn_ar: `متن ${i}`,
+      matn_en: `matn ${i}`,
+      grade: i % 2 === 0 ? "Sahih" : null,
+    })),
+  }
+}
+
+const NETWORK = {
+  narrator_id: "malik",
+  nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+  edges: [],
+  teachers: 12,
+  students: 8,
+}
+
+function renderPage(id = "malik") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/narrators/${id}`]}>
+        <Routes>
+          <Route path="/narrators/:id" element={<NarratorDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("NarratorDetailPage", () => {
+  beforeEach(() => {
+    mockFetchNarrator.mockReset()
+    mockFetchChains.mockReset()
+    mockFetchNetwork.mockReset()
+  })
+
+  it("renders the narrator profile once the primary query resolves", async () => {
+    mockFetchNarrator.mockResolvedValue(makeNarrator())
+    mockFetchChains.mockResolvedValue(makeChains(0))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("مالك بن أنس")).toBeInTheDocument()
+    })
+    // English name, profile metadata, and reliability aggregate all render.
+    expect(screen.getAllByText("Malik ibn Anas").length).toBeGreaterThan(0)
+    expect(screen.getByText("Abu Abdullah")).toBeInTheDocument()
+    expect(screen.getByText(/Aggregate: Thiqah/)).toBeInTheDocument()
+  })
+
+  it("passes the route :id param through to the data fetchers", async () => {
+    mockFetchNarrator.mockResolvedValue(makeNarrator({ id: "shafii" }))
+    mockFetchChains.mockResolvedValue(makeChains(0))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage("shafii")
+
+    await waitFor(() => expect(mockFetchNarrator).toHaveBeenCalledWith("shafii"))
+    expect(mockFetchChains).toHaveBeenCalledWith("shafii")
+    expect(mockFetchNetwork).toHaveBeenCalledWith("shafii", 1)
+  })
+
+  it("surfaces an error message when the primary query rejects", async () => {
+    mockFetchNarrator.mockRejectedValue(new Error("upstream exploded"))
+    mockFetchChains.mockResolvedValue(makeChains(0))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error: upstream exploded/)).toBeInTheDocument()
+    })
+  })
+
+  it("shows a not-found message when the narrator query resolves to null", async () => {
+    // The API client is typed non-null, but a null body is a real runtime
+    // possibility the page explicitly guards against.
+    mockFetchNarrator.mockResolvedValue(null)
+    mockFetchChains.mockResolvedValue(makeChains(0))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Narrator not found.")).toBeInTheDocument()
+    })
+  })
+
+  it("renders the network preview stats from the network query", async () => {
+    mockFetchNarrator.mockResolvedValue(makeNarrator())
+    mockFetchChains.mockResolvedValue(makeChains(0))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("3 nodes in ego-graph")).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Teachers: 12 \| Students: 8/)).toBeInTheDocument()
+  })
+
+  it("does not render the hadith list when the narrator has no chains", async () => {
+    mockFetchNarrator.mockResolvedValue(makeNarrator())
+    mockFetchChains.mockResolvedValue(makeChains(0))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("مالك بن أنس")).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/Hadith Narrated/)).not.toBeInTheDocument()
+  })
+
+  it("paginates the hadith list client-side at 10 per page", async () => {
+    mockFetchNarrator.mockResolvedValue(makeNarrator())
+    // 12 chains -> 2 pages (10 per page).
+    mockFetchChains.mockResolvedValue(makeChains(12))
+    mockFetchNetwork.mockResolvedValue(NETWORK)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Hadith Narrated (12 total)")).toBeInTheDocument()
+    })
+
+    // Page 1: first 10 hadiths present, 11th not yet.
+    expect(screen.getByText("Hadith h0")).toBeInTheDocument()
+    expect(screen.getByText("Hadith h9")).toBeInTheDocument()
+    expect(screen.queryByText("Hadith h10")).not.toBeInTheDocument()
+    expect(screen.getByText("1 of 2")).toBeInTheDocument()
+
+    // Advance to page 2 — the remaining 2 hadiths show, the first 10 don't.
+    await userEvent.click(screen.getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Hadith h10")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Hadith h11")).toBeInTheDocument()
+    expect(screen.queryByText("Hadith h0")).not.toBeInTheDocument()
+    expect(screen.getByText("2 of 2")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #798. Frontend test coverage was limited to ~8 UI component rendering tests plus narrow pure-function tests for `useAuth`/`client`. This PR adds **70 behavioral tests** across the highest-value untested surfaces. Test-only — no application code changed.

## What's covered

**Hooks**
- `useTheme` (`useTheme.test.ts`, 9 tests) — localStorage hydration, corrupt-value fallback to `system`, `toggle` for explicit + system themes, OS-preference (`matchMedia`) change re-application, and listener cleanup on unmount. `matchMedia` is stubbed since jsdom does not implement it.
- `useAuth` / `AuthProvider` (`useAuth.behavior.test.tsx`, 18 tests) — the hook itself, not just the pure `deriveHighestRole` helper already covered in `useAuth.test.ts`. Initial `/me` load, **401 → token-refresh → retry**, refresh-failure clears auth, role derivation (`isAdmin`/`role`/`hasRole`), `SESSION_EXPIRED_EVENT` handling, `signOut`/`signOutAll`/`dismissSessionExpired` (including: a network failure mid-revoke still clears local auth), `refreshUser`, and the new-user onboarding flag.

**API clients**
- `admin-client.ts` (12 tests) — `fetchAdminJson` branches: 401 emits `sessionExpired` + throws, **403 throws without emitting** (forbidden != expired), 500 throws; auth-header + `credentials: include` wiring, path-param encoding, mutation body/headers, `getUsersExportUrl` builder.
- `profile-client.ts` (10 tests) — `fetchProfileJson` error paths plus `revokeSession`'s separate hand-rolled void-return guard.
- `client.ts` (`client.error-paths.test.ts`, 14 tests) — the default `fetchJson` path (always throws on non-OK, emits on 401), query-string construction, URL-encoding of reserved chars, and the hand-rolled `updateModerationItem` / `flagContent` mutation guards. Complements the existing `client.test.ts` which only covered `fetchSubscriptionOrNull`'s `allowStatuses` branch.

**Page**
- `NarratorDetailPage` (7 tests) — loading / error / not-found / loaded states, route `:id` param threading into all three `useQuery` fetchers, network preview stats, and client-side hadith pagination (10/page).

## Scope note

Per the issue's priority order, this lands items 1-3 (hooks, API clients) plus one meaningful page test. **Explicit remaining follow-up scope for #798:**
- Additional page tests — `GraphExplorerPage` (D3 — needs canvas/force-graph mocking), `HadithDetailPage`, admin `DashboardPage`.
- Playwright E2E golden paths (login, search, graph exploration) — infra exists, no test files.

These are larger surfaces (D3/canvas mocking, full E2E harness) better done as a focused follow-up than bolted onto this PR. Recommend a tracking issue if #798 is closed here, or keep #798 open for the E2E portion.

## Test plan

- [x] `npx vitest run` — full frontend suite: **132 passed** (21 files), 70 new
- [x] `npm run lint` — 0 errors (11 pre-existing warnings, none in new files)
- [x] `npx tsc --noEmit` — passes
- [ ] CI green on PR
