### PR TITLE
fix(security #917): bump urllib3 2.6.3 -> 2.7.0 (CVE-2026-44431 + CVE-2026-44432)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1459,11 +1459,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `urllib3 2.6.3 -> 2.7.0` in `uv.lock` to resolve two CVEs currently failing the `security-audit` lane on every wave-11 isnad-graph PR (cross-witnessed on #912, #914, #915, #916 by Anya/Ingrid/Jun-Seo at 2026-05-17 04:10-04:12Z).

`urllib3` is a transitive dependency (via `docker`, `requests`, `testcontainers`); no explicit pin in `pyproject.toml`. Sibling cherry of #882 (Idris's wave-10 bump that didn't reach wave-11's base via main; wave-10 still has 60 commits unmerged to main).

Closes #917.

## Advisories

| CVE | Severity | Vector | Fix |
|---|---|---|---|
| [CVE-2026-44431](https://nvd.nist.gov/vuln/detail/CVE-2026-44431) | Header-leak on cross-origin redirect | `ProxyManager.connection_from_url().urlopen(..., assert_same_host=False)` forwards `Authorization` / `Cookie` / `Proxy-Authorization` on cross-origin redirect | urllib3 >= 2.7.0 |
| [CVE-2026-44432](https://nvd.nist.gov/vuln/detail/CVE-2026-44432) | Decompression CPU/memory blowup (CWE-409) | Brotli `HTTPResponse.read(amt=N)` second call + `drain_conn()` after partial read decompress full body | urllib3 >= 2.7.0 |

Both advisories list `2.7.0` as the Fix Version per `pip-audit --strict` output.

## Cross-repo precedent

- isnad-graph PR #882 (Idris, merged 2026-05-14 to wave-10) — identical bump, identical scope. This PR replicates that fix onto wave-11.
- noorinalabs-isnad-ingest-platform PR #32 (Fatima) — same urllib3 line item in her dep-bump bundle; identical dep-bump pattern across the org.

## Lockfile diff scope

```
 uv.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

Bounded to the `urllib3` package block only: `version`, `sdist` URL+hash, `wheel` URL+hash. No transitive consumer's resolution shifted. No other packages bumped. Bumped via `uv lock --upgrade-package urllib3` (minimum-churn discipline).

No `import urllib3` in `src/` or `tests/` (verified by `grep -rn "import urllib3\|from urllib3"`) — purely runtime transitive replacement.

## Verification — Live trace (CI-verbatim invocation)

```
$ uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
$ uv run pip-audit --strict --desc -r /tmp/requirements.txt \
    --ignore-vuln CVE-2024-23342 \
    --ignore-vuln CVE-2026-4539 \
    --ignore-vuln CVE-2026-25645
No known vulnerabilities found, 1 ignored
```

(`1 ignored` = the existing CI-allowlisted CVE-2024-23342.)

`make check` also clean:
- `ruff check src/ tests/` -> All checks passed
- `ruff format --check src/ tests/` -> 98 files already formatted
- `mypy src/` -> Success: no issues found in 47 source files
- `pytest tests/ -x -m "not integration and not e2e"` -> **496 passed, 55 deselected, 6 warnings in 32.39s**

## TechDebt attestation

This PR REMOVES debt (closes a `tech-debt`/`security` issue). No new debt introduced.

## Post-merge plan (wave-wide unblock)

Once this PR lands on `deployments/phase-3/wave-11`:

1. Rebase #912 (Mateo, charter paths), #914 (Jun-Seo, UserRole), #915 (Marisol, frontend tests), #916 (Idris, health probe) onto wave-11 HEAD.
2. Confirm `security-audit` lane goes GREEN on at least one rebased PR (Pass C: live-trace evidence > synthetic-test acceptance).
3. Wave-status dashboard returns to baseline (no uniform red on `security-audit`).

If a wave-wide `pip-audit` cron / weekly hygiene PR rotation is desired (4th instance of pre-existing-CVE-surfaces-on-wave-PR pattern after #283/#310/#846), file separately as a /wave-retro candidate — not in scope here.

## Reviewers

- Primary: **Idris Yusuf** (Security Engineer — CVE-bump review is his core role; authored sibling #882)
- Secondary: **Jelani Mwangi** (DevOps Architect — uv.lock churn discipline + CI gate eye)

## Test plan

- [x] `uv lock --upgrade-package urllib3` produces bounded diff (3+/3- on urllib3 block only)
- [x] `pip-audit --strict` (CI-verbatim) clean post-bump (1 ignored = allowlisted)
- [x] `make check` clean (ruff + mypy + 496 pytest)
- [x] No `import urllib3` in `src/` or `tests/`
- [ ] CI `security-audit` job goes green on THIS PR (will verify on PR run)
- [ ] Post-merge: at least one other open W11 PR's security-audit goes green after rebase
