### PR TITLE
tech-debt(frontend): consume published @noorinalabs/design-system from GH Packages registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,46 +84,17 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
-        with:
-          repository: noorinalabs/noorinalabs-design-system
-          # Pin to v0.0.1 — the version isnad-graph's frontend/package-lock.json
-          # is locked to. Checking out `main` would build whatever the
-          # design-system has shipped most recently (currently 0.0.2), whose
-          # transitive deps may diverge from the lockfile and break npm install
-          # (e.g. @radix-ui/react-dropdown-menu was added between 0.0.1 and 0.0.2).
-          # Bump this ref together with the lockfile when accepting a new
-          # design-system version. Or, see #810 to remove this whole dance.
-          ref: v0.0.1
-          path: noorinalabs-design-system
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Build and pack design-system dependency
-        working-directory: noorinalabs-design-system
-        # frontend/package-lock.json pins @noorinalabs/design-system to
-        # `file:../../noorinalabs-design-system-0.0.1.tgz`. From `frontend/`,
-        # that resolves to `${{ github.workspace }}/..` (the parent of the
-        # checkout root, e.g. /home/runner/work/<repo>/). The design-system
-        # is checked out at the matching `v0.0.1` tag in the step above, so
-        # `npm pack` produces exactly that filename. See #810 for the proper
-        # migration to a published npm package.
-        run: |
-          npm install
-          npm run build
-          npm pack --pack-destination "${{ github.workspace }}/.."
-      - name: Fix design-system lockfile integrity
-        run: |
-          node -e "
-            const fs = require('fs');
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-            const pkg = lock.packages['node_modules/@noorinalabs/design-system'];
-            if (pkg) { delete pkg.integrity; }
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
-      - run: npm install
+          registry-url: https://npm.pkg.github.com
+          scope: "@noorinalabs"
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
       - run: npx eslint src/
       - run: npx tsc --noEmit
       - run: npx vitest run
@@ -193,46 +164,17 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
-        with:
-          repository: noorinalabs/noorinalabs-design-system
-          # Pin to v0.0.1 — the version isnad-graph's frontend/package-lock.json
-          # is locked to. Checking out `main` would build whatever the
-          # design-system has shipped most recently (currently 0.0.2), whose
-          # transitive deps may diverge from the lockfile and break npm install
-          # (e.g. @radix-ui/react-dropdown-menu was added between 0.0.1 and 0.0.2).
-          # Bump this ref together with the lockfile when accepting a new
-          # design-system version. Or, see #810 to remove this whole dance.
-          ref: v0.0.1
-          path: noorinalabs-design-system
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Build and pack design-system dependency
-        working-directory: noorinalabs-design-system
-        # frontend/package-lock.json pins @noorinalabs/design-system to
-        # `file:../../noorinalabs-design-system-0.0.1.tgz`. From `frontend/`,
-        # that resolves to `${{ github.workspace }}/..` (the parent of the
-        # checkout root, e.g. /home/runner/work/<repo>/). The design-system
-        # is checked out at the matching `v0.0.1` tag in the step above, so
-        # `npm pack` produces exactly that filename. See #810 for the proper
-        # migration to a published npm package.
-        run: |
-          npm install
-          npm run build
-          npm pack --pack-destination "${{ github.workspace }}/.."
-      - name: Fix design-system lockfile integrity
-        run: |
-          node -e "
-            const fs = require('fs');
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-            const pkg = lock.packages['node_modules/@noorinalabs/design-system'];
-            if (pkg) { delete pkg.integrity; }
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
-      - run: npm install
+          registry-url: https://npm.pkg.github.com
+          scope: "@noorinalabs"
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
       - run: npx playwright install --with-deps chromium
       - run: npm run build
       - name: Start preview server

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -15,12 +15,10 @@
 # workflow dispatched noorinalabs-deploy on every push-to-main without waiting
 # for publish. See isnad-graph#817 and main#145.
 #
