### PR TITLE
refactor: replace inline test data with shared row factories

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,135 @@
+"""Factory helpers for Neo4j-result-shaped test dictionaries.
+
+The API tests mock ``Neo4jClient.execute_read`` and assert on the JSON the
+route builds from those rows. Each route reads a specific *shape* of row, so
+these factories are grouped by the shape the consuming route expects — not by
+domain entity. A single ``make_narrator_*`` is deliberately split into three
+because the ``/narrators`` list row, the ``/graph/.../network`` node row, and
+the ``/search`` hit row are genuinely different dictionaries (different keys,
+e.g. ``generation`` vs ``gen``); collapsing them would force tests to assert
+against a shape their route never actually produces.
+
+Every factory takes ``**overrides`` so a test can pin the one or two fields it
+cares about while the rest stay at sensible defaults. Each call returns a
+fresh dict, so tests can mutate the result without bleeding into siblings.
+
+These complement — they do not replace — the ``sample_narrator`` /
+``sample_hadith`` fixtures in ``conftest.py``, which return frozen Pydantic
+*model* instances for the model-layer tests. The API tests need raw dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_narrator_row(**overrides: Any) -> dict[str, Any]:
+    """A NARRATOR node's ``props`` as read by the ``/narrators`` list/detail routes.
+
+    Wrap in ``{"props": make_narrator_row()}`` to match the Cypher output the
+    route iterates.
+    """
+    return {
+        "id": "nar-001",
+        "name_ar": "أبو هريرة",
+        "name_en": "Abu Hurayra",
+        "generation": "companion",
+        "gender": "male",
+        "sect_affiliation": "sunni",
+        "trustworthiness_consensus": "thiqah",
+        **overrides,
+    }
+
+
+def make_hadith_row(**overrides: Any) -> dict[str, Any]:
+    """A HADITH node's ``props`` as read by the ``/hadiths`` list/detail routes.
+
+    Wrap in ``{"props": make_hadith_row()}`` to match the Cypher output.
+    """
+    return {
+        "id": "hdt:lk:abu_dawud:10:1574",
+        "matn_ar": "إنما الأعمال بالنيات",
+        "matn_en": "Actions are by intentions",
+        "source_corpus": "lk",
+        "collection_name": "abu_dawud",
+        **overrides,
+    }
+
+
+def make_collection_row(**overrides: Any) -> dict[str, Any]:
+    """A COLLECTION node's ``props`` as read by the ``/collections`` routes.
+
+    Wrap in ``{"props": make_collection_row()}`` to match the Cypher output.
+    """
+    return {
+        "id": "col-001",
+        "name_ar": "صحيح البخاري",
+        "name_en": "Sahih al-Bukhari",
+        "sect": "sunni",
+        **overrides,
+    }
+
+
+def make_chain_row(**overrides: Any) -> dict[str, Any]:
+    """A chain row as read by ``/graph/narrator/{id}/chains``.
+
+    Unlike the node factories above this is *not* ``props``-wrapped — the
+    chains query projects these fields directly.
+    """
+    return {
+        "chain_id": "ch-001",
+        "hadith_id": "had-001",
+        "matn_ar": "متن الحديث",
+        "matn_en": "Hadith text",
+        "grade": "sahih",
+        **overrides,
+    }
+
+
+def make_narrator_node(**overrides: Any) -> dict[str, Any]:
+    """A narrator row as read by ``/graph/narrator/{id}/network``.
+
+    Distinct from :func:`make_narrator_row`: the network query projects
+    ``gen`` (not ``generation``) and adds the centrality/degree metrics the
+    ego-graph response needs. Not ``props``-wrapped.
+    """
+    return {
+        "id": "nar-001",
+        "name_ar": "الراوي المركزي",
+        "name_en": "Central Narrator",
+        "gen": "companion",
+        "community_id": 1,
+        "in_degree": 2,
+        "out_degree": 3,
+        "betweenness_centrality": 0.05,
+        "pagerank": 0.002,
+        "sect_affiliation": "sunni",
+        "trustworthiness_consensus": "thiqah",
+        "death_year_ah": 59,
+        "birth_year_ah": None,
+        "kunya": None,
+        "nisba": None,
+        **overrides,
+    }
+
+
+def make_search_narrator_hit(**overrides: Any) -> dict[str, Any]:
+    """A narrator full-text search hit as read by the ``/search`` route."""
+    return {
+        "id": "nar-001",
+        "name_ar": "اختبار",
+        "name_en": "test narrator",
+        "score": 2.5,
+        **overrides,
+    }
+
+
+def make_search_hadith_hit(**overrides: Any) -> dict[str, Any]:
+    """A hadith full-text search hit as read by the ``/search`` route."""
+    return {
+        "id": "had-001",
+        "matn_ar": "نص اختبار",
+        "matn_en": "test hadith text",
+        "score": 1.8,
+        **overrides,
+    }

--- a/tests/test_api/test_collections.py
+++ b/tests/test_api/test_collections.py
@@ -6,12 +6,7 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
-SAMPLE_COLLECTION = {
-    "id": "col-001",
-    "name_ar": "صحيح البخاري",
-    "name_en": "Sahih al-Bukhari",
-    "sect": "sunni",
-}
+from tests.factories import make_collection_row
 
 
 def test_list_collections_empty(client: TestClient, mock_neo4j: MagicMock) -> None:
@@ -27,7 +22,7 @@ def test_list_collections_empty(client: TestClient, mock_neo4j: MagicMock) -> No
 
 def test_list_collections_with_data(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/collections returns paginated collections from Neo4j."""
