### PR TITLE
refactor: consolidate duplicated test fixtures across admin test files

### DIFF
--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -1,15 +1,35 @@
-"""API test fixtures."""
+"""API test fixtures.
+
+Shared fixtures for all ``tests/test_api`` modules. Admin test files
+(``test_admin*.py``) previously each defined their own copies of the
+settings-cache shim, ``mock_neo4j``, and the admin/noauth/regular app+client
+fixtures; those now live here so the admin suite shares a single source.
+
+Note: ``_test_settings()`` builds ``AuthSettings()`` with its class defaults and
+deliberately does *not* set ``user_service_url`` / ``user_service_jwks_cache_ttl``.
+That distinction is intentional — ``tests/test_auth/conftest.py`` keeps a
+separate settings fixture that *does* populate the auth fields, and the two
+must not be merged.
+"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from src.api.auth import User
-from src.api.middleware import require_auth
+from src.api.middleware import require_admin, require_auth
+from src.config import (
+    AuthSettings,
+    Neo4jSettings,
+    PostgresSettings,
+    RedisSettings,
+    Settings,
+    get_settings,
+)
 
 
 def _fake_user() -> User:
@@ -18,6 +38,50 @@ def _fake_user() -> User:
         email="test@example.com",
         name="Test User",
     )
+
+
+def _admin_user() -> User:
+    return User(
+        id="admin-user",
+        email="admin@example.com",
+        name="Admin User",
+        is_admin=True,
+    )
+
+
+def _regular_user() -> User:
+    return User(
+        id="regular-user",
+        email="user@example.com",
+        name="Regular User",
+        is_admin=False,
+    )
+
+
+def _test_settings() -> Settings:
+    """Build a Settings instance without reading .env.
+
+    Uses ``AuthSettings()`` defaults — see the module docstring for why the
+    auth fields are intentionally left unset.
+    """
+    return Settings(
+        _env_file=None,
+        neo4j=Neo4jSettings(uri="bolt://localhost:7687", user="neo4j", password="test"),
+        postgres=PostgresSettings(dsn="postgresql://test:test@localhost:5432/test"),
+        redis=RedisSettings(url="redis://localhost:6379/0"),
+        auth=AuthSettings(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch get_settings to avoid .env parsing errors in tests."""
+    test_settings = _test_settings()
+    get_settings.cache_clear()
+
+    import src.config
+
+    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
 
 
 @pytest.fixture
@@ -44,3 +108,57 @@ def app(mock_neo4j: MagicMock) -> FastAPI:
 def client(app: FastAPI) -> TestClient:
     """Test client."""
     return TestClient(app)
+
+
+# --- Admin app/client fixtures (shared across test_admin*.py) ---
+
+
+@pytest.fixture
+def admin_app(mock_neo4j: MagicMock) -> FastAPI:
+    """FastAPI app with admin auth override."""
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+    app.dependency_overrides[require_admin] = _admin_user
+    return app
+
+
+@pytest.fixture
+def admin_client(admin_app: FastAPI) -> TestClient:
+    return TestClient(admin_app)
+
+
+@pytest.fixture
+def noauth_app(mock_neo4j: MagicMock) -> FastAPI:
+    """FastAPI app with NO auth overrides — tests 401 paths."""
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+    return app
+
+
+@pytest.fixture
+def noauth_client(noauth_app: FastAPI) -> TestClient:
+    return TestClient(noauth_app)
+
+
+@pytest.fixture
+def regular_app(mock_neo4j: MagicMock) -> FastAPI:
+    """FastAPI app with non-admin user override for require_admin — tests 403 paths."""
+    from src.api.app import create_app
+
+    app = create_app()
+    app.state.neo4j = mock_neo4j
+
+    def _raise_forbidden() -> User:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    app.dependency_overrides[require_admin] = _raise_forbidden
+    return app
+
+
+@pytest.fixture
+def regular_client(regular_app: FastAPI) -> TestClient:
+    return TestClient(regular_app)

