### PR TITLE
fix(isnad-graph #913): admin health probe observability + psycopg2→psycopg

### DIFF
--- a/src/api/routes/admin/health.py
+++ b/src/api/routes/admin/health.py
@@ -2,13 +2,30 @@
 
 from __future__ import annotations
 
+import re
+
 from fastapi import APIRouter, Depends
 
 from src.api.deps import get_neo4j
 from src.api.models import SystemHealthResponse
+from src.utils.logging import get_logger
 from src.utils.neo4j_client import Neo4jClient
 
 router = APIRouter(prefix="/health")
+
+log = get_logger(__name__)
+
+_DSN_CREDENTIALS_RE = re.compile(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)[^@/\s]+(?=@)")
+
+
+def _redact_dsn(text: str) -> str:
+    """Strip ``user:password`` from any ``scheme://user:pass@host`` URI in *text*.
+
+    Defensive — modern psycopg/redis don't leak credentials in error messages, but
+    this guarantees the no-credentials-in-logs invariant even if a future library
+    bump changes that behaviour.
+    """
+    return _DSN_CREDENTIALS_RE.sub(r"\g<scheme>***", text)
 
 
 @router.get("/live", response_model=SystemHealthResponse)
@@ -26,7 +43,12 @@ def liveness() -> SystemHealthResponse:
 def readiness(
     neo4j: Neo4jClient = Depends(get_neo4j),
 ) -> SystemHealthResponse:
-    """Readiness probe — check Neo4j, PostgreSQL, and Redis connectivity."""
+    """Readiness probe — check Neo4j, PostgreSQL, and Redis connectivity.
+
+    All three probes log structured failures (with exception class) so degraded
+    states are debuggable from logs. DSN credentials are redacted from any
+    exception text that escapes into log messages.
+    """
     neo4j_ok = False
     pg_ok = False
     redis_ok = False
@@ -34,21 +56,29 @@ def readiness(
     try:
         neo4j.execute_read("RETURN 1 AS ok")
         neo4j_ok = True
-    except Exception:
-        pass
+    except Exception as exc:
+        log.error(
+            "neo4j health probe failed",
+            exc_type=type(exc).__name__,
+            exc_msg=_redact_dsn(str(exc)),
+        )
 
     try:
         from src.config import get_settings
 
         settings = get_settings()
         if settings.postgres.dsn:
-            import psycopg2
+            import psycopg
 
-            conn = psycopg2.connect(str(settings.postgres.dsn))
+            conn = psycopg.connect(str(settings.postgres.dsn))
             conn.close()
             pg_ok = True
-    except Exception:
-        pass
+    except Exception as exc:
+        log.error(
+            "postgres health probe failed",
+            exc_type=type(exc).__name__,
+            exc_msg=_redact_dsn(str(exc)),
+        )
 
     try:
         from src.config import get_settings
@@ -60,8 +90,12 @@ def readiness(
             r = redis.from_url(str(settings.redis.url))
             r.ping()
             redis_ok = True
-    except Exception:
-        pass
+    except Exception as exc:
+        log.error(
+            "redis health probe failed",
+            exc_type=type(exc).__name__,
+            exc_msg=_redact_dsn(str(exc)),
+        )
 
     all_ok = neo4j_ok and pg_ok and redis_ok
     return SystemHealthResponse(

--- a/tests/test_api/test_admin.py
+++ b/tests/test_api/test_admin.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+
+if TYPE_CHECKING:
+    from contextlib import ExitStack
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -140,6 +144,131 @@ class TestAdminHealth:
         assert "neo4j" in data
         assert "postgres" in data
         assert "redis" in data
+
+
+class TestAdminHealthObservability:
+    """Issue #913 — failing probes must log structured failures without leaking DSN."""
+
+    def test_redact_dsn_strips_basic_auth_userpass(self) -> None:
+        from src.api.routes.admin.health import _redact_dsn
+
+        assert _redact_dsn("postgresql://user:secret@host/db") == "postgresql://***@host/db"
+        assert _redact_dsn("redis://:topsecret@host:6379/0") == "redis://***@host:6379/0"
+
+    def test_redact_dsn_leaves_dsn_free_text_untouched(self) -> None:
+        from src.api.routes.admin.health import _redact_dsn
+
+        assert _redact_dsn("connection refused on port 5432") == "connection refused on port 5432"
+        assert _redact_dsn("OperationalError: server closed connection") == (
+            "OperationalError: server closed connection"
+        )
+
+    def test_neo4j_probe_failure_logs_exc_type_no_dsn(
+        self, admin_client: TestClient, mock_neo4j: MagicMock
+    ) -> None:
+        from structlog.testing import capture_logs
+
+        mock_neo4j.execute_read.side_effect = RuntimeError(
+            "auth failed for bolt://neo4j:supersecret@host:7687"
+        )
+        with capture_logs() as cap_logs, _patched_pg_redis():
+            resp = admin_client.get("/api/v1/admin/health/ready")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["neo4j"] is False
+        assert data["status"] == "degraded"
+
+        neo4j_events = [r for r in cap_logs if "neo4j" in r.get("event", "")]
+        assert len(neo4j_events) >= 1, f"expected neo4j failure log, got {cap_logs}"
+        ev = neo4j_events[0]
+        assert ev["log_level"] == "error"
+        assert ev["exc_type"] == "RuntimeError"
+        for field_value in ev.values():
+            assert "supersecret" not in str(field_value), f"DSN secret leaked in field: {ev}"
+
+    def test_postgres_probe_failure_logs_no_dsn(self, admin_client: TestClient) -> None:
+        from unittest.mock import patch
+
+        from structlog.testing import capture_logs
+
+        mock_neo4j = admin_client.app.state.neo4j  # type: ignore[attr-defined]
+        mock_neo4j.execute_read.return_value = [{"ok": 1}]
+
+        boom = RuntimeError("connect: postgresql://pguser:pgpass@db:5432/x")
+        with capture_logs() as cap_logs:
+            with (
+                patch("psycopg.connect", side_effect=boom),
+                patch("redis.from_url") as mock_redis_from_url,
+            ):
+                mock_redis_from_url.return_value.ping.return_value = True
+                resp = admin_client.get("/api/v1/admin/health/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["postgres"] is False
+
+        pg_events = [r for r in cap_logs if "postgres" in r.get("event", "")]
+        assert len(pg_events) == 1
+        ev = pg_events[0]
+        assert ev["exc_type"] == "RuntimeError"
+        assert ev["log_level"] == "error"
+        # Mandatory security assertion — DSN password must NOT appear anywhere in the log record
+        for field_value in ev.values():
+            assert "pgpass" not in str(field_value), f"DSN password leaked: {ev}"
+            assert "pguser:pgpass" not in str(field_value)
+
+    def test_redis_probe_failure_logs_no_url_secret(self, admin_client: TestClient) -> None:
+        from unittest.mock import patch
+
+        from structlog.testing import capture_logs
+
+        mock_neo4j = admin_client.app.state.neo4j  # type: ignore[attr-defined]
+        mock_neo4j.execute_read.return_value = [{"ok": 1}]
+
+        boom = RuntimeError("auth failed: redis://:topsecret@cache:6379/0")
+        with capture_logs() as cap_logs:
+            with patch("psycopg.connect"), patch("redis.from_url") as mock_redis_from_url:
+                mock_redis_from_url.return_value.ping.side_effect = boom
+                resp = admin_client.get("/api/v1/admin/health/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["redis"] is False
+
+        redis_events = [r for r in cap_logs if "redis" in r.get("event", "")]
+        assert len(redis_events) == 1
+        ev = redis_events[0]
+        assert ev["exc_type"] == "RuntimeError"
+        for field_value in ev.values():
+            assert "topsecret" not in str(field_value), f"Redis URL secret leaked: {ev}"
+
+    def test_all_probes_pass_emits_no_failure_logs(
+        self, admin_client: TestClient, mock_neo4j: MagicMock
+    ) -> None:
+        from structlog.testing import capture_logs
+
+        mock_neo4j.execute_read.return_value = [{"ok": 1}]
+        with capture_logs() as cap_logs, _patched_pg_redis():
+            resp = admin_client.get("/api/v1/admin/health/ready")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        failure_events = [r for r in cap_logs if "health probe failed" in r.get("event", "")]
+        assert failure_events == []
+
+
+def _patched_pg_redis() -> ExitStack:
+    """Context manager: stub psycopg.connect and redis.from_url to no-op success."""
+    from contextlib import ExitStack
+    from unittest.mock import MagicMock, patch
+
+    stack = ExitStack()
+    pg_patch = patch("psycopg.connect")
+    redis_patch = patch("redis.from_url")
+    stack.enter_context(pg_patch)
+    mock_redis = stack.enter_context(redis_patch)
+    mock_redis.return_value = MagicMock()
+    mock_redis.return_value.ping.return_value = True
+    return stack
 
 
 # --- Stats endpoint ---


### PR DESCRIPTION
## Summary

Closes #913. Transferred from [deploy#144](https://github.com/noorinalabs/noorinalabs-deploy/issues/144) — GH 410-redirected the cross-repo issue transfer, so this PR carries it forward in the correct repo.

## Root cause

The admin `/health/ready` probe silently swallowed all probe failures via `except Exception: pass`, making it impossible to distinguish a real outage from a config-drift issue or a hidden import error.

**The hidden import error**: `import psycopg2` inside the probe — but only `psycopg[binary]` (v3) is installed in `pyproject.toml`. Every readiness call raised `ImportError` on the import line, the bare-except swallowed it, and `pg_ok` stayed False. The sibling `/health` route at `src/api/routes/health.py` already uses `import psycopg` (v3) correctly. This is what was producing the "PostgreSQL down" report on the admin System Health page — not a real outage.

### Side question from #913 — answered

> "Does isnad-graph api still USE PostgreSQL post user-service extraction?"

**Yes — PG is actively used.** Verified via `git grep`:
- `src/api/routes/search.py:11,124` — injects `get_pg()` for narrator search
- `src/api/routes/admin/config.py:11,83,93,144` — injects `get_pg()` for config CRUD
- `src/utils/pg_client.py` — the live PG client

The probe is real, not a stale check. Refutes the "dead-check, just remove" alternative.

## Changes

All three probes (neo4j + postgres + redis) — single observability refactor per Nadia's brief:

1. **Switch `psycopg2` → `psycopg` (v3)** to match the rest of the codebase (`src/api/routes/health.py`, `src/utils/pg_client.py`, `src/cli.py`).
2. **Replace each silent `except Exception: pass`** with `except Exception as exc:` + structlog `log.error(...)` carrying `exc_type=type(exc).__name__` and a DSN-redacted `exc_msg`.
3. **Add `_redact_dsn(text)` helper** that strips `user:password` from any `scheme://user:pass@host` URI. Defensive: psycopg3 and redis-py don't currently leak credentials in error strings (verified empirically against `psycopg.connect('postgresql://user:secretpass@...')` — error string contains only host/port), but the helper preserves the no-credentials-in-logs invariant if either library's behaviour changes in a future bump.

## Decision: SystemHealthResponse schema expansion

**Deferred (not done in this PR).** Rationale: the sibling `/health` endpoint already exposes per-service `ServiceStatus` with structured `error` fields. Admin `/health/ready` is a dumb-boolean view by design. Expanding `SystemHealthResponse` to mirror `ServiceStatus` would invite drift between the two schemas.

The right fix for an admin-frontend rich error display is to consume `/health` (which already provides the data), not duplicate fields on `SystemHealthResponse`. That's an out-of-scope follow-up worth filing if/when the admin UI grows past boolean indicators.

## Security review (self-attestation, security-engineer role)

**Mandatory invariant**: no DSN credentials may appear in log output, ever. Enforced three ways:

1. **Defensive redaction at log-emit time**: every probe's `log.error(...)` passes `exc_msg=_redact_dsn(str(exc))`, not `str(exc)` directly. The regex `(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)[^@/\s]+(?=@)` matches the `user:pass` segment of any URI form.
2. **Library-behaviour audit** (empirical, via `.venv/bin/python` repl):
   - `psycopg.connect('postgresql://baduser:secretpass@host:1/db')` → `OperationalError: connection failed: connection to server at "127.0.0.1", port 1 failed: Connection refused` — **no creds leaked**.
   - `redis.from_url('redis://:secretpass@host:1/0').ping()` → `ConnectionError: Error 111 connecting to localhost:1.` — **no creds leaked**.
   - So even without `_redact_dsn`, the current library versions are well-behaved. The helper is defence in depth.
3. **Test-asserted invariant**: every probe-failure test injects a fake `RuntimeError` containing a known secret token (`pgpass`, `topsecret`, `supersecret`) into the exception message, then exhaustively scans every field of every captured log record asserting the token is absent.

**Pre-existing, out-of-scope observation**: the sibling `src/api/routes/health.py` (`/health` route) returns `ServiceStatus(error=str(exc))` to the public response — safe today with current library versions, could regress on a future bump. Worth a follow-up to apply `_redact_dsn` there for defence in depth, but I'm not expanding this PR's blast radius. I'll file a separate issue.

## Test plan

- [x] `_redact_dsn` correctly strips `user:password` from `postgresql://`, `redis://`, etc.
- [x] `_redact_dsn` leaves DSN-free strings untouched.
- [x] neo4j probe failure logs `exc_type` and emits no DSN secret in any field.
- [x] postgres probe failure logs `exc_type` and emits no DSN secret.
- [x] redis probe failure logs `exc_type` and emits no URL secret.
- [x] All-pass case emits NO failure logs (no noise on healthy state).
- [x] Pre-existing `TestAdminHealth` (test_liveness, test_readiness) still pass — contract preserved.

## Live-trace (verified at this PR's HEAD)

```
$ ruff check src/api/routes/admin/health.py tests/test_api/test_admin.py
All checks passed!

$ ruff format --check src/api/routes/admin/health.py tests/test_api/test_admin.py
2 files already formatted

$ python -c "import mypy.api as m; print(m.run(['src/api/routes/admin/health.py', 'tests/test_api/test_admin.py'])[0])"
Success: no issues found in 2 source files

$ ENVIRONMENT=test pytest tests/test_api/test_admin.py -q
........................                                                 [100%]
24 passed in 1.78s

$ ENVIRONMENT=test pytest tests/test_api/ -q
161 passed in 8.44s
```

Repo-wide format and lint sanity check also clean (`ruff format --check .` → 104 files, `ruff check src/ tests/` → all checks passed).

## Tech Debt

I attest, in my implementer capacity, that I have considered tech debt introduced by this PR. **None added.** This PR retires two tech-debt items (silent `except: pass` hiding real `ImportError`; mismatched DB driver `psycopg2` vs the rest of the codebase on `psycopg`) and introduces no new debt.

Two out-of-scope follow-up candidates noted above:
- Apply `_redact_dsn` to the sibling `/health` route's `ServiceStatus.error` field for defence in depth.
- Consider removing the `types-psycopg2` dev dep from `pyproject.toml` line 42 if no remaining call site needs it (probably unused after this PR; worth a separate cleanup).

I will file these as separate issues, not bundle them into this PR.

## Reviewers

- **Primary**: @anya-kowalczyk (Anya Kowalczyk, Tech Lead — API conventions, logger handle, model-schema discipline)
- **Secondary**: @marisol-vega-cruz (Marisol Vega-Cruz, QA — `capture_logs` fixture + no-DSN-in-logs assertion patterns)

Fallback if Marisol saturated on #907: @jelani-mwangi (Jelani Mwangi, DevOps Architect — alertmanager integration context).
