### PR TITLE
tech-debt(#911): replace relative org-charter paths with GitHub blob URLs

### DIFF
--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -1,5 +1,13 @@
 # Team Charter — noorinalabs-isnad-graph
 
+## Repository Context
+
+`noorinalabs-isnad-graph` is a child repo of [`noorinalabs-main`](https://github.com/noorinalabs/noorinalabs-main). The shared org-level charter sub-docs are the single source of truth and live in the parent repo at `noorinalabs-main/.claude/team/charter/`. Links to those sub-docs from this charter use **GitHub blob URLs** rather than relative filesystem paths, so they resolve identically from:
+
+- a standalone clone of this repo (where the parent isn't on disk),
+- a worktree checkout (where directory depth breaks relative paths), and
+- a nested clone under `noorinalabs-main/` (where the on-disk copy under the parent's `.claude/team/charter/` directory also exists for offline reference).
+
 ## Purpose
 
 All work on the noorinalabs-isnad-graph repository is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
@@ -17,14 +25,14 @@ The following rules are defined once in the org charter and apply to all repos. 
 
 | Topic | Reference |
 |-------|-----------|
-| Issue comments, reply protocol, delegation, assignment, hygiene | [Org § Issues](../../../.claude/team/charter/issues.md) |
-| Branching rules, deployments branches, worktree cleanup | [Org § Branching](../../../.claude/team/charter/branching.md) |
-| Commit identity, co-author trailers | [Org § Commits](../../../.claude/team/charter/commits.md) |
-| PR workflow, CI enforcement, consolidated PRs, cross-PR deps | [Org § Pull Requests](../../../.claude/team/charter/pull-requests.md) |
-| Agent naming, lifecycle, hub-and-spoke, team lifecycle | [Org § Agents](../../../.claude/team/charter/agents.md) |
-| Hooks (validate identity, block --no-verify, block git config, auto env test, validate labels) | [Org § Hooks](../../../.claude/team/charter/hooks.md) |
-| Tech preferences, debate, tie-breaking (LCA) | [Org § Tech Decisions](../../../.claude/team/charter/tech-decisions.md) |
-| Cross-repo communication protocol | [Org § Communication](../../../.claude/team/charter/communication.md) |
+| Issue comments, reply protocol, delegation, assignment, hygiene | [Org § Issues](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/issues.md) |
+| Branching rules, deployments branches, worktree cleanup | [Org § Branching](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/branching.md) |
+| Commit identity, co-author trailers | [Org § Commits](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/commits.md) |
+| PR workflow, CI enforcement, consolidated PRs, cross-PR deps | [Org § Pull Requests](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/pull-requests.md) |
+| Agent naming, lifecycle, hub-and-spoke, team lifecycle | [Org § Agents](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/agents.md) |
+| Hooks (validate identity, block --no-verify, block git config, auto env test, validate labels) | [Org § Hooks](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/hooks.md) |
+| Tech preferences, debate, tie-breaking (LCA) | [Org § Tech Decisions](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/tech-decisions.md) |
+| Cross-repo communication protocol | [Org § Communication](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/communication.md) |
 
 ## Issue Review Process
 
@@ -178,7 +186,7 @@ Each team member maintains a directional trust score (1-5). Default is 3 (neutra
 | Thandiwe Moyo | `Thandiwe Moyo` | `parametrization+Thandiwe.Moyo@gmail.com` |
 | Ravi Wickramasinghe | `Ravi Wickramasinghe` | `parametrization+Ravi.Wickramasinghe@gmail.com` |
 
-See [Org § Commits](../../../.claude/team/charter/commits.md) for the commit format, co-author trailers, and identity rules.
+See [Org § Commits](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/commits.md) for the commit format, co-author trailers, and identity rules.
 
 ## Automated Enforcement (Git Hooks)
 
@@ -194,7 +202,7 @@ See [Org § Commits](../../../.claude/team/charter/commits.md) for the commit fo
 
 GitHub repository rulesets requiring at least 1 approving review on all PRs targeting `deployments/**` branches. Emergency override: repository admins can bypass via the GitHub UI (hotfix scenarios only with Manager approval).
 
-See [Org § Hooks](../../../.claude/team/charter/hooks.md) for Claude Code hook details (validate identity, block --no-verify, block git config, auto env test, validate labels).
+See [Org § Hooks](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/hooks.md) for Claude Code hook details (validate identity, block --no-verify, block git config, auto env test, validate labels).
 
 ## Steady-State Goal
 


### PR DESCRIPTION
## Summary

Closes #911. Mechanical docs-only fix mirroring [user-service#15 / PR #120](https://github.com/noorinalabs/noorinalabs-user-service/pull/120) (same lesson, same file shape).

### What was broken

`.claude/team/charter.md` linked to the 8 org-level charter sub-docs via `../../../.claude/team/charter/<doc>.md` relative paths. **10 references total** — 8 in the Shared Rules table + 2 inline (commit-format, hook details).

Pre-fix enumeration (from `origin/deployments/phase-3/wave-11` HEAD `3534444`):

```
$ grep -rn '\.\./\.\./\.\./\.claude/team/charter' .claude/
.claude/team/charter.md:20:| Issue comments... ](../../../.claude/team/charter/issues.md) |
.claude/team/charter.md:21:| Branching rules... ](../../../.claude/team/charter/branching.md) |
.claude/team/charter.md:22:| Commit identity... ](../../../.claude/team/charter/commits.md) |
.claude/team/charter.md:23:| PR workflow... ](../../../.claude/team/charter/pull-requests.md) |
.claude/team/charter.md:24:| Agent naming... ](../../../.claude/team/charter/agents.md) |
.claude/team/charter.md:25:| Hooks... ](../../../.claude/team/charter/hooks.md) |
.claude/team/charter.md:26:| Tech preferences... ](../../../.claude/team/charter/tech-decisions.md) |
.claude/team/charter.md:27:| Cross-repo... ](../../../.claude/team/charter/communication.md) |
.claude/team/charter.md:181:See [Org § Commits](../../../.claude/team/charter/commits.md) ...
.claude/team/charter.md:197:See [Org § Hooks](../../../.claude/team/charter/hooks.md) ...
```

Those paths resolve **only** when the repo sits at exactly `noorinalabs-main/noorinalabs-isnad-graph/`. They break in two situations:

1. **Standalone clone** — the org docs don't exist on disk at all
2. **Worktree checkout** — `.claude/worktrees/<name>/` sits deeper than three levels, so `../../../` already missed the org root *even inside* `noorinalabs-main`. This is why the issue is real, not theoretical — every team member working in a worktree hits a broken link.

### The fix

Replaced all 10 with **GitHub blob URLs**:
`https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/<doc>.md`

These resolve identically from standalone clone, nested clone, and worktree checkout, and render as working links on GitHub.

Added a short **Repository Context** section at the top of `charter.md` explaining the GH-blob-URL choice and the three checkout scenarios.

### Approaches considered and rejected

- **Vendor/copy the org docs into this repo** — rejected. Contradicts the charter's explicit single-source-of-truth design ("defined once in the org charter and apply to all repos"); copying would create drift.
- **Symlinks** — rejected. Don't survive a standalone clone either, and fragile cross-platform.

### Verification (live-trace)

All run against this PR's HEAD:

```
$ find . -name "*.md" -path "*/.claude/*" -exec grep -l '\.\./\.\./\.\./\.claude' {} \;
(empty — PASS)

$ grep '\.\./\.\./' .claude/team/charter.md
(empty — PASS)

$ grep -c 'github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/' .claude/team/charter.md
10
```

All 8 target org charter sub-docs verified present on `noorinalabs-main` at `main` via `gh api .../contents/.claude/team/charter/<doc>.md?ref=main` — every one returns the expected `.md` filename.

## Tech Debt

None. Mechanical docs-only fix; no code, no tests, no CI gates affected; no follow-ups identified.

## Reviewers

- Primary: @anya (Anya Kowalczyk, Tech Lead)
- Secondary: @idris (Idris Yusuf, Security Engineer) — charter doc-shape eye

## Test plan

- [x] Pre-fix enumeration matches expected pattern (10 occurrences, 1 file)
- [x] All 10 replacements applied
- [x] Post-fix `grep` returns zero for the original pattern
- [x] All 8 blob-URL targets confirmed present at canonical location
- [x] Docs-only — no code/tests/CI affected