--- a/tests/test_api/test_admin.py
+++ b/tests/test_api/test_admin.py
@@ -1,4 +1,11 @@
-"""Tests for admin API endpoints."""
+"""Tests for admin API endpoints.
+
+Shared fixtures (``mock_neo4j``, ``admin_app``/``admin_client``,
+``noauth_app``/``noauth_client``, ``regular_app``/``regular_client``, the
+``_clear_settings_cache`` autouse shim) and the ``_admin_user`` /
+``_regular_user`` / ``_test_settings`` helpers live in
+``tests/test_api/conftest.py``.
+"""
 
 from __future__ import annotations
 
@@ -7,119 +14,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from src.api.auth import User
-from src.api.middleware import require_admin
-from src.config import (
-    AuthSettings,
-    Neo4jSettings,
-    PostgresSettings,
-    RedisSettings,
-    Settings,
-    get_settings,
-)
-
-
-def _admin_user() -> User:
-    return User(
-        id="admin-user",
-        email="admin@example.com",
-        name="Admin User",
-        is_admin=True,
-    )
-
-
-def _regular_user() -> User:
-    return User(
-        id="regular-user",
-        email="user@example.com",
-        name="Regular User",
-        is_admin=False,
-    )
-
-
-def _test_settings() -> Settings:
-    """Build a Settings instance without reading .env."""
-    return Settings(
-        _env_file=None,
-        neo4j=Neo4jSettings(uri="bolt://localhost:7687", user="neo4j", password="test"),
-        postgres=PostgresSettings(dsn="postgresql://test:test@localhost:5432/test"),
-        redis=RedisSettings(url="redis://localhost:6379/0"),
-        auth=AuthSettings(),
-    )
-
-
-@pytest.fixture(autouse=True)
-def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch get_settings to avoid .env parsing errors in tests."""
-    test_settings = _test_settings()
-    get_settings.cache_clear()
-
-    import src.config
-
-    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
-
-
-@pytest.fixture
-def mock_neo4j() -> MagicMock:
-    client = MagicMock()
-    client.execute_read.return_value = []
-    client.execute_write.return_value = []
-    return client
-
-
-@pytest.fixture
-def admin_app(mock_neo4j: MagicMock) -> FastAPI:
-    """FastAPI app with admin auth override."""
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-    app.dependency_overrides[require_admin] = _admin_user
-    return app
-
-
-@pytest.fixture
-def admin_client(admin_app: FastAPI) -> TestClient:
-    return TestClient(admin_app)
-
-
-@pytest.fixture
-def noauth_app(mock_neo4j: MagicMock) -> FastAPI:
-    """FastAPI app with NO auth overrides — tests 401/403 paths."""
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-    return app
-
-
-@pytest.fixture
-def noauth_client(noauth_app: FastAPI) -> TestClient:
-    return TestClient(noauth_app)
-
-
-@pytest.fixture
-def regular_app(mock_neo4j: MagicMock) -> FastAPI:
-    """FastAPI app with non-admin user override for require_admin."""
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-
-    from fastapi import HTTPException
-
-    def _raise_forbidden() -> User:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
-    app.dependency_overrides[require_admin] = _raise_forbidden
-    return app
-
-
-@pytest.fixture
-def regular_client(regular_app: FastAPI) -> TestClient:
-    return TestClient(regular_app)
-
 
 # --- Health endpoints ---
 

--- a/tests/test_api/test_admin_auth.py
+++ b/tests/test_api/test_admin_auth.py
@@ -1,72 +1,13 @@
-"""Tests for admin auth enforcement across all admin endpoints."""
+"""Tests for admin auth enforcement across all admin endpoints.
+
+The ``noauth_client`` / ``regular_client`` fixtures and the
+``_clear_settings_cache`` autouse shim live in ``tests/test_api/conftest.py``.
+"""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
-from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-
-from src.api.auth import User
-from src.api.middleware import require_admin
-from tests.test_api.test_admin import _test_settings
-
-
-@pytest.fixture(autouse=True)
-def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    test_settings = _test_settings()
-    from src.config import get_settings
-
-    get_settings.cache_clear()
-
-    import src.config
-
-    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
-
-
-@pytest.fixture
-def mock_neo4j() -> MagicMock:
-    client = MagicMock()
-    client.execute_read.return_value = []
-    client.execute_write.return_value = []
-    return client
-
-
-@pytest.fixture
-def noauth_app(mock_neo4j: MagicMock) -> FastAPI:
-    """App with no auth overrides — all admin endpoints should return 401."""
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-    return app
-
-
-@pytest.fixture
-def noauth_client(noauth_app: FastAPI) -> TestClient:
-    return TestClient(noauth_app)
-
-
-@pytest.fixture
-def regular_app(mock_neo4j: MagicMock) -> FastAPI:
-    """App with non-admin user — all admin endpoints should return 403."""
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-
-    def _raise_forbidden() -> User:
-        raise HTTPException(status_code=403, detail="Admin access required")
-
-    app.dependency_overrides[require_admin] = _raise_forbidden
-    return app
-
-
-@pytest.fixture
-def regular_client(regular_app: FastAPI) -> TestClient:
-    return TestClient(regular_app)
-
 
 # All admin GET endpoints that should be protected
 ADMIN_GET_ENDPOINTS = [

--- a/tests/test_api/test_admin_config.py
+++ b/tests/test_api/test_admin_config.py
@@ -1,4 +1,11 @@
-"""Tests for admin config endpoints."""
+"""Tests for admin config endpoints.
+
+Shared fixtures (``mock_neo4j``, ``admin_app``/``admin_client``,
+``noauth_client``, ``regular_client``, the ``_clear_settings_cache`` autouse
+shim) live in ``tests/test_api/conftest.py``. The ``get_pg`` dependency
+override with a local ``mock_pg`` is specific to the config endpoints and
+stays here.
+"""
 
 from __future__ import annotations
 
@@ -8,30 +15,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src.api.auth import User
-from src.api.middleware import require_admin
-from tests.test_api.test_admin import _admin_user, _test_settings
-
-
-@pytest.fixture(autouse=True)
-def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    test_settings = _test_settings()
-    from src.config import get_settings
-
-    get_settings.cache_clear()
-
-    import src.config
-
-    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
-
-
-@pytest.fixture
-def mock_neo4j() -> MagicMock:
-    client = MagicMock()
-    client.execute_read.return_value = []
-    client.execute_write.return_value = []
-    return client
-
 
 @pytest.fixture
 def mock_pg() -> MagicMock:
@@ -40,21 +23,12 @@ def mock_pg() -> MagicMock:
     return pg
 
 
-@pytest.fixture
-def admin_app(mock_neo4j: MagicMock, mock_pg: MagicMock) -> FastAPI:
-    from src.api.app import create_app
+@pytest.fixture(autouse=True)
+def _override_get_pg(admin_app: FastAPI, mock_pg: MagicMock) -> None:
+    """Override the get_pg dependency on the shared admin_app with mock_pg."""
     from src.api.deps import get_pg
 
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-    app.dependency_overrides[require_admin] = _admin_user
-    app.dependency_overrides[get_pg] = lambda: mock_pg
-    return app
-
-
-@pytest.fixture
-def admin_client(admin_app: FastAPI) -> TestClient:
-    return TestClient(admin_app)
+    admin_app.dependency_overrides[get_pg] = lambda: mock_pg
 
 
 class TestGetConfig:
@@ -204,37 +178,6 @@ class TestConfigAudit:
 
 
 class TestConfigAuthEnforcement:
-    @pytest.fixture
-    def noauth_app(self, mock_neo4j: MagicMock) -> FastAPI:
-        from src.api.app import create_app
-
-        app = create_app()
-        app.state.neo4j = mock_neo4j
-        return app
-
-    @pytest.fixture
-    def noauth_client(self, noauth_app: FastAPI) -> TestClient:
-        return TestClient(noauth_app)
-
-    @pytest.fixture
-    def regular_app(self, mock_neo4j: MagicMock) -> FastAPI:
-        from fastapi import HTTPException
-
-        from src.api.app import create_app
-
-        app = create_app()
-        app.state.neo4j = mock_neo4j
-
-        def _raise_forbidden() -> User:
-            raise HTTPException(status_code=403, detail="Admin access required")
-
-        app.dependency_overrides[require_admin] = _raise_forbidden
-        return app
-
-    @pytest.fixture
-    def regular_client(self, regular_app: FastAPI) -> TestClient:
-        return TestClient(regular_app)
-
     def test_get_config_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.get("/api/v1/admin/config")
         assert resp.status_code == 401

--- a/tests/test_api/test_admin_moderation.py
+++ b/tests/test_api/test_admin_moderation.py
@@ -1,54 +1,16 @@
-"""Tests for admin moderation endpoints."""
+"""Tests for admin moderation endpoints.
+
+Shared fixtures (``mock_neo4j``, ``admin_client``, ``noauth_client``,
+``regular_client``, the ``_clear_settings_cache`` autouse shim) live in
+``tests/test_api/conftest.py``.
+"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from src.api.auth import User
-from src.api.middleware import require_admin
-from tests.test_api.test_admin import (
-    _admin_user,
-    _test_settings,
-)
-
-
-@pytest.fixture(autouse=True)
-def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    test_settings = _test_settings()
-    from src.config import get_settings
-
-    get_settings.cache_clear()
-
-    import src.config
-
-    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
-
-
-@pytest.fixture
-def mock_neo4j() -> MagicMock:
-    client = MagicMock()
-    client.execute_read.return_value = []
-    client.execute_write.return_value = []
-    return client
-
-
-@pytest.fixture
-def admin_app(mock_neo4j: MagicMock) -> FastAPI:
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-    app.dependency_overrides[require_admin] = _admin_user
-    return app
-
-
-@pytest.fixture
-def admin_client(admin_app: FastAPI) -> TestClient:
-    return TestClient(admin_app)
 
 
 @pytest.fixture
