### PR TITLE
test(admin): remove redundant TestAdminAuthEnforcement class (#797)

### DIFF
--- a/tests/test_api/test_admin.py
+++ b/tests/test_api/test_admin.py
@@ -257,16 +257,3 @@ class TestAdminConfig:
         assert data["entries"][0]["key"] == "rate_limit_per_minute"
         assert data["entries"][0]["old_value"] == "60"
         assert data["entries"][0]["new_value"] == "120"
-
-
-# --- Auth enforcement ---
-
-
-class TestAdminAuthEnforcement:
-    def test_unauthenticated_returns_401(self, noauth_client: TestClient) -> None:
-        resp = noauth_client.get("/api/v1/admin/stats")
-        assert resp.status_code == 401
-
-    def test_non_admin_returns_403(self, regular_client: TestClient) -> None:
-        resp = regular_client.get("/api/v1/admin/stats")
-        assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Closes #797. Removes the `TestAdminAuthEnforcement` class from `tests/test_api/test_admin.py` — it was a strict subset of the parameterized coverage already in `test_admin_auth.py`, so it added runtime with no extra coverage.

## Why this is safe

`TestAdminAuthEnforcement` tested unauthenticated-401 and non-admin-403 for **one** endpoint (`/api/v1/admin/stats`). `test_admin_auth.py` already covers 401/403 for **all** admin endpoints:

- `TestAllEndpoints401.test_get_endpoints_401` — parameterized over `ADMIN_GET_ENDPOINTS`
- `TestAllEndpoints403.test_get_endpoints_403` — parameterized over `ADMIN_GET_ENDPOINTS`

`ADMIN_GET_ENDPOINTS` includes `/api/v1/admin/stats`, and both suites use the same conftest-provided `noauth_client` / `regular_client` fixtures. Verified against wave-10 HEAD before deleting:

```
tests/test_api/test_admin_auth.py::TestAllEndpoints401::test_get_endpoints_401[/api/v1/admin/stats]
tests/test_api/test_admin_auth.py::TestAllEndpoints403::test_get_endpoints_403[/api/v1/admin/stats]
```

So the `/admin/stats` 401/403 behavior is still exercised — just from the comprehensive parameterized suite instead of a duplicate single-endpoint class.

## Changes

- `tests/test_api/test_admin.py`: removed the `TestAdminAuthEnforcement` class and its now-orphaned `# --- Auth enforcement ---` section comment. 1 file, -13 lines.

## Test plan

- [x] Collection delta is exactly **-2** (235 → 233), same cwd before/after — only the two `TestAdminAuthEnforcement::test_*` tests; no other test added or removed
- [x] `ENVIRONMENT=test uv run pytest tests/test_api/ tests/test_auth/` — **233 passed**
- [x] `ruff check tests/test_api/test_admin.py` — clean
- [x] `ruff format --check tests/test_api/test_admin.py` — already formatted
- [x] `mypy tests/test_api/test_admin.py` — no issues
- [ ] CI green on PR