-# The frontend build needs the design-system tarball staged into the frontend
-# build context. We check out noorinalabs-design-system @ v0.0.1, run
-# `npm ci && npm run build && npm pack`, and move the .tgz into ./frontend/
-# before docker/build-push-action runs. The frontend Dockerfile's
-# `COPY noorinalabs-design-system-0.0.1.tgz /` step (fixed in #820) expects
-# the tarball at the root of its build context.
+# The frontend build resolves @noorinalabs/design-system from the GitHub
+# Packages npm registry (isnad-graph#810). The frontend Dockerfile runs
+# `npm ci` against that registry, so the GH Packages read token is passed
+# into the Docker build as a build secret (npmrc).
 
 name: Publish to GHCR
 
@@ -42,10 +40,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  # Pinned to the version frontend/package-lock.json references. When the
-  # frontend bumps to 0.0.2 (isnad-graph#818), update this AND the
-  # Dockerfile's COPY line and the package-lock together.
-  DESIGN_SYSTEM_REF: v0.0.1
 
 jobs:
   build-and-push:
@@ -74,60 +68,17 @@ jobs:
       - name: Checkout (isnad-graph)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Frontend only: stage the design-system tarball into the build context
-      # so the Dockerfile's `COPY noorinalabs-design-system-0.0.1.tgz /` works.
-      # GITHUB_TOKEN works cross-repo because both repos are in the same org.
-      - name: Checkout design-system (frontend only)
+      # Frontend only: build an .npmrc carrying the GH Packages read token so
+      # the Dockerfile's `npm ci` can resolve @noorinalabs/design-system from
+      # the registry (isnad-graph#810). Passed into the Docker build as a
+      # secret file — never baked into an image layer.
+      - name: Write npm auth for design-system registry (frontend only)
         if: matrix.component == 'frontend'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: noorinalabs/noorinalabs-design-system