@@ -232,37 +194,6 @@ class TestFlagContent:
 
 
 class TestModerationAuthEnforcement:
-    @pytest.fixture
-    def noauth_app(self, mock_neo4j: MagicMock) -> FastAPI:
-        from src.api.app import create_app
-
-        app = create_app()
-        app.state.neo4j = mock_neo4j
-        return app
-
-    @pytest.fixture
-    def noauth_client(self, noauth_app: FastAPI) -> TestClient:
-        return TestClient(noauth_app)
-
-    @pytest.fixture
-    def regular_app(self, mock_neo4j: MagicMock) -> FastAPI:
-        from fastapi import HTTPException
-
-        from src.api.app import create_app
-
-        app = create_app()
-        app.state.neo4j = mock_neo4j
-
-        def _raise_forbidden() -> User:
-            raise HTTPException(status_code=403, detail="Admin access required")
-
-        app.dependency_overrides[require_admin] = _raise_forbidden
-        return app
-
-    @pytest.fixture
-    def regular_client(self, regular_app: FastAPI) -> TestClient:
-        return TestClient(regular_app)
-
     def test_list_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.get("/api/v1/admin/moderation")
         assert resp.status_code == 401

--- a/tests/test_api/test_admin_reports.py
+++ b/tests/test_api/test_admin_reports.py
@@ -1,51 +1,15 @@
-"""Tests for admin reports endpoint."""
+"""Tests for admin reports endpoint.
+
+Shared fixtures (``mock_neo4j``, ``admin_client``, ``noauth_client``,
+``regular_client``, the ``_clear_settings_cache`` autouse shim) live in
+``tests/test_api/conftest.py``.
+"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from src.api.auth import User
-from src.api.middleware import require_admin
-from tests.test_api.test_admin import _admin_user, _test_settings
-
-
-@pytest.fixture(autouse=True)
-def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    test_settings = _test_settings()
-    from src.config import get_settings
-
-    get_settings.cache_clear()
-
-    import src.config
-
-    monkeypatch.setattr(src.config, "get_settings", lambda: test_settings)
-
-
-@pytest.fixture
-def mock_neo4j() -> MagicMock:
-    client = MagicMock()
-    client.execute_read.return_value = []
-    client.execute_write.return_value = []
-    return client
-
-
-@pytest.fixture
-def admin_app(mock_neo4j: MagicMock) -> FastAPI:
-    from src.api.app import create_app
-
-    app = create_app()
-    app.state.neo4j = mock_neo4j
-    app.dependency_overrides[require_admin] = _admin_user
-    return app
-
-
-@pytest.fixture
-def admin_client(admin_app: FastAPI) -> TestClient:
-    return TestClient(admin_app)
 
 
 class TestSystemReports:
@@ -117,37 +81,6 @@ class TestSystemReports:
 
 
 class TestReportsAuthEnforcement:
-    @pytest.fixture
-    def noauth_app(self, mock_neo4j: MagicMock) -> FastAPI:
-        from src.api.app import create_app
-
-        app = create_app()
-        app.state.neo4j = mock_neo4j
-        return app
-
-    @pytest.fixture
-    def noauth_client(self, noauth_app: FastAPI) -> TestClient:
-        return TestClient(noauth_app)
-
-    @pytest.fixture
-    def regular_app(self, mock_neo4j: MagicMock) -> FastAPI:
-        from fastapi import HTTPException
-
-        from src.api.app import create_app
-
-        app = create_app()
-        app.state.neo4j = mock_neo4j
-
-        def _raise_forbidden() -> User:
-            raise HTTPException(status_code=403, detail="Admin access required")
-
-        app.dependency_overrides[require_admin] = _raise_forbidden
-        return app
-
-    @pytest.fixture
-    def regular_client(self, regular_app: FastAPI) -> TestClient:
-        return TestClient(regular_app)
-
     def test_reports_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.get("/api/v1/admin/reports")
         assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Consolidates the duplicated test-fixture setup across the five admin test modules into `tests/test_api/conftest.py`, per #795.

Before this change, `test_admin.py`, `test_admin_auth.py`, `test_admin_config.py`, `test_admin_moderation.py`, and `test_admin_reports.py` each carried their own copies of:
- the `_clear_settings_cache` autouse settings shim
- `mock_neo4j`
- the `admin_app`/`admin_client`, `noauth_app`/`noauth_client`, `regular_app`/`regular_client` fixtures

…and the four non-`test_admin` files imported `_admin_user` / `_test_settings` directly from `test_admin.py`, coupling the modules together.

## Changes

- Moved the shared fixtures + the `_admin_user` / `_regular_user` / `_test_settings` helpers into `tests/test_api/conftest.py` (pytest auto-discovers them for every module in the package).
- Removed the now-redundant definitions from all five admin test files; dropped the cross-file imports from `test_admin.py`.
- `test_admin_config.py` keeps a local `mock_pg` fixture + a `get_pg` override — that is specific to the config endpoints and not shared.
- **Intentionally NOT touched:** `tests/test_auth/conftest.py`. Its settings fixture deliberately populates `user_service_url` / `user_service_jwks_cache_ttl`, whereas `_test_settings()` uses `AuthSettings()` defaults. Per the issue caveat, that distinction is preserved — the two settings fixtures are not merged.

Net: 6 files, +158 / -398.

## Test plan

- [x] `pytest tests/test_api/ tests/test_auth/` — 221 passed (identical count to pre-change baseline; no test added or removed)
- [x] Full backend unit suite — 512 passed, 0 failures (the 55 errors are all in `tests/e2e/` + `tests/integration/`, which need Docker/Playwright and are unrelated to this change)
- [x] `ruff check` — clean on all 6 files
- [x] `ruff format --check` — all 6 files already formatted
- [x] `mypy` — no issues in all 6 files

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