-    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [{"props": SAMPLE_COLLECTION}]]
+    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [{"props": make_collection_row()}]]
     resp = client.get("/api/v1/collections")
     assert resp.status_code == 200
     body = resp.json()
@@ -39,7 +34,7 @@ def test_list_collections_with_data(client: TestClient, mock_neo4j: MagicMock) -
 
 def test_get_collection_found(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/collections/{id} returns collection when found."""
-    mock_neo4j.execute_read.return_value = [{"props": SAMPLE_COLLECTION}]
+    mock_neo4j.execute_read.return_value = [{"props": make_collection_row()}]
     resp = client.get("/api/v1/collections/col-001")
     assert resp.status_code == 200
     assert resp.json()["id"] == "col-001"

--- a/tests/test_api/test_graph.py
+++ b/tests/test_api/test_graph.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
+from tests.factories import make_chain_row, make_narrator_node
+
 
 def test_narrator_chains_found(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/graph/narrator/{id}/chains returns chains."""
@@ -13,15 +15,7 @@ def test_narrator_chains_found(client: TestClient, mock_neo4j: MagicMock) -> Non
         # exists check
         [{"id": "nar-001"}],
         # chain rows
-        [
-            {
-                "chain_id": "ch-001",
-                "hadith_id": "had-001",
-                "matn_ar": "متن الحديث",
-                "matn_en": "Hadith text",
-                "grade": "sahih",
-            }
-        ],
+        [make_chain_row()],
     ]
     resp = client.get("/api/v1/graph/narrator/nar-001/chains")
     assert resp.status_code == 200
@@ -37,15 +31,7 @@ def test_narrator_chains_with_max_depth(client: TestClient, mock_neo4j: MagicMoc
         # exists check
         [{"id": "nar-001"}],
         # chain rows
-        [
-            {
-                "chain_id": "ch-001",
-                "hadith_id": "had-001",
-                "matn_ar": "متن الحديث",
-                "matn_en": "Hadith text",
-                "grade": "sahih",
-            }
-        ],
+        [make_chain_row()],
     ]
     resp = client.get("/api/v1/graph/narrator/nar-001/chains?max_depth=3")
     assert resp.status_code == 200