-          ref: ${{ env.DESIGN_SYSTEM_REF }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: design-system-src
-
-      - name: Build and pack design-system (frontend only)
-        if: matrix.component == 'frontend'
-        working-directory: design-system-src
-        # CRITICAL pattern from ci.yml@f5f413f (Marisol, 2026-04-06):
-        # v0.0.1's package.json declares `files: ["dist"]` with NO prepack /
-        # prepare hook, and `dist/` is not committed. A fresh clone packs an
-        # empty 172-byte tarball (just package.json metadata) unless we run
-        # the build first. We also MUST install ALL deps (no `--omit=dev`)
-        # because Vite (the builder) is a devDependency.
-        # Sequence: install ALL deps from lockfile → run build (populates dist/) → pack.
-        # `npm ci` (not `npm install`) is used to install exact locked versions
-        # from package-lock.json — reproducible release artifact, fails fast if
-        # lockfile and package.json drift (#823).
         run: |
-          npm ci
-          npm run build
-          npm pack
-          ls -lh ./*.tgz
-          mv ./noorinalabs-design-system-*.tgz ../frontend/
-
-      - name: Fix design-system lockfile integrity (frontend only)
-        if: matrix.component == 'frontend'
-        working-directory: frontend
-        # Pattern from ci.yml@615a692 (Marisol, 2026-04-06). The committed
-        # frontend/package-lock.json records the integrity hash of the v0.0.1
-        # tarball that was built and packed at release time. A freshly-packed
-        # tarball from source has a different hash (timestamps / filesystem
-        # ordering), which makes `npm ci` inside the Dockerfile fail with
-        # EINTEGRITY. Strip the integrity field from the lockfile entry;
-        # npm then trusts the resolved `file:` path without checksum.
-        # Because this rewrites the lockfile inside the frontend/ build
-        # context (before docker/build-push-action uploads the context),
-        # the Dockerfile's `COPY package.json package-lock.json ./` + `npm ci`
-        # see the patched lockfile and succeed.
-        run: |
-          node -e "
-            const fs = require('fs');
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-            const pkg = lock.packages['node_modules/@noorinalabs/design-system'];
-            if (pkg) { delete pkg.integrity; }
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
+          {
+            echo "@noorinalabs:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}"
+          } > "${{ runner.temp }}/ds-npmrc"
 
       - name: Set up QEMU (multi-arch)
         if: contains(matrix.platforms, 'arm64')
@@ -183,6 +134,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Frontend only: mount the GH Packages .npmrc as a build secret so
+          # the Dockerfile's `npm ci` resolves @noorinalabs/design-system from
+          # the registry without baking the token into a layer (#810).
+          secret-files: |
+            ${{ matrix.component == 'frontend' && format('npmrc={0}/ds-npmrc', runner.temp) || '' }}
           # Per-component cache scopes so api and frontend don't evict each
           # other's layers during parallel matrix builds.
           cache-from: type=gha,scope=${{ matrix.component }}

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,6 +1,1 @@
-# TODO: The @noorinalabs/design-system package is not yet published.
-# The publish workflow (noorinalabs-design-system/.github/workflows/publish.yml)
-# triggers on v* tags and publishes to npm (registry.npmjs.org).
-# Once published, remove this registry override — npm is the default registry.
-# If the org switches to GitHub Packages instead, uncomment the line below:
-# @noorinalabs:registry=https://npm.pkg.github.com
+@noorinalabs:registry=https://npm.pkg.github.com

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,15 @@
 FROM node:24-alpine AS build
 WORKDIR /app
-COPY package.json package-lock.json ./
-# package-lock.json references @noorinalabs/design-system via a file: path
-# pointing at /noorinalabs-design-system-0.0.1.tgz. The deploy script stages
-# this tarball into the build context root before docker build (see #818).
-# Long-term: switch to GHCR-published image (#817) or npm registry
-# (design-system#57) and drop this implicit-contract copy.
-COPY noorinalabs-design-system-0.0.1.tgz /
-RUN npm ci
+COPY package.json package-lock.json .npmrc ./
+# @noorinalabs/design-system resolves from the GitHub Packages npm registry
+# (see frontend/.npmrc and isnad-graph#810). The registry read token is
+# mounted as a build secret (id=npmrc) so it never lands in an image layer;
+# ghcr-publish.yml supplies it via secret-files. The committed .npmrc sets
+# the @noorinalabs registry; the secret only adds the _authToken line.
+RUN --mount=type=secret,id=npmrc,target=/run/secrets/npmrc \
+    cat /run/secrets/npmrc .npmrc > /tmp/npmrc-merged && \
+    npm ci --userconfig /tmp/npmrc-merged && \
+    rm -f /tmp/npmrc-merged
 # Cache-bust: ARG changes invalidate all subsequent layers
 ARG CACHEBUST=1
 COPY . .

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1300,8 +1300,8 @@
     },
     "node_modules/@noorinalabs/design-system": {
       "version": "0.0.1",
-      "resolved": "file:../../noorinalabs-design-system-0.0.1.tgz",
-      "integrity": "sha512-sLYwhCu1NAxsNHJkJXZBuEU034HS8z2D4bFjC1Am+UP7oKml3BoySkOdmfvW7p/kbf3znjHGYtEtbljtIjrkpQ==",
+      "resolved": "https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.1/fbcb44e1448a3028c5badde45c169a41e38f4ec0",
+      "integrity": "sha512-sKoQGQA6HkqqLNkfIasJWEyK+EUfFDPDIG97dKU2OrfoEMQDGHT+Fy90fTfCc8HY98+radkNh8B9sIK6urXOpw==",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",


### PR DESCRIPTION
## Summary

Migrates the frontend's `@noorinalabs/design-system` dependency from a local
`.tgz` file path to the **published `0.0.1` package on the GitHub Packages npm
registry**, eliminating the brittle "checkout design-system → npm pack → patch
lockfile integrity" workaround across CI and the Docker build.

Closes #810.

## Changes

- **`frontend/package-lock.json`** — `@noorinalabs/design-system` now resolves
  to `https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.1/...`
  (was `file:../../noorinalabs-design-system-0.0.1.tgz`). The `resolved` +
  `integrity` values are the registry-published 0.0.1 artifact's, transcribed
  from `noorinalabs-landing-page`'s lockfile history (it already consumes the
  same published package) and confirmed by a strict-integrity `npm ci` locally.
- **`frontend/.npmrc`** — activated the `@noorinalabs:registry=https://npm.pkg.github.com`
  mapping (was a TODO placeholder comment).
- **`.github/workflows/ci.yml`** — removed the design-system checkout +
  build-and-pack + lockfile-integrity-strip steps from both
  `frontend-lint-and-test` and `e2e`. They now `npm ci` the package straight
  from the registry, authed via `secrets.GH_PACKAGES_TOKEN` (same secret
  landing-page's CI uses), with `registry-url` + `scope` on `setup-node`.
- **`.github/workflows/ghcr-publish.yml`** — removed the frontend-only
  checkout/pack/integrity steps and the `DESIGN_SYSTEM_REF` env. The GH Packages
  `.npmrc` is now passed into the frontend Docker build as a `secret-files`
  build secret.
- **`frontend/Dockerfile`** — dropped `COPY noorinalabs-design-system-0.0.1.tgz /`.
  `npm ci` resolves from the registry using a `--mount=type=secret` npmrc, so
  the token never lands in an image layer.

## Version note

Stays on **`0.0.1`** — the only version ever published to the registry. `package.json`
already declared `^0.0.1`, so this is purely a *resolution-mechanism* change, not a
version bump. The `0.0.2`+ consumer bump is blocked separately on the design-system
publish pipeline (`design-system#81`) and tracked by `IG#840`.

## Impact on IG#822 (DS version dedup)

#822 targets three duplicated DS-version locations. This PR's effect on each:

| #822 location | Effect of this PR |
|---|---|
| `ghcr-publish.yml` `DESIGN_SYSTEM_REF: v0.0.1` | **Removed entirely.** The env var and the steps that consumed it are gone. |
| `frontend/Dockerfile` tgz `COPY` (`...0.0.1.tgz`) | **Removed entirely.** No version string in the Dockerfile anymore. |
| `frontend/package-lock.json` DS entry | **Restructured, not removed.** Still carries `version: 0.0.1` + the registry `resolved`/`integrity` — the normal lockfile shape for a registry dependency. |

Net: #822's remaining work collapses to keeping `frontend/package.json` (`^0.0.1`) and
the lockfile entry in sync — a single normal dependency, no cross-file version
duplication. The CI/Dockerfile copies #822 was created to dedupe no longer exist.

## Test plan

Verified locally (worktree, isnad-graph deps from npmjs.org + design-system
`0.0.1` content):

- [x] `npm ci` resolves `@noorinalabs/design-system@0.0.1` from `npm.pkg.github.com`
      and passes npm's strict integrity check against the new lockfile entry
      (observed before a cache-clean; confirms `resolved`/`integrity` are correct).
- [x] `npx eslint src/` — 0 errors (11 pre-existing warnings, unrelated).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 15 files, 62 tests, all pass.
- [x] `npm run build` — succeeds, produces `dist/`.
- [x] `actionlint` clean for both modified workflows (the 2 reported warnings
      are on pre-existing untouched lines).
- [x] `frontend/package-lock.json` passes the `lockfile-validation` CI gate
      (no `file:` local absolute paths).

**Could NOT verify locally:** a clean-room `npm ci` straight from GH Packages —
the local environment's token lacks the `read:packages` scope (GH Packages
returns 401 for anonymous reads). CI supplies `secrets.GH_PACKAGES_TOKEN` for
this; the resolution path is otherwise identical to landing-page's working CI.
Reviewers should confirm CI's `frontend-lint-and-test` / `e2e` / `ghcr-publish`
jobs go green, since the registry-auth path is the one piece not exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
