### PR TITLE
test(frontend): #907 page + E2E coverage remainder (GraphExplorer, HadithDetail, Dashboard, golden paths)

### DIFF
--- a/frontend/src/pages/__tests__/GraphExplorerPage.test.tsx
+++ b/frontend/src/pages/__tests__/GraphExplorerPage.test.tsx
@@ -1,0 +1,469 @@
+/**
+ * GraphExplorerPage test — D3 / canvas mocking strategy
+ * ------------------------------------------------------
+ * GraphExplorerPage renders a `ForceGraph` component that wraps `react-force-graph-2d`,
+ * which itself drives an HTMLCanvasElement via D3 force-simulation. jsdom does NOT
+ * implement HTMLCanvasElement.getContext (returns null), so the real component would
+ * throw or warn when rendered under Vitest.
+ *
+ * Strategy: stub the entire `ForceGraph` component at the module boundary using
+ * `vi.mock`. The stub renders a deterministic `<div role="application">` with the
+ * incoming nodes/edges as data-* attributes, which gives us:
+ *   - zero canvas calls (no jsdom workaround needed)
+ *   - assertable props (nodes/edges/selectedNodeId visible in DOM)
+ *   - exercise of every code path in GraphExplorerPage that is NOT inside the
+ *     canvas drawing routine
+ *
+ * `communityColor` is re-exported from the real module so the toolbar's legend code
+ * (which calls it directly) keeps working. Tests that need to assert against the
+ * actual canvas drawing of D3 belong in Playwright (golden path / accessibility),
+ * not Vitest — see frontend/tests/e2e/graph.spec.ts.
+ *
+ * The narrator-search dropdown, depth/layout toggles, reset behavior, suggested-
+ * narrator quick-links, and detail-panel open/close are all covered here.
+ */
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import GraphExplorerPage from "../GraphExplorerPage"
+import {
+  fetchGraphNetwork,
+  fetchNarrators,
+  fetchNarrator,
+  fetchNarratorChains,
+} from "../../api/client"
+import type {
+  GraphNode,
+  GraphEdge,
+  Narrator,
+  NarratorNetworkResponse,
+  PaginatedResponse,
+} from "../../types/api"
+
+vi.mock("../../api/client", () => ({
+  fetchGraphNetwork: vi.fn(),
+  fetchNarrators: vi.fn(),
+  fetchNarrator: vi.fn(),
+  fetchNarratorChains: vi.fn(),
+}))
+
+vi.mock("../../components/ForceGraph", () => ({
+  default: (props: {
+    nodes: GraphNode[]
+    edges: GraphEdge[]
+    selectedNodeId: string | null
+  }) => (
+    <div
+      data-testid="force-graph-stub"
+      data-node-count={props.nodes.length}
+      data-edge-count={props.edges.length}
+      data-selected={props.selectedNodeId ?? ""}
+    >
+      ForceGraph stub
+    </div>
+  ),
+  // The toolbar legend imports `communityColor` from this module — stub it as a
+  // deterministic function so assertions about color swatches don't rely on D3.
+  communityColor: (cid: number) => `hsl(${cid * 30}, 60%, 50%)`,
+}))
+
+function makeNarrator(overrides: Partial<Narrator> = {}): Narrator {
+  return {
+    id: "n1",
+    name_ar: "أبو هريرة",
+    name_en: "Abu Hurayra",
+    kunya: null,
+    nisba: null,
+    laqab: null,
+    birth_year_ah: 19,
+    death_year_ah: 59,
+    generation: "Companion",
+    gender: "M",
+    sect_affiliation: "Sunni",
+    trustworthiness_consensus: "Thiqa",
+    aliases: [],
+    betweenness_centrality: 0.5,
+    in_degree: 10,
+    out_degree: 20,
+    pagerank: 0.01,
+    community_id: 1,
+    ...overrides,
+  }
+}
+
+function makeNode(overrides: Partial<GraphNode> = {}): GraphNode {
+  return {
+    id: "n1",
+    label: "Abu Hurayra",
+    name_ar: "أبو هريرة",
+    name_en: "Abu Hurayra",
+    type: "narrator",
+    generation: "Companion",
+    community_id: 1,
+    in_degree: 10,
+    out_degree: 20,
+    betweenness_centrality: 0.5,
+    pagerank: 0.01,
+    sect_affiliation: "Sunni",
+    trustworthiness_consensus: "Thiqa",
+    death_year_ah: 59,
+    birth_year_ah: 19,
+    kunya: null,
+    nisba: null,
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <GraphExplorerPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // ResizeObserver isn't in jsdom — minimal stub so the resize-effect doesn't throw.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+
+describe("GraphExplorerPage — empty state", () => {
+  it("renders the empty-state message and suggested narrators by default", () => {
+    renderPage()
+    expect(screen.getByText("No graph data")).toBeInTheDocument()
+    expect(
+      screen.getByText(/Search for a narrator to explore/i),
+    ).toBeInTheDocument()
+    // Suggested narrators rendered as buttons
+    expect(screen.getByRole("button", { name: "Abu Hurayra" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "al-Zuhri" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Malik ibn Anas" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Aisha bint Abi Bakr" }),
+    ).toBeInTheDocument()
+  })
+
+  it("renders 0 nodes / 0 edges in the status bar by default", () => {
+    renderPage()
+    expect(screen.getByText("0 nodes, 0 edges")).toBeInTheDocument()
+  })
+
+  it("does NOT render the ForceGraph stub when there are no nodes", () => {
+    renderPage()
+    expect(screen.queryByTestId("force-graph-stub")).not.toBeInTheDocument()
+  })
+})
+
+describe("GraphExplorerPage — toolbar controls", () => {
+  it("highlights the active depth button when clicked", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    // Default depth is 1 — button "1" should have a non-transparent background.
+    // Click "2" — it becomes the active depth.
+    await user.click(screen.getByRole("button", { name: "2" }))
+    // Visual state assertion: the active button has fontWeight 600. Inspect
+    // via getComputedStyle/inline style.
+    const btn2 = screen.getByRole("button", { name: "2" })
+    expect(btn2).toHaveStyle({ fontWeight: "600" })
+  })
+
+  it("switches layout mode when a layout button is clicked", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const force = screen.getByRole("button", { name: /^force$/i })
+    const radial = screen.getByRole("button", { name: /radial/i })
+    // Default layout is 'force' — the active button uses the primary background.
+    // Capture initial inline-background of force vs radial.
+    const forceBgBefore = force.style.background
+    const radialBgBefore = radial.style.background
+    expect(forceBgBefore).not.toBe(radialBgBefore)
+
+    await user.click(radial)
+    // After clicking radial, the two backgrounds should have swapped:
+    // radial now has the active (primary) background, force has transparent.
+    expect(radial.style.background).toBe(forceBgBefore)
+    expect(force.style.background).toBe(radialBgBefore)
+  })
+
+  it("opens the legend panel when 'Legend' is clicked", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole("button", { name: "Legend" }))
+    expect(screen.getByText("Node size: degree")).toBeInTheDocument()
+    expect(screen.getByText("Node color: community")).toBeInTheDocument()
+    expect(screen.getByText("Edge: transmission direction")).toBeInTheDocument()
+  })
+
+  it("opens the search dropdown when typing", async () => {
+    const user = userEvent.setup()
+    // Use a name that's NOT in the suggested-narrator list, so the dropdown
+    // match is unambiguous and the suggested-list duplicate doesn't confuse
+    // text queries.
+    const results: PaginatedResponse<Narrator> = {
+      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    }
+    vi.mocked(fetchNarrators).mockResolvedValue(results)
+
+    renderPage()
+    const input = screen.getByLabelText("Search for a narrator")
+    await user.type(input, "Sufy")
+    await waitFor(() => {
+      expect(fetchNarrators).toHaveBeenCalled()
+    })
+    expect(await screen.findByText("Sufyan al-Thawri")).toBeInTheDocument()
+  })
+})
+
+describe("GraphExplorerPage — suggested narrator quick-search", () => {
+  it("focuses the search input and pre-fills it when a suggested narrator is clicked", async () => {
+    const user = userEvent.setup()
+    vi.mocked(fetchNarrators).mockResolvedValue({
+      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    })
+
+    renderPage()
+    await user.click(screen.getByRole("button", { name: "al-Zuhri" }))
+
+    const input = screen.getByLabelText(
+      "Search for a narrator",
+    ) as HTMLInputElement
+    expect(input.value).toBe("al-Zuhri")
+  })
+})
+
+describe("GraphExplorerPage — network data integration", () => {
+  it("renders the ForceGraph stub when network data is loaded via search selection", async () => {
+    const user = userEvent.setup()
+    vi.mocked(fetchNarrators).mockResolvedValue({
+      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    })
+
+    const network: NarratorNetworkResponse = {
+      narrator_id: "n1",
+      nodes: [makeNode({ id: "n1" }), makeNode({ id: "n2", label: "n2" })],
+      edges: [
+        { source: "n1", target: "n2", relationship: "TRANSMITTED_TO", weight: 1 },
+      ],
+      teachers: 1,
+      students: 1,
+    }
+    vi.mocked(fetchGraphNetwork).mockResolvedValue(network)
+    vi.mocked(fetchNarrator).mockResolvedValue(makeNarrator({ id: "n1" }))
+    vi.mocked(fetchNarratorChains).mockResolvedValue({
+      narrator_id: "n1",
+      chains: [],
+      total: 0,
+    })
+
+    renderPage()
+    const input = screen.getByLabelText("Search for a narrator")
+    await user.type(input, "Sufy")
+
+    const dropdownItem = await screen.findByText("Sufyan al-Thawri")
+    await user.click(dropdownItem)
+
+    const stub = await screen.findByTestId("force-graph-stub")
+    expect(stub).toHaveAttribute("data-node-count", "2")
+    expect(stub).toHaveAttribute("data-edge-count", "1")
+    expect(stub).toHaveAttribute("data-selected", "n1")
+
+    // Status bar reflects the loaded counts
+    expect(screen.getByText("2 nodes, 1 edges")).toBeInTheDocument()
+  })
+
+  it("opens the detail panel and renders narrator metadata after selection", async () => {
+    const user = userEvent.setup()
+    vi.mocked(fetchNarrators).mockResolvedValue({
+      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    })
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "n1",
+      nodes: [makeNode({ id: "n1" })],
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+    vi.mocked(fetchNarrator).mockResolvedValue(
+      makeNarrator({
+        id: "n1",
+        name_en: "Sufyan al-Thawri",
+        kunya: "Abu Abdallah",
+        nisba: "al-Thawri",
+      }),
+    )
+    vi.mocked(fetchNarratorChains).mockResolvedValue({
+      narrator_id: "n1",
+      chains: [],
+      total: 0,
+    })
+
+    renderPage()
+    await user.type(
+      screen.getByLabelText("Search for a narrator"),
+      "Sufy",
+    )
+    const dropdownItem = await screen.findByText("Sufyan al-Thawri")
+    await user.click(dropdownItem)
+
+    // Wait for the detail panel to render the narrator info
+    await screen.findByText("Network Statistics")
+    expect(screen.getByText("al-Thawri")).toBeInTheDocument()
+    expect(screen.getByText(/Companion/)).toBeInTheDocument()
+    // "View Full Profile" link is rendered with the narrator id
+    expect(
+      screen.getByRole("link", { name: /View Full Profile/i }),
+    ).toHaveAttribute("href", "/narrators/n1")
+  })
+
+  it("closes the detail panel when the close button is clicked", async () => {
+    const user = userEvent.setup()
+    vi.mocked(fetchNarrators).mockResolvedValue({
+      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    })
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "n1",
+      nodes: [makeNode({ id: "n1" })],
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+    vi.mocked(fetchNarrator).mockResolvedValue(makeNarrator({ id: "n1" }))
+    vi.mocked(fetchNarratorChains).mockResolvedValue({
+      narrator_id: "n1",
+      chains: [],
+      total: 0,
+    })
+
+    renderPage()
+    await user.type(
+      screen.getByLabelText("Search for a narrator"),
+      "Sufy",
+    )
+    const dropdownItem = await screen.findByText("Sufyan al-Thawri")
+    await user.click(dropdownItem)
+
+    await screen.findByText("Network Statistics")
+    await user.click(
+      screen.getByRole("button", { name: "Close detail panel" }),
+    )
+    await waitFor(() => {
+      expect(screen.queryByText("Network Statistics")).not.toBeInTheDocument()
+    })
+  })
+
+  it("resets all state when Reset is clicked", async () => {
+    const user = userEvent.setup()
+    vi.mocked(fetchNarrators).mockResolvedValue({
+      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    })
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "n1",
+      nodes: [makeNode({ id: "n1" })],
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+    vi.mocked(fetchNarrator).mockResolvedValue(makeNarrator({ id: "n1" }))
+    vi.mocked(fetchNarratorChains).mockResolvedValue({
+      narrator_id: "n1",
+      chains: [],
+      total: 0,
+    })
+
+    renderPage()
+    await user.type(
+      screen.getByLabelText("Search for a narrator"),
+      "Sufy",
+    )
+    const dropdownItem = await screen.findByText("Sufyan al-Thawri")
+    await user.click(dropdownItem)
+
+    await screen.findByTestId("force-graph-stub")
+    await user.click(screen.getByRole("button", { name: "Reset" }))
+
+    // After reset, the empty-state is back and the stub is gone
+    await waitFor(() => {
+      expect(screen.queryByTestId("force-graph-stub")).not.toBeInTheDocument()
+    })
+    expect(screen.getByText("No graph data")).toBeInTheDocument()
+    expect(screen.getByText("0 nodes, 0 edges")).toBeInTheDocument()
+  })
+})
+
+describe("GraphExplorerPage — over-limit warning", () => {
+  it("renders the over-limit banner when more than NODE_LIMIT nodes are loaded", async () => {
+    const user = userEvent.setup()
+    vi.mocked(fetchNarrators).mockResolvedValue({
+      items: [makeNarrator({ id: "big", name_en: "Big Network" })],
+      total: 1,
+      page: 1,
+      limit: 10,
+    })
+    // 5001 nodes — exceeds the page's NODE_LIMIT (5000)
+    const bigNodes = Array.from({ length: 5001 }, (_, i) =>
+      makeNode({ id: `n${i}` }),
+    )
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "big",
+      nodes: bigNodes,
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+    vi.mocked(fetchNarrator).mockResolvedValue(makeNarrator({ id: "big" }))
+    vi.mocked(fetchNarratorChains).mockResolvedValue({
+      narrator_id: "big",
+      chains: [],
+      total: 0,
+    })
+
+    renderPage()
+    await user.type(
+      screen.getByLabelText("Search for a narrator"),
+      "Bi",
+    )
+    const dropdownItem = await screen.findByText("Big Network")
+    await user.click(dropdownItem)
+
+    const warning = await screen.findByText(
+      /This query returned 5001 nodes/i,
+    )
+    expect(warning).toBeInTheDocument()
+    expect(within(warning.parentElement!).getByRole("button", {
+      name: "Open Filters",
+    })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/HadithDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/HadithDetailPage.test.tsx
@@ -1,0 +1,335 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import HadithDetailPage from "../HadithDetailPage"
+import { fetchHadith, fetchHadithParallels } from "../../api/client"
+import type { Hadith, ParallelsResponse } from "../../types/api"
+
+vi.mock("../../api/client", () => ({
+  fetchHadith: vi.fn(),
+  fetchHadithParallels: vi.fn(),
+}))
+
+function makeHadith(overrides: Partial<Hadith> = {}): Hadith {
+  return {
+    id: "bukhari:1",
+    matn_ar: "إنما الأعمال بالنيات",
+    matn_en: "Actions are but by intentions",
+    isnad_raw_ar: null,
+    isnad_raw_en: null,
+    grade_composite: "Sahih",
+    topic_tags: ["intention", "worship"],
+    source_corpus: "Sahih al-Bukhari",
+    collection_name: "Bukhari",
+    display_title: "Bukhari 1",
+    has_sunni_parallel: true,
+    has_shia_parallel: false,
+    ...overrides,
+  }
+}
+
+function renderAt(path = "/hadiths/bukhari:1") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/hadiths/:id" element={<HadithDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe("HadithDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Clipboard polyfill — jsdom omits navigator.clipboard.writeText
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
+  describe("loading + error + not-found branches", () => {
+    it("renders the skeleton while loading", () => {
+      vi.mocked(fetchHadith).mockImplementation(() => new Promise(() => {}))
+      vi.mocked(fetchHadithParallels).mockImplementation(() => new Promise(() => {}))
+      const { container } = renderAt()
+      expect(container.querySelector(".animate-pulse")).not.toBeNull()
+    })
+
+    it("shows the error message when fetchHadith fails", async () => {
+      vi.mocked(fetchHadith).mockRejectedValue(new Error("hadith-404"))
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+      await waitFor(() => {
+        expect(screen.getByText(/Error: hadith-404/)).toBeInTheDocument()
+      })
+    })
+
+    it("shows 'Hadith not found.' when data is null/undefined", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(null as never)
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+      await waitFor(() => {
+        expect(screen.getByText("Hadith not found.")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("rendering with full data", () => {
+    it("renders Arabic matn, English matn, grade badge, and metadata", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+
+      await screen.findByText("Bukhari 1", { selector: "h2" })
+      expect(screen.getByText("إنما الأعمال بالنيات")).toBeInTheDocument()
+      expect(
+        screen.getByText("Actions are but by intentions"),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText("Sahih", { selector: "span" }),
+      ).toBeInTheDocument()
+      // Metadata fields
+      expect(screen.getByText("Collection")).toBeInTheDocument()
+      expect(screen.getByText("Bukhari")).toBeInTheDocument()
+      expect(screen.getByText("Source Corpus")).toBeInTheDocument()
+      expect(screen.getByText("Sunni parallel")).toBeInTheDocument()
+      expect(screen.queryByText("Shia parallel")).not.toBeInTheDocument()
+    })
+
+    it("renders the isnad-raw prefix in front of the Arabic matn when present", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(
+        makeHadith({
+          isnad_raw_ar: "حدثنا أبو هريرة",
+          isnad_raw_en: "Narrated by Abu Hurayra",
+        }),
+      )
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+
+      await screen.findByText("Bukhari 1", { selector: "h2" })
+      expect(screen.getByText(/حدثنا أبو هريرة/)).toBeInTheDocument()
+      expect(screen.getByText(/Narrated by Abu Hurayra/)).toBeInTheDocument()
+    })
+
+    it("renders topic badges that link to /search", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+
+      await screen.findByText("Topics")
+      const intentionLink = screen.getByRole("link", { name: /intention/i })
+      expect(intentionLink).toHaveAttribute(
+        "href",
+        "/search?q=intention",
+      )
+    })
+
+    it("renders parallel hadith with similarity scores and a Compare link", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      const parallels: ParallelsResponse = {
+        hadith_id: "bukhari:1",
+        total: 2,
+        parallels: [
+          {
+            id: "muslim:1",
+            matn_ar: "إنما الأعمال بالنيات (مسلم)",
+            matn_en: "Muslim's version",
+            source_corpus: "Sahih Muslim",
+            grade: "Sahih",
+            similarity_score: 0.95,
+            variant_type: "verbatim",
+            cross_sect: false,
+          },
+          {
+            id: "kafi:1",
+            matn_ar: "نسخة كافي",
+            matn_en: null,
+            source_corpus: "al-Kafi",
+            grade: null,
+            similarity_score: 0.72,
+            variant_type: "thematic",
+            cross_sect: true,
+          },
+        ],
+      }
+      vi.mocked(fetchHadithParallels).mockResolvedValue(parallels)
+      renderAt()
+
+      await screen.findByText(/Parallel Hadith \(2 found\)/)
+      expect(screen.getByText("Sahih Muslim")).toBeInTheDocument()
+      expect(screen.getByText("Similarity: 95%")).toBeInTheDocument()
+      expect(screen.getByText("al-Kafi")).toBeInTheDocument()
+      expect(screen.getByText("Similarity: 72%")).toBeInTheDocument()
+      expect(screen.getByText("Cross-sect")).toBeInTheDocument()
+      // Find the inner "Compare" link by exact name match — outer parallel
+      // cards are anchors too (the entire card is clickable), so the inner
+      // Compare link needs to be matched by exact name.
+      const compareLinks = screen.getAllByRole("link", { name: "Compare" })
+      expect(compareLinks).toHaveLength(2)
+      expect(compareLinks[0]).toHaveAttribute(
+        "href",
+        "/compare?a=bukhari:1&b=muslim:1",
+      )
+      expect(compareLinks[1]).toHaveAttribute(
+        "href",
+        "/compare?a=bukhari:1&b=kafi:1",
+      )
+    })
+  })
+
+  describe("copy-to-clipboard buttons", () => {
+    it("copies the citation when the Copy-citation button is clicked", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+
+      const copyBtn = await screen.findByRole("button", {
+        name: "Copy citation",
+      })
+      fireEvent.click(copyBtn)
+
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          expect.stringContaining("Bukhari 1, Hadith bukhari:1"),
+        )
+      })
+      // Button label flips to "Copied!" once the async writeText resolves
+      await screen.findByRole("button", { name: "Copied!" })
+    })
+
+    it("copies the Arabic matn when the Copy-Arabic button is clicked", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+
+      const btn = await screen.findByRole("button", {
+        name: "Copy Arabic text",
+      })
+      fireEvent.click(btn)
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          "إنما الأعمال بالنيات",
+        )
+      })
+    })
+
+    it("hides the Copy-translation button when matn_en is null", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith({ matn_en: null }))
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+      renderAt()
+
+      await screen.findByRole("button", { name: "Copy citation" })
+      expect(
+        screen.queryByRole("button", { name: "Copy translation" }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("share button", () => {
+    it("falls back to clipboard when navigator.share is undefined", async () => {
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (navigator as any).share
+
+      renderAt()
+      const shareBtn = await screen.findByRole("button", { name: "Share" })
+      fireEvent.click(shareBtn)
+
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalled()
+      })
+      const calls = vi.mocked(navigator.clipboard.writeText).mock.calls
+      expect(calls.length).toBeGreaterThan(0)
+      const arg = calls[0]![0]
+      expect(arg).toMatch(/^http/)
+    })
+
+    it("uses navigator.share when present", async () => {
+      const shareSpy = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, "share", {
+        configurable: true,
+        value: shareSpy,
+      })
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+
+      renderAt()
+      const shareBtn = await screen.findByRole("button", { name: "Share" })
+      fireEvent.click(shareBtn)
+      await waitFor(() => {
+        expect(shareSpy).toHaveBeenCalledTimes(1)
+      })
+      // Clipboard NOT used when share resolves successfully
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+    })
+
+    it("falls back to clipboard when navigator.share rejects (user cancel)", async () => {
+      Object.defineProperty(navigator, "share", {
+        configurable: true,
+        value: vi.fn().mockRejectedValue(new Error("AbortError")),
+      })
+      vi.mocked(fetchHadith).mockResolvedValue(makeHadith())
+      vi.mocked(fetchHadithParallels).mockResolvedValue({
+        hadith_id: "bukhari:1",
+        parallels: [],
+        total: 0,
+      })
+
+      renderAt()
+      const shareBtn = await screen.findByRole("button", { name: "Share" })
+      fireEvent.click(shareBtn)
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import DashboardPage from "../DashboardPage"
+import { fetchDashboardStats } from "../../../api/admin-client"
+import type { DashboardStats } from "../../../api/admin-client"
+
+// Role names are kept as variables, NOT literals, so the tests survive the
+// pending UserRole vocab change in #876 (viewer/editor/moderator → trial/reader/researcher).
+// DashboardPage itself is vocab-agnostic — it iterates `data.users_by_role` and renders
+// whatever the API returns.
+const ROLE_A = "researcher"
+const ROLE_B = "reader"
+const ROLE_ADMIN = "admin"
+
+vi.mock("../../../api/admin-client", () => ({
+  fetchDashboardStats: vi.fn(),
+}))
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows loading state initially", () => {
+    vi.mocked(fetchDashboardStats).mockImplementation(
+      () => new Promise(() => {}),
+    )
+    renderPage()
+    expect(screen.getByText(/Loading dashboard/i)).toBeInTheDocument()
+  })
+
+  it("renders error state when the query fails", async () => {
+    vi.mocked(fetchDashboardStats).mockRejectedValue(
+      new Error("boom: stats unreachable"),
+    )
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Error: boom: stats unreachable/),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("renders all StatCards when user stats are present", async () => {
+    const stats: DashboardStats = {
+      total_users: 1234,
+      active_users: 987,
+      suspended_users: 12,
+      new_registrations_7d: 45,
+      active_sessions: 56,
+      users_by_role: [
+        { role: ROLE_A, count: 100 },
+        { role: ROLE_B, count: 50 },
+        { role: ROLE_ADMIN, count: 3 },
+      ],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    expect(await screen.findByText("Admin Dashboard")).toBeInTheDocument()
+    expect(screen.getByText("Total Users")).toBeInTheDocument()
+    expect(screen.getByText("1234")).toBeInTheDocument()
+    expect(screen.getByText("Active Users")).toBeInTheDocument()
+    expect(screen.getByText("987")).toBeInTheDocument()
+    expect(screen.getByText("Suspended Users")).toBeInTheDocument()
+    expect(screen.getByText("12")).toBeInTheDocument()
+    expect(screen.getByText("New (7d)")).toBeInTheDocument()
+    expect(screen.getByText("45")).toBeInTheDocument()
+    expect(screen.getByText("Active Sessions")).toBeInTheDocument()
+    expect(screen.getByText("56")).toBeInTheDocument()
+  })
+
+  it("renders the users-by-role table when the list is non-empty", async () => {
+    const stats: DashboardStats = {
+      total_users: 100,
+      active_sessions: 5,
+      users_by_role: [
+        { role: ROLE_A, count: 60 },
+        { role: ROLE_B, count: 30 },
+        { role: ROLE_ADMIN, count: 10 },
+      ],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    await screen.findByText("Users by Role")
+    expect(screen.getByRole("columnheader", { name: "Role" })).toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: "Count" })).toBeInTheDocument()
+    expect(screen.getByText(ROLE_A)).toBeInTheDocument()
+    expect(screen.getByText("60")).toBeInTheDocument()
+    expect(screen.getByText(ROLE_B)).toBeInTheDocument()
+    expect(screen.getByText("30")).toBeInTheDocument()
+    expect(screen.getByText(ROLE_ADMIN)).toBeInTheDocument()
+    expect(screen.getByText("10")).toBeInTheDocument()
+  })
+
+  it("omits a StatCard when the corresponding field is undefined", async () => {
+    const stats: DashboardStats = {
+      // total_users / active_users / suspended_users / new_registrations_7d omitted
+      active_sessions: 7,
+      users_by_role: [{ role: ROLE_ADMIN, count: 1 }],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    await screen.findByText("Active Sessions")
+    expect(screen.queryByText("Total Users")).not.toBeInTheDocument()
+    expect(screen.queryByText("Active Users")).not.toBeInTheDocument()
+    expect(screen.queryByText("Suspended Users")).not.toBeInTheDocument()
+    expect(screen.queryByText("New (7d)")).not.toBeInTheDocument()
+    expect(screen.getByText("Active Sessions")).toBeInTheDocument()
+    expect(screen.getByText("7")).toBeInTheDocument()
+  })
+
+  it("renders the cross-service migration placeholder when user stats are absent and users_by_role is empty", async () => {
+    const stats: DashboardStats = {
+      active_sessions: 9,
+      users_by_role: [],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    await screen.findByText("Active Sessions")
+    expect(
+      screen.getByText(/User statistics have moved to user-service/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/see #806/)).toBeInTheDocument()
+    expect(screen.queryByText("Users by Role")).not.toBeInTheDocument()
+  })
+
+  it("does NOT render the placeholder when any user-stat field is present, even with empty users_by_role", async () => {
+    const stats: DashboardStats = {
+      total_users: 5,
+      active_sessions: 1,
+      users_by_role: [],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    await screen.findByText("Total Users")
+    expect(
+      screen.queryByText(/User statistics have moved to user-service/i),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Users by Role")).not.toBeInTheDocument()
+  })
+
+  it("treats `data === null` as a no-op render (returns null branch)", async () => {
+    vi.mocked(fetchDashboardStats).mockResolvedValue(null as never)
+    const { container } = renderPage()
+    await waitFor(() => {
+      // Once the query resolves, the loading text disappears and the component returns null
+      expect(screen.queryByText(/Loading dashboard/i)).not.toBeInTheDocument()
+    })
+    expect(container.querySelector("h2")).toBeNull()
+  })
+})

--- a/frontend/tests/e2e/fixtures/admin-user.json
+++ b/frontend/tests/e2e/fixtures/admin-user.json
@@ -1,0 +1,11 @@
+{
+  "id": "admin-user-001",
+  "email": "admin@example.com",
+  "display_name": "Admin User",
+  "avatar_url": null,
+  "email_verified": true,
+  "is_active": true,
+  "locale": "en",
+  "created_at": "2026-01-01T00:00:00Z",
+  "roles": ["admin"]
+}

--- a/frontend/tests/e2e/fixtures/dashboard-stats.json
+++ b/frontend/tests/e2e/fixtures/dashboard-stats.json
@@ -1,0 +1,12 @@
+{
+  "total_users": 42,
+  "active_users": 30,
+  "suspended_users": 2,
+  "new_registrations_7d": 5,
+  "active_sessions": 12,
+  "users_by_role": [
+    { "role": "admin", "count": 3 },
+    { "role": "reader", "count": 25 },
+    { "role": "researcher", "count": 14 }
+  ]
+}

--- a/frontend/tests/e2e/fixtures/hadith-detail.json
+++ b/frontend/tests/e2e/fixtures/hadith-detail.json
@@ -1,0 +1,14 @@
+{
+  "id": "bukhari:1",
+  "matn_ar": "إنما الأعمال بالنيات",
+  "matn_en": "Actions are but by intentions",
+  "isnad_raw_ar": null,
+  "isnad_raw_en": null,
+  "grade_composite": "Sahih",
+  "topic_tags": ["intention", "worship"],
+  "source_corpus": "Sahih al-Bukhari",
+  "collection_name": "Bukhari",
+  "display_title": "Bukhari 1",
+  "has_shia_parallel": false,
+  "has_sunni_parallel": true
+}

--- a/frontend/tests/e2e/fixtures/hadiths.json
+++ b/frontend/tests/e2e/fixtures/hadiths.json
@@ -1,0 +1,19 @@
+{
+  "items": [
+    {
+      "id": "bukhari:1",
+      "matn_ar": "إنما الأعمال بالنيات",
+      "matn_en": "Actions are but by intentions",
+      "grade_composite": "Sahih",
+      "topic_tags": ["intention"],
+      "source_corpus": "Sahih al-Bukhari",
+      "collection_name": "Bukhari",
+      "display_title": "Bukhari 1",
+      "has_shia_parallel": false,
+      "has_sunni_parallel": true
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "limit": 20
+}

--- a/frontend/tests/e2e/fixtures/moderation-items.json
+++ b/frontend/tests/e2e/fixtures/moderation-items.json
@@ -1,0 +1,19 @@
+{
+  "items": [
+    {
+      "id": "mod-001",
+      "entity_type": "hadith",
+      "entity_id": "bukhari:1",
+      "reason": "spam",
+      "status": "pending",
+      "flagged_by": "user-001",
+      "flagged_at": "2026-05-01T10:00:00Z",
+      "resolved_by": null,
+      "resolved_at": null,
+      "notes": null
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "limit": 20
+}

--- a/frontend/tests/e2e/golden-paths.spec.ts
+++ b/frontend/tests/e2e/golden-paths.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Golden-path E2E tests — #907
+ * ----------------------------
+ * These specs cover the three user journeys that #907 calls out:
+ *   1. Login → land in app → click a narrator card → land on detail page
+ *   2. Hadith list → click → hadith detail page
+ *   3. Admin moderation flow (admin user → /admin/moderation)
+ *
+ * All API calls are mocked at the route layer (see existing `navigation.spec.ts`
+ * precedent). These specs DO NOT require a running Neo4j/Postgres/Redis stack —
+ * only the built frontend served on `baseURL` (Playwright config defaults to
+ * `http://localhost:4173`, i.e. `vite preview`).
+ *
+ * Run locally:
+ *   cd frontend
+ *   npm run build              # produces dist/
+ *   npx vite preview --port 4173 &
+ *   npm run e2e -- golden-paths
+ *
+ * Run in CI: see frontend/CI documentation; these specs are co-located with
+ * existing E2E specs and run via the same `npm run e2e` command.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const authUser = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/auth-user.json'), 'utf-8'),
+)
+const adminUser = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/admin-user.json'), 'utf-8'),
+)
+const narrators = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/narrators.json'), 'utf-8'),
+)
+const hadiths = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/hadiths.json'), 'utf-8'),
+)
+const hadithDetail = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/hadith-detail.json'), 'utf-8'),
+)
+const dashboardStats = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/dashboard-stats.json'), 'utf-8'),
+)
+const moderationItems = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/moderation-items.json'), 'utf-8'),
+)
+
+type RoleConfig = { admin: boolean }
+
+async function mockBackend(page: Page, config: RoleConfig = { admin: false }) {
+  const user = config.admin ? adminUser : authUser
+
+  // /users/me — primary identity endpoint
+  await page.route('**/api/v1/users/me', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(user) }),
+  )
+  // Legacy alias still hit by some E2E specs
+  await page.route('**/api/v1/auth/me', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(user) }),
+  )
+  await page.route('**/api/v1/auth/subscription', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'trial', tier: 'trial', days_remaining: 7 }),
+    }),
+  )
+
+  // Narrator detail
+  await page.route('**/api/v1/narrators/narrator-001', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(narrators.items[0]),
+    }),
+  )
+  await page.route('**/api/v1/narrators/narrator-001/chains', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ narrator_id: 'narrator-001', chains: [], total: 0 }),
+    }),
+  )
+
+  // Hadith list + detail
+  await page.route('**/api/v1/hadiths/facets**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ source_corpus: ['Sahih al-Bukhari'] }),
+    }),
+  )
+  await page.route('**/api/v1/hadiths/bukhari:1/parallels**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ hadith_id: 'bukhari:1', parallels: [], total: 0 }),
+    }),
+  )
+  await page.route('**/api/v1/hadiths/bukhari:1', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(hadithDetail),
+    }),
+  )
+  await page.route('**/api/v1/hadiths**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(hadiths),
+    }),
+  )
+
+  // Narrators list
+  await page.route('**/api/v1/narrators**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(narrators),
+    }),
+  )
+
+  // Admin dashboard + moderation
+  await page.route('**/api/v1/admin/dashboard/stats', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(dashboardStats),
+    }),
+  )
+  await page.route('**/api/v1/admin/moderation**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(moderationItems),
+    }),
+  )
+
+  // Catch-all — return empty 200 so unscoped queries don't hang
+  await page.route('**/api/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+
+  // Seed auth token so ProtectedRoute sees an authenticated user
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'mock-token')
+  })
+}
+
+test.describe('Golden path: narrator list → detail', () => {
+  test('clicking a narrator on the Narrators page lands on its detail page', async ({ page }) => {
+    await mockBackend(page)
+    await page.goto('/narrators')
+
+    // Narrator card for Abu Hurayra is rendered from the fixture
+    const card = page.getByText('Abu Hurayra').first()
+    await expect(card).toBeVisible()
+    await card.click()
+
+    await expect(page).toHaveURL(/\/narrators\/narrator-001/)
+  })
+})
+
+test.describe('Golden path: hadith list → detail', () => {
+  test('clicking a hadith on the Hadiths page lands on its detail page', async ({ page }) => {
+    await mockBackend(page)
+    await page.goto('/hadiths')
+
+    // Either the Arabic matn or the corpus is enough to identify the row
+    const row = page.getByText('Actions are but by intentions').first()
+    await expect(row).toBeVisible()
+    await row.click()
+
+    await expect(page).toHaveURL(/\/hadiths\/bukhari:1/)
+    await expect(
+      page.getByRole('heading', { name: /Bukhari 1/ }),
+    ).toBeVisible()
+  })
+
+  test('hadith detail page renders Arabic matn, English matn, and grade badge', async ({ page }) => {
+    await mockBackend(page)
+    await page.goto('/hadiths/bukhari:1')
+
+    await expect(page.getByText('إنما الأعمال بالنيات')).toBeVisible()
+    await expect(
+      page.getByText('Actions are but by intentions'),
+    ).toBeVisible()
+    await expect(page.getByText('Sahih').first()).toBeVisible()
+  })
+})
+
+test.describe('Golden path: admin moderation flow', () => {
+  test('admin user can land on /admin/moderation', async ({ page }) => {
+    await mockBackend(page, { admin: true })
+    await page.goto('/admin/moderation')
+
+    // Verify we did NOT bounce to the 403 page (the AdminRoute fallback)
+    await expect(page.getByRole('heading', { name: '403' })).toHaveCount(0)
+    // Some indicator of the moderation page surface — accept any heading containing "Moderation"
+    await expect(page.getByText(/Moderation/i).first()).toBeVisible()
+  })
+
+  test('non-admin user is blocked from /admin/moderation with a 403', async ({ page }) => {
+    await mockBackend(page, { admin: false })
+    await page.goto('/admin/moderation')
+
+    await expect(page.getByRole('heading', { name: '403' })).toBeVisible()
+    await expect(
+      page.getByText(/You do not have permission/i),
+    ).toBeVisible()
+  })
+
+  test('admin dashboard renders StatCards from /admin/dashboard/stats', async ({ page }) => {
+    await mockBackend(page, { admin: true })
+    await page.goto('/admin/dashboard')
+
+    await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible()
+    await expect(page.getByText('Total Users')).toBeVisible()
+    await expect(page.getByText('42')).toBeVisible()
+    await expect(page.getByText('Active Sessions')).toBeVisible()
+    await expect(page.getByText('12')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #907 — frontend test surface deferred from #798 / PR #905 (Jun-Seo).

Adds 34 Vitest unit tests across three page test files plus 6 Playwright golden-path E2E test cases.

### Per-page test count

| Surface | File | Tests |
|---|---|---|
| `DashboardPage` (admin) | `frontend/src/pages/admin/__tests__/DashboardPage.test.tsx` | 8 |
| `HadithDetailPage` | `frontend/src/pages/__tests__/HadithDetailPage.test.tsx` | 13 |
| `GraphExplorerPage` | `frontend/src/pages/__tests__/GraphExplorerPage.test.tsx` | 13 |
| Playwright golden paths | `frontend/tests/e2e/golden-paths.spec.ts` | 6 |
| **Total** | | **40 new tests** |

### D3 / canvas mocking strategy (GraphExplorerPage)

`react-force-graph-2d` drives an `HTMLCanvasElement` via D3 force-simulation; jsdom does not implement `HTMLCanvasElement.getContext`, so the real component would warn/throw when rendered under Vitest.

Strategy: stub the entire `ForceGraph` component at the module boundary via `vi.mock(...)`. The stub renders a deterministic `<div data-testid="force-graph-stub">` with the incoming nodes/edges/selectedNodeId as `data-*` attributes. This gives:
- Zero canvas calls — no jsdom workaround needed
- Assertable props (node count, edge count, selected ID visible in the DOM)
- Full exercise of every code path in `GraphExplorerPage` that is NOT inside the canvas drawing routine

`communityColor` is re-stubbed as a deterministic `hsl(...)` function so the legend code (which imports it directly from the same module) keeps working.

Tests that need to assert against the actual canvas rendering of D3 belong in Playwright (golden path + accessibility), not Vitest. Strategy is documented in a comment block at the top of the test file for future authors.

Limitations: `ResizeObserver` is also stubbed in `beforeEach` (jsdom doesn't ship one); the dimensions-effect simply doesn't fire size-change updates, but no assertion in this PR depends on dynamic dimension changes.

### Playwright command + CI

Run locally:
```
cd frontend
npm run build
npx vite preview --port 4173 &
npm run e2e -- golden-paths
```

CI integration status: the spec runs via the existing `npm run e2e` command — this PR does not introduce a new CI job for Playwright. Whatever Playwright integration the repo already has continues to run; see the existing `tests/e2e/*.spec.ts` files for the pre-existing pattern. Playwright in this repo is runtime acceptance (requires a built frontend served at `baseURL`), not PR-time acceptance.

## Coordination

- **#876 (Jun-Seo, UserRole vocab change)**: at PR-open time, `J.Park/0876-userrole-backend-vocab` is not pushed to origin (local-only). DashboardPage tests use vocab-agnostic role-name variables (e.g., `const ROLE_A = "researcher"`), so they survive either vocab. Sent Jun-Seo a coordination message before starting.
- **Predecessor #905 (Jun-Seo)**: merged into wave-10 on 2026-05-15 (70 tests for `useAuth`, `useTheme`, API clients, `NarratorDetailPage`). This PR is the deferred remainder from #798. Wave-11 hasn't pulled wave-10 forward yet, so the `NarratorDetailPage.test.tsx` precedent from #905 is not present in this base — I followed the same patterns from `ComparativePage.test.tsx` (which is in the wave-11 base).

## Tech Debt

None introduced.

Surfaced two pre-existing items (NOT in scope for this PR; flag-only):
1. `HadithDetailPage` nests `<Link to="/compare">` inside `<Link to="/hadiths/...">` — triggers a "`<a>` cannot contain a nested `<a>`" warning during render. Pre-existing source bug, not caused by this PR.
2. `package-lock.json` on wave-11 still references a missing local tarball (`file:../../noorinalabs-design-system-0.0.1.tgz`) — fixed on wave-10 by #908 (L.Pham) but wave-11 was branched before that landed. `npm install` from a fresh worktree fails on the wave-11 base; I worked around it locally via a symlink. Not in scope here.

## Tech Debt

None introduced.

## Live-trace acceptance

- `npm run test` — **85 passed (85)** across 15 test files (12 pre-existing + 3 new); 34 of those are new in this PR. Full output:
  ```
  Test Files  15 passed (15)
       Tests  85 passed (85)
  ```
- `npm run lint` — 0 errors, 11 pre-existing warnings (none in my files).
- `npm run build` — clean (`tsc && vite build`). Bundle produced.
- `npm run e2e -- --list golden-paths` — 6 test cases enumerated correctly. Cannot run in this sandbox (no built frontend served on `baseURL`); documented as runtime acceptance per [[feedback_runtime_gate_scoping]].

## Reviewers

- Primary: **Jun-Seo Park** — authored predecessor #905, knows the D3/canvas mocking gotchas
- Secondary: **Aisling Brennan** — frontend-curious second-pair scrutiny

## Test plan

- [x] `npm run test` clean (85/85)
- [x] `npm run lint` clean (no new warnings)
- [x] `npm run build` clean (tsc + vite both pass)
- [x] Playwright `--list` confirms 6 golden-path tests parse
- [ ] Playwright `npm run e2e -- golden-paths` runs green against a built frontend (runtime acceptance; verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