@@ -60,15 +46,7 @@ def test_narrator_chains_default_max_depth(client: TestClient, mock_neo4j: Magic
     """GET /api/v1/graph/narrator/{id}/chains uses default max_depth=5."""
     mock_neo4j.execute_read.side_effect = [
         [{"id": "nar-001"}],
-        [
-            {
-                "chain_id": "ch-001",
-                "hadith_id": "had-001",
-                "matn_ar": "متن",
-                "matn_en": None,
-                "grade": None,
-            }
-        ],
+        [make_chain_row(matn_ar="متن", matn_en=None, grade=None)],
     ]
     resp = client.get("/api/v1/graph/narrator/nar-001/chains")
     assert resp.status_code == 200
@@ -128,44 +106,15 @@ def test_hadith_chain_not_found(client: TestClient) -> None:
 
 def test_narrator_network_found(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/graph/narrator/{id}/network returns ego network."""
-    _narrator_fields = {
-        "id": "nar-001",
-        "name_ar": "الراوي المركزي",
-        "name_en": "Central Narrator",
-        "gen": "companion",
-        "community_id": 1,
-        "in_degree": 2,
-        "out_degree": 3,
-        "betweenness_centrality": 0.05,
-        "pagerank": 0.002,
-        "sect_affiliation": "sunni",
-        "trustworthiness_consensus": "thiqah",
-        "death_year_ah": 59,
-        "birth_year_ah": None,
-        "kunya": None,
-        "nisba": None,
-    }
     mock_neo4j.execute_read.side_effect = [
         # 1: exists check
         [{"id": "nar-001"}],
         # 2: center node fields
-        [_narrator_fields],
+        [make_narrator_node()],
         # 3: neighbors at depth
         [
-            {
-                **_narrator_fields,
-                "id": "nar-010",
-                "name_ar": "المعلم",
-                "name_en": "Teacher",
-                "gen": "companion",
-            },
-            {
-                **_narrator_fields,
-                "id": "nar-020",
-                "name_ar": "الطالب",
-                "name_en": "Student",
-                "gen": "successor",
-            },
+            make_narrator_node(id="nar-010", name_ar="المعلم", name_en="Teacher", gen="companion"),
+            make_narrator_node(id="nar-020", name_ar="الطالب", name_en="Student", gen="successor"),
         ],
         # 4: TRANSMITTED_TO edges
         [

--- a/tests/test_api/test_hadiths.py
+++ b/tests/test_api/test_hadiths.py
@@ -6,13 +6,7 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
-SAMPLE_HADITH = {
-    "id": "hdt:lk:abu_dawud:10:1574",
-    "matn_ar": "إنما الأعمال بالنيات",
-    "matn_en": "Actions are by intentions",
-    "source_corpus": "lk",
-    "collection_name": "abu_dawud",
-}
+from tests.factories import make_hadith_row
 
 
 def test_get_hadith_facets_empty(client: TestClient) -> None:
@@ -49,7 +43,7 @@ def test_list_hadiths_with_data(client: TestClient, mock_neo4j: MagicMock) -> No
     """GET /api/v1/hadiths returns hadiths from Neo4j."""
     mock_neo4j.execute_read.side_effect = [
         [{"total": 1}],
-        [{"props": SAMPLE_HADITH}],
+        [{"props": make_hadith_row()}],
     ]
     resp = client.get("/api/v1/hadiths")
     assert resp.status_code == 200
@@ -65,10 +59,7 @@ def test_list_hadiths_display_title_with_known_collection(
     client: TestClient, mock_neo4j: MagicMock
 ) -> None:
     """Display title uses collection_name when available."""
-    hadith = {
-        **SAMPLE_HADITH,
-        "collection_name": "Sunan Abu Dawud",
-    }
+    hadith = make_hadith_row(collection_name="Sunan Abu Dawud")
     mock_neo4j.execute_read.side_effect = [
         [{"total": 1}],
         [{"props": hadith}],
@@ -82,7 +73,7 @@ def test_list_hadiths_filter_by_collection(client: TestClient, mock_neo4j: Magic
     """GET /api/v1/hadiths?collection=X passes filter to query."""
     mock_neo4j.execute_read.side_effect = [
         [{"total": 1}],
-        [{"props": SAMPLE_HADITH}],
+        [{"props": make_hadith_row()}],
     ]
     resp = client.get("/api/v1/hadiths?collection=abu_dawud")
     assert resp.status_code == 200
@@ -96,7 +87,7 @@ def test_list_hadiths_filter_by_source_corpus(client: TestClient, mock_neo4j: Ma
     """GET /api/v1/hadiths?source_corpus=lk passes filter to query."""
     mock_neo4j.execute_read.side_effect = [
         [{"total": 1}],
-        [{"props": SAMPLE_HADITH}],
+        [{"props": make_hadith_row()}],
     ]
     resp = client.get("/api/v1/hadiths?source_corpus=lk")
     assert resp.status_code == 200
@@ -109,7 +100,7 @@ def test_list_hadiths_text_search(client: TestClient, mock_neo4j: MagicMock) -> 
     """GET /api/v1/hadiths?q=intentions passes text search filter."""
     mock_neo4j.execute_read.side_effect = [
         [{"total": 1}],
-        [{"props": SAMPLE_HADITH}],
+        [{"props": make_hadith_row()}],
     ]
     resp = client.get("/api/v1/hadiths?q=intentions")
     assert resp.status_code == 200
@@ -120,7 +111,7 @@ def test_list_hadiths_text_search(client: TestClient, mock_neo4j: MagicMock) -> 
 
 def test_get_hadith_found(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/hadiths/{id} returns hadith when found."""
-    mock_neo4j.execute_read.return_value = [{"props": SAMPLE_HADITH}]
+    mock_neo4j.execute_read.return_value = [{"props": make_hadith_row()}]
     resp = client.get("/api/v1/hadiths/hdt:lk:abu_dawud:10:1574")
     assert resp.status_code == 200
     assert resp.json()["id"] == "hdt:lk:abu_dawud:10:1574"

--- a/tests/test_api/test_narrators.py
+++ b/tests/test_api/test_narrators.py
@@ -6,15 +6,7 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
-SAMPLE_NARRATOR = {
-    "id": "nar-001",
-    "name_ar": "\u0623\u0628\u0648 \u0647\u0631\u064a\u0631\u0629",
-    "name_en": "Abu Hurayra",
-    "generation": "companion",
-    "gender": "male",
-    "sect_affiliation": "sunni",
-    "trustworthiness_consensus": "thiqah",
-}
+from tests.factories import make_narrator_row
 
 
 def test_list_narrators_empty(client: TestClient) -> None:
@@ -32,7 +24,7 @@ def test_list_narrators_with_data(client: TestClient, mock_neo4j: MagicMock) -> 
     """GET /api/v1/narrators returns narrators from Neo4j."""
     mock_neo4j.execute_read.side_effect = [
         [{"total": 1}],
-        [{"props": SAMPLE_NARRATOR}],
+        [{"props": make_narrator_row()}],
     ]
     resp = client.get("/api/v1/narrators")
     assert resp.status_code == 200
@@ -47,7 +39,7 @@ def test_list_narrators_pagination(client: TestClient, mock_neo4j: MagicMock) ->
     """Pagination params are forwarded correctly."""
     mock_neo4j.execute_read.side_effect = [
         [{"total": 50}],
-        [{"props": SAMPLE_NARRATOR}],
+        [{"props": make_narrator_row()}],
     ]
     resp = client.get("/api/v1/narrators?page=3&limit=10")
     assert resp.status_code == 200
@@ -61,7 +53,7 @@ def test_list_narrators_fulltext_search(client: TestClient, mock_neo4j: MagicMoc
     mock_neo4j.execute_read.return_value = [
         {
             "total": 1,
-            "rows": [{"props": SAMPLE_NARRATOR}],
+            "rows": [{"props": make_narrator_row()}],
         }
     ]
     resp = client.get("/api/v1/narrators?q=Abu")
@@ -85,7 +77,7 @@ def test_list_narrators_fulltext_search_pagination(
     mock_neo4j.execute_read.return_value = [
         {
             "total": 25,
-            "rows": [{"props": SAMPLE_NARRATOR}],
+            "rows": [{"props": make_narrator_row()}],
         }
     ]
     resp = client.get("/api/v1/narrators?q=Abu&page=2&limit=10")
@@ -104,7 +96,7 @@ def test_list_narrators_fulltext_search_pagination(
 
 def test_get_narrator_found(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/narrators/{id} returns narrator when found."""
-    mock_neo4j.execute_read.return_value = [{"props": SAMPLE_NARRATOR}]
+    mock_neo4j.execute_read.return_value = [{"props": make_narrator_row()}]
     resp = client.get("/api/v1/narrators/nar-001")
     assert resp.status_code == 200
     assert resp.json()["id"] == "nar-001"

--- a/tests/test_api/test_negative.py
+++ b/tests/test_api/test_negative.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
+from tests.factories import make_narrator_row
 from tests.test_api.routes import GRAPH, HADITHS, NARRATORS, SEARCH
 
 
@@ -90,15 +91,9 @@ class TestBoundaryConditions:
 
     def test_single_narrator_in_database(self, client: TestClient, mock_neo4j: MagicMock) -> None:
         """Database with exactly one narrator returns it correctly."""
-        narrator_props = {
-            "id": "nar-only",
-            "name_ar": "محمد",
-            "name_en": "Muhammad",
-            "generation": "sahabi",
-            "gender": "male",
-            "sect_affiliation": "sunni",
-            "trustworthiness_consensus": "thiqah",
-        }
+        narrator_props = make_narrator_row(
+            id="nar-only", name_ar="محمد", name_en="Muhammad", generation="sahabi"
+        )
         mock_neo4j.execute_read.side_effect = [
             [{"total": 1}],
             [{"props": narrator_props}],

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -6,28 +6,16 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
+from tests.factories import make_search_hadith_hit, make_search_narrator_hit
+
 
 def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/search?q=test uses full-text index and returns results."""
     mock_neo4j.execute_read.side_effect = [
         # narrator full-text search
-        [
-            {
-                "id": "nar-001",
-                "name_ar": "اختبار",
-                "name_en": "test narrator",
-                "score": 2.5,
-            }
-        ],
+        [make_search_narrator_hit()],
         # hadith full-text search
-        [
-            {
-                "id": "had-001",
-                "matn_ar": "نص اختبار",
-                "matn_en": "test hadith text",
-                "score": 1.8,
-            }
-        ],
+        [make_search_hadith_hit()],
         # narrator count query
         [{"total": 7}],
         # hadith count query
@@ -56,10 +44,11 @@ def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMo
 def test_search_total_exceeds_limit(client: TestClient, mock_neo4j: MagicMock) -> None:
     """total reflects the true match count even when results are capped at limit."""
     narrator_hits = [
-        {"id": f"nar-{i}", "name_ar": "اختبار", "name_en": f"n{i}", "score": 1.0} for i in range(2)
+        make_search_narrator_hit(id=f"nar-{i}", name_en=f"n{i}", score=1.0) for i in range(2)
     ]
     hadith_hits = [
-        {"id": f"had-{i}", "matn_ar": "نص", "matn_en": f"h{i}", "score": 1.0} for i in range(2)
+        make_search_hadith_hit(id=f"had-{i}", matn_ar="نص", matn_en=f"h{i}", score=1.0)
+        for i in range(2)
     ]
     mock_neo4j.execute_read.side_effect = [
         narrator_hits,
@@ -82,7 +71,7 @@ def test_search_falls_back_to_contains(client: TestClient, mock_neo4j: MagicMock
     # hadith count: fulltext raises, CONTAINS count fallback succeeds
     mock_neo4j.execute_read.side_effect = [
         Exception("No such index 'narrator_search'"),
-        [{"id": "nar-001", "name_ar": "اختبار", "name_en": "fallback", "score": 1.0}],
+        [make_search_narrator_hit(name_en="fallback", score=1.0)],
         Exception("No such index 'hadith_search'"),
         [],
         Exception("No such index 'narrator_search'"),


### PR DESCRIPTION
## Summary

Replaces inline mock-Neo4j-result dicts in the API tests with shared `**overrides` factory functions, per #799.

The API tests built the same narrator / hadith / collection / chain result-dict shapes inline across `test_narrators.py`, `test_hadiths.py`, `test_collections.py`, `test_graph.py`, `test_search.py`, and `test_negative.py`, with slight per-test variation. `conftest.py`'s `sample_narrator` / `sample_hadith` fixtures return frozen Pydantic *models*, not the raw result-dict shapes the API tests need — so they were unused by these tests.

## Changes

New `tests/factories.py` — factory functions grouped by **the row shape the consuming route actually reads**, not by domain entity (the same entity genuinely has different shapes per route, so a single `make_narrator_row` couldn't honestly serve all call sites):

| Factory | Shape it produces |
|---|---|
| `make_narrator_row` | `props`-wrapped NARRATOR node — `/narrators` list+detail |
| `make_hadith_row` | `props`-wrapped HADITH node — `/hadiths` list+detail |
| `make_collection_row` | `props`-wrapped COLLECTION node — `/collections` |
| `make_chain_row` | chain projection (not `props`-wrapped) — `/graph/.../chains` |
| `make_narrator_node` | network node — `gen` (not `generation`) + centrality metrics — `/graph/.../network` |
| `make_search_narrator_hit` / `make_search_hadith_hit` | full-text search hit — `/search` |

Every factory takes `**overrides`; each default reproduces the exact dict the test previously inlined.

**Behavior-preserving** — no assertions changed, no tests added/removed.

## Intentionally left inline (called out for the reviewer)

- `test_collections.py`'s two edge-case dicts — the *extra-prop* and *missing-`sect`* tests. `**overrides` can override keys but not delete them, and inlining keeps the "this test is about a weird-shaped row" intent legible.
- `test_search.py`'s pgvector semantic-search result — a Postgres row, not a Neo4j row, used once.
- `test_graph.py`'s chain-*visualization* edge row (`source_id`/`target_id`/...) — a one-off shape used once.
- `test_parallels.py` / `test_timeline.py` — already use module-level constants with no inline duplication; their shapes (parallel pair, timeline event) are outside the issue's named factory list, so left untouched.

## Test plan

- [x] `pytest tests/test_api/` — 177 passed
- [x] Full backend unit suite (`pytest tests/ --ignore=tests/e2e --ignore=tests/integration`) — **511 passed, 0 failures**
- [x] `ruff check` — clean on all 7 files
- [x] `ruff format --check` — clean (one file reformatted then re-verified)
- [x] `mypy` — no issues in all 7 files

Closes #799

Note: conflict-aware with IG#797 (PR #909, Jun-Seo) — that PR only removes a class from `test_admin.py`; this PR touches none of its files (`test_admin.py` untouched here, `conftest.py` untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
