### PR TITLE
feat(schema): cross-repo codegen + drift gate (isnad-graph side, closes ingest-platform#24)

### DIFF
--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,0 +1,87 @@
+name: schema-drift
+
+# Cross-repo drift gate between this repo's Pydantic models in src/models/ and
+# noorinalabs-isnad-ingest-platform/workers/ingest/schema.py. See
+# noorinalabs/noorinalabs-isnad-ingest-platform#24 for the design.
+#
+# Fails the PR if scripts/emit_ingest_schema.py detects unrationalized divergence
+# in either direction (model field ingest doesn't accept; ingest field not on
+# model). Documented exceptions live in scripts/{ingest,model}-extras.yaml.
+
+on:
+  pull_request:
+    branches: [main, 'deployments/**']
+    paths:
+      - 'src/models/**'
+      - 'scripts/emit_ingest_schema.py'
+      - 'scripts/ingest-extras.yaml'
+      - 'scripts/model-extras.yaml'
+      - '.github/workflows/schema-drift.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: schema-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout isnad-graph
+        uses: actions/checkout@v6
+
+      - name: Resolve ingest-platform sibling ref
+        id: sibling-ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Match this PR's base branch when possible (so a wave-branch PR here
+          # checks against the matching wave-branch on ingest-platform); fall
+          # back to main if the sibling doesn't have it yet. Per
+          # feedback_cross_repo_wave_ref_resolution (deploy#159 W10 lesson).
+          BASE_REF="${{ github.base_ref || github.ref_name }}"
+          REPO=noorinalabs/noorinalabs-isnad-ingest-platform
+          if gh api "repos/${REPO}/branches/${BASE_REF}" --silent 2>/dev/null; then
+            echo "ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+            echo "::notice::ingest-platform sibling branch matched: ${BASE_REF}"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "::notice::ingest-platform '${BASE_REF}' not found; falling back to main"
+          fi
+
+      - name: Checkout ingest-platform schema (sparse)
+        uses: actions/checkout@v6
+        with:
+          repository: noorinalabs/noorinalabs-isnad-ingest-platform
+          ref: ${{ steps.sibling-ref.outputs.ref }}
+          path: _sibling
+          sparse-checkout: |
+            workers/ingest/schema.py
+          sparse-checkout-cone-mode: false
+
+      - name: Verify sibling schema fetched
+        run: |
+          if [ ! -f _sibling/workers/ingest/schema.py ]; then
+            echo "::error::sibling sparse-checkout failed: workers/ingest/schema.py not present"
+            ls -la _sibling/ || true
+            exit 1
+          fi
+          echo "fetched $(wc -l < _sibling/workers/ingest/schema.py) lines"
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-${{ runner.os }}-
+
+      - run: uv sync
+
+      - name: Check schema drift
+        run: |
+          uv run python scripts/emit_ingest_schema.py check \
+            --ingest-schema _sibling/workers/ingest/schema.py

--- a/scripts/emit_ingest_schema.py
+++ b/scripts/emit_ingest_schema.py
@@ -1,0 +1,335 @@
+"""Emit and diff the cross-repo ingest schema allow-lists from Pydantic models.
+
+This script is the source-of-truth bridge between the Pydantic models in
+``src/models/`` (this repo) and the per-label property allow-lists in
+``noorinalabs-isnad-ingest-platform/workers/ingest/schema.py`` (sibling repo).
+
+Two subcommands:
+
+- ``emit``  — write a ``NODE_PROPERTY_MAP`` / ``EDGE_PROPERTY_MAP`` Python literal
+  derived from ``model.model_fields``, minus exclusions declared in
+  ``model-extras.yaml``. Emits stdout by default; ``--out PATH`` writes to a file.
+- ``check`` — fetch the live ingest ``schema.py`` (from a path you provide via
+  ``--ingest-schema``), compare against the model + extras files, and exit
+  non-zero on any unrationalized drift. This is what the schema-drift CI job
+  runs to gate cross-repo PRs.
+
+Drift is detected in BOTH directions:
+
+  1. **Model → ingest drop**: a field on a Pydantic model that ingest does NOT
+     accept AND is NOT excused by ``model-extras.yaml``. This is the failure
+     case noorinalabs/noorinalabs-isnad-ingest-platform#24 was filed to catch.
+
+  2. **Ingest → model phantom**: a field in ingest's allow-list that is NOT on
+     the Pydantic model AND is NOT excused by ``ingest-extras.yaml``. Catches
+     the inverse case (model field renamed/removed but ingest still merging).
+
+The two YAML extras files (``scripts/ingest-extras.yaml`` and
+``scripts/model-extras.yaml``) explicitly document the asymmetry between the
+two surfaces with per-field rationale + tracking-issue refs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# Allow ``from src.models...`` imports when run as a standalone script.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# Cypher node label → Pydantic model class. Order is preserved in emitted output.
+NODE_LABEL_TO_MODEL_PATH: dict[str, tuple[str, str]] = {
+    "Hadith": ("src.models.hadith", "Hadith"),
+    "Narrator": ("src.models.narrator", "Narrator"),
+    "Collection": ("src.models.collection", "Collection"),
+    "Chain": ("src.models.chain", "Chain"),
+    "Grading": ("src.models.grading", "Grading"),
+    "HistoricalEvent": ("src.models.historical", "HistoricalEvent"),
+    "Location": ("src.models.historical", "Location"),
+}
+
+# Cypher relationship type → edge model class. Relationships with no model-defined
+# properties (NARRATED, GRADED_BY) are intentionally absent — they map to ``[]``
+# in the emitted ``EDGE_PROPERTY_MAP``.
+EDGE_LABEL_TO_MODEL_PATH: dict[str, tuple[str, str]] = {
+    "TRANSMITTED_TO": ("src.models.edges", "TransmittedTo"),
+    "APPEARS_IN": ("src.models.edges", "AppearsIn"),
+    "STUDIED_UNDER": ("src.models.edges", "StudiedUnder"),
+    "PARALLEL_OF": ("src.models.edges", "ParallelOf"),
+    "ACTIVE_DURING": ("src.models.edges", "ActiveDuring"),
+    "BASED_IN": ("src.models.edges", "BasedIn"),
+}
+
+# Edge labels that ingest accepts but for which there is no model-defined property
+# allow-list (the edge carries no SET properties — only the relationship itself).
+EDGE_LABELS_NO_PROPS: tuple[str, ...] = ("NARRATED", "GRADED_BY")
+
+# Per-relationship FROM/TO endpoint fields. Matched in the MERGE clause and never
+# re-SET on the relationship as properties. Per-relationship because the same field
+# name can be an endpoint on one relationship and a SET property on another (e.g.
+# `location_id` is the TO-endpoint of BASED_IN but a SET property on STUDIED_UNDER).
+EDGE_ENDPOINT_FIELDS: dict[str, frozenset[str]] = {
+    "TRANSMITTED_TO": frozenset({"from_narrator_id", "to_narrator_id"}),
+    "APPEARS_IN": frozenset({"hadith_id", "collection_id"}),
+    "STUDIED_UNDER": frozenset({"student_id", "teacher_id"}),
+    "PARALLEL_OF": frozenset({"hadith_id_a", "hadith_id_b"}),
+    "ACTIVE_DURING": frozenset({"narrator_id", "event_id"}),
+    "BASED_IN": frozenset({"narrator_id", "location_id"}),
+}
+
+
+@dataclass(frozen=True)
+class Extra:
+    field: str
+    category: str
+    issue: str
+    note: str
+
+
+def _load_extras(path: Path) -> tuple[dict[str, list[Extra]], dict[str, list[Extra]]]:
+    """Load a {nodes, edges} YAML extras file into per-label lists."""
+    if not path.exists():
+        return {}, {}
+    raw = yaml.safe_load(path.read_text()) or {}
+    nodes: dict[str, list[Extra]] = {}
+    edges: dict[str, list[Extra]] = {}
+    for section, target in (("nodes", nodes), ("edges", edges)):
+        for label, entries in (raw.get(section) or {}).items():
+            for entry in entries or []:
+                target.setdefault(label, []).append(
+                    Extra(
+                        field=entry["field"],
+                        category=entry["category"],
+                        issue=entry["issue"],
+                        note=entry.get("note", ""),
+                    )
+                )
+    return nodes, edges
+
+
+def _model_fields(module_path: str, class_name: str) -> list[str]:
+    """Return ordered field names declared on a Pydantic model."""
+    module = __import__(module_path, fromlist=[class_name])
+    cls: type[BaseModel] = getattr(module, class_name)
+    return list(cls.model_fields.keys())
+
+
+def _emit_node_map(
+    model_extras: dict[str, list[Extra]],
+) -> dict[str, list[str]]:
+    """Build the NODE_PROPERTY_MAP derived from models minus model-extras exclusions."""
+    out: dict[str, list[str]] = {}
+    for label, (mod, cls) in NODE_LABEL_TO_MODEL_PATH.items():
+        excluded = {e.field for e in model_extras.get(label, [])}
+        out[label] = [f for f in _model_fields(mod, cls) if f not in excluded]
+    return out
+
+
+def _emit_edge_map(
+    model_extras: dict[str, list[Extra]],
+) -> dict[str, list[str]]:
+    """Build the EDGE_PROPERTY_MAP. Empty list for relationships with no props."""
+    out: dict[str, list[str]] = {label: [] for label in EDGE_LABELS_NO_PROPS}
+    for label, (mod, cls) in EDGE_LABEL_TO_MODEL_PATH.items():
+        excluded = {e.field for e in model_extras.get(label, [])}
+        endpoints = EDGE_ENDPOINT_FIELDS.get(label, frozenset())
+        out[label] = [
+            f for f in _model_fields(mod, cls) if f not in endpoints and f not in excluded
+        ]
+    return out
+
+
+def _render_python_map(name: str, mapping: dict[str, list[str]]) -> str:
+    """Render a {label: [fields]} dict as a stable Python literal for diffing."""
+    lines = [f"{name}: dict[str, list[str]] = {{"]
+    for label, fields in mapping.items():
+        if not fields:
+            lines.append(f'    "{label}": [],')
+            continue
+        lines.append(f'    "{label}": [')
+        for field in fields:
+            lines.append(f'        "{field}",')
+        lines.append("    ],")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _parse_ingest_schema(text: str) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Extract NODE_PROPERTY_MAP and EDGE_PROPERTY_MAP literals from ingest schema.py.
+
+    Uses ast.literal_eval on the assigned dict body — no execution of ingest code,
+    which would require its full Python env. The ingest file is small and the maps
+    are static literal assignments by convention; if that ever changes the parser
+    will raise a clear error.
+    """
+    tree = ast.parse(text)
+    found: dict[str, dict[str, list[str]]] = {}
+    targets = {"NODE_PROPERTY_MAP", "EDGE_PROPERTY_MAP"}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AnnAssign | ast.Assign):
+            continue
+        target_names = (
+            [node.target.id]
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+            else [t.id for t in getattr(node, "targets", []) if isinstance(t, ast.Name)]
+        )
+        for name in target_names:
+            if name in targets and node.value is not None:
+                found[name] = ast.literal_eval(node.value)
+    missing = targets - found.keys()
+    if missing:
+        msg = f"ingest schema.py missing expected literals: {sorted(missing)}"
+        raise ValueError(msg)
+    return found["NODE_PROPERTY_MAP"], found["EDGE_PROPERTY_MAP"]
+
+
+def _check_drift(
+    model_node_map: dict[str, list[str]],
+    model_edge_map: dict[str, list[str]],
+    ingest_node_map: dict[str, list[str]],
+    ingest_edge_map: dict[str, list[str]],
+    ingest_extras_nodes: dict[str, list[Extra]],
+    ingest_extras_edges: dict[str, list[Extra]],
+) -> list[str]:
+    """Return human-readable drift errors. Empty list means clean."""
+    errors: list[str] = []
+
+    def _check_one_direction(
+        kind: str,
+        model_map: dict[str, list[str]],
+        ingest_map: dict[str, list[str]],
+        ingest_extras: dict[str, list[Extra]],
+    ) -> None:
+        all_labels = set(model_map) | set(ingest_map)
+        for label in sorted(all_labels):
+            model_set = set(model_map.get(label, []))
+            ingest_set = set(ingest_map.get(label, []))
+            extras_set = {e.field for e in ingest_extras.get(label, [])}
+
+            # Model → ingest drop
+            for field in sorted(model_set - ingest_set):
+                errors.append(
+                    f"[{kind}:{label}] model field '{field}' is NOT in ingest "
+                    f"NODE_PROPERTY_MAP/EDGE_PROPERTY_MAP and NOT in "
+                    f"model-extras.yaml. Either add it to ingest's allow-list "
+                    f"(cross-repo PR to ingest-platform) OR add an entry to "
+                    f"scripts/model-extras.yaml explaining why ingest deliberately "
+                    f"omits it (with category + tracking issue)."
+                )
+
+            # Ingest → model phantom
+            for field in sorted(ingest_set - model_set - extras_set):
+                errors.append(
+                    f"[{kind}:{label}] ingest allow-list contains '{field}' which "
+                    f"is NOT on the Pydantic model AND NOT in "
+                    f"scripts/ingest-extras.yaml. Either remove it from ingest's "
+                    f"allow-list (cross-repo PR) OR add an entry to "
+                    f"scripts/ingest-extras.yaml documenting why ingest accepts a "
+                    f"property the model doesn't define (with category + tracking issue)."
+                )
+
+    _check_one_direction("node", model_node_map, ingest_node_map, ingest_extras_nodes)
+    _check_one_direction("edge", model_edge_map, ingest_edge_map, ingest_extras_edges)
+    return errors
+
+
+def cmd_emit(args: argparse.Namespace) -> int:
+    _model_extras_nodes, _model_extras_edges = _load_extras(SCRIPTS_DIR / "model-extras.yaml")
+    node_map = _emit_node_map(_model_extras_nodes)
+    edge_map = _emit_edge_map(_model_extras_edges)
+    output = "\n\n".join(
+        [
+            "# AUTO-GENERATED by noorinalabs-isnad-graph/scripts/emit_ingest_schema.py.",
+            "# Source: src/models/*.py + scripts/model-extras.yaml.",
+            "# DO NOT EDIT BY HAND — re-run emit_ingest_schema.py.",
+            _render_python_map("NODE_PROPERTY_MAP", node_map),
+            _render_python_map("EDGE_PROPERTY_MAP", edge_map),
+        ]
+    )
+    if args.out:
+        Path(args.out).write_text(output + "\n")
+    else:
+        sys.stdout.write(output + "\n")
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    ingest_path = Path(args.ingest_schema)
+    if not ingest_path.exists():
+        sys.stderr.write(f"ingest schema not found: {ingest_path}\n")
+        return 2
+
+    _model_extras_nodes, _model_extras_edges = _load_extras(SCRIPTS_DIR / "model-extras.yaml")
+    _ingest_extras_nodes, _ingest_extras_edges = _load_extras(SCRIPTS_DIR / "ingest-extras.yaml")
+
+    model_node_map = _emit_node_map(_model_extras_nodes)
+    model_edge_map = _emit_edge_map(_model_extras_edges)
+    ingest_node_map, ingest_edge_map = _parse_ingest_schema(ingest_path.read_text())
+
+    errors = _check_drift(
+        model_node_map,
+        model_edge_map,
+        ingest_node_map,
+        ingest_edge_map,
+        _ingest_extras_nodes,
+        _ingest_extras_edges,
+    )
+    if errors:
+        sys.stderr.write(
+            f"schema-drift: found {len(errors)} unrationalized divergence(s) between "
+            f"noorinalabs-isnad-graph models and "
+            f"noorinalabs-isnad-ingest-platform/workers/ingest/schema.py:\n\n"
+        )
+        for err in errors:
+            sys.stderr.write(f"  - {err}\n\n")
+        sys.stderr.write(
+            "Fix by either (a) opening a cross-repo PR to ingest-platform to "
+            "align the allow-list, OR (b) adding an entry to "
+            "scripts/{ingest,model}-extras.yaml with a rationale + tracking "
+            "issue. See noorinalabs/noorinalabs-isnad-ingest-platform#24 for the "
+            "design.\n"
+        )
+        return 1
+    sys.stdout.write(
+        "schema-drift: clean. Models and ingest allow-list converge "
+        "(after applying rationalized extras).\n"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    emit = sub.add_parser("emit", help="emit NODE_PROPERTY_MAP / EDGE_PROPERTY_MAP literal")
+    emit.add_argument("--out", help="write to this path instead of stdout")
+    emit.set_defaults(func=cmd_emit)
+
+    check = sub.add_parser("check", help="diff models vs a live ingest schema.py")
+    check.add_argument(
+        "--ingest-schema",
+        required=True,
+        help="path to noorinalabs-isnad-ingest-platform/workers/ingest/schema.py",
+    )
+    check.set_defaults(func=cmd_check)
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest-extras.yaml
+++ b/scripts/ingest-extras.yaml
@@ -1,0 +1,77 @@
+# Ingest-only property allow-list extras.
+#
+# Properties that workers/ingest/schema.py legitimately accepts in NODE_PROPERTY_MAP /
+# EDGE_PROPERTY_MAP but are NOT defined on the corresponding Pydantic model in
+# src/models/. Each entry must have a rationale and a tracking issue.
+#
+# Used by scripts/emit_ingest_schema.py to suppress drift-failure on these specific
+# fields. Anything in ingest's allow-list but not in this file AND not on the model
+# will fail the schema-drift CI gate.
+#
+# Categories:
+#   phase-3-legacy  — emitted by current normalize-v1 pipeline; rationalization
+#                     tracked in `issue`. Either promote to model, keep ingest-only,
+#                     or remove from ingest.
+#   defensive       — accepted as part of a defensive allow-list to catch a class of
+#                     attacker-controlled key; should never be removed without
+#                     security review.
+#   permanent       — intentionally ingest-only forever (defensive or operational).
+#                     `issue` may point at a doc/ADR rather than a tracking issue.
+#
+# Seed populated 2026-05-17 from origin/deployments/phase-3/wave-11 HEAD diff.
+
+nodes:
+  Hadith:
+    - field: grade
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: legacy normalize-v1 emits coarse grade alongside grade_composite; model only has grade_composite
+    - field: sect
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: emitted by normalize-v1; model derives sect via has_shia_parallel / has_sunni_parallel pair
+    - field: collection_name
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: denormalized join from APPEARS_IN edge; consider removing once query layer joins efficiently
+    - field: book_number
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: emitted by normalize-v1; model carries via APPEARS_IN edge book_number
+    - field: chapter_number
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: emitted by normalize-v1; model carries via APPEARS_IN edge chapter_number
+    - field: hadith_number
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: emitted by normalize-v1; model carries hadith_number_in_book via APPEARS_IN edge
+    - field: chapter_name_ar
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: denormalized chapter context; not on model; candidate for removal
+    - field: chapter_name_en
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: denormalized chapter context; not on model; candidate for removal
+  Narrator:
+    - field: name_ar_normalized
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: pre-computed normalized form for index lookups; consider promoting to model
+    - field: transmission_method
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: per-edge attribute on TRANSMITTED_TO; ingesting on node is a denormalization
+  Collection:
+    - field: source_corpus
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: present on Hadith model and Collection ingest; consider promoting to Collection model
+
+edges:
+  APPEARS_IN:
+    - field: hadith_number
+      category: phase-3-legacy
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#35
+      note: legacy normalize-v1 emits both hadith_number and hadith_number_in_book on APPEARS_IN; AppearsIn model only has hadith_number_in_book. Decide which is canonical.

--- a/scripts/model-extras.yaml
+++ b/scripts/model-extras.yaml
@@ -1,0 +1,103 @@
+# Model-only property exclusions.
+#
+# Pydantic-model fields in src/models/ that workers/ingest/schema.py deliberately
+# omits from NODE_PROPERTY_MAP / EDGE_PROPERTY_MAP. Each entry must have a rationale
+# and a tracking issue (or a doc/ADR ref for `permanent` category).
+#
+# Used by scripts/emit_ingest_schema.py to suppress drift-failure on these specific
+# fields. Anything on a model that is not in this file AND not in the ingest
+# allow-list will fail the schema-drift CI gate — that's exactly the silent-drop
+# failure mode noorinalabs/noorinalabs-isnad-ingest-platform#24 was filed to catch.
+#
+# Categories:
+#   enrichment-only  — populated only by post-ingest Phase-4 enrichment pipeline.
+#                      Including it in ingest's allow-list would let an
+#                      unenriched batch overwrite the enriched value with null.
+#                      The rationale text below is taken verbatim from
+#                      workers/ingest/schema.py docstring `Fields intentionally
+#                      omitted` section, attribution: PR #18 D-ii.
+#   merge-key        — used in the Cypher MERGE clause itself, never re-SET on
+#                      properties. `id` on every node falls in this bucket.
+#   todo-rationalize — model field with no clear answer on whether ingest should
+#                      pick it up; do not silently drop without explicit decision.
+#                      Decision tracked in `issue`.
+#
+# Seed populated 2026-05-17 from origin/deployments/phase-3/wave-11 HEAD diff and
+# verbatim rationale from workers/ingest/schema.py @ 58fb249.
+
+nodes:
+  Hadith:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET (per workers/ingest/schema.py docstring)
+    - field: topic_tags
+      category: todo-rationalize
+      issue: noorinalabs/noorinalabs-isnad-graph#24
+      note: model carries Phase-4 topic classifier output; ingest currently ignores. Decide promote vs. keep enrichment-only.
+    - field: has_shia_parallel
+      category: todo-rationalize
+      issue: noorinalabs/noorinalabs-isnad-graph#24
+      note: derived field; emitted by normalize? Verify before promote.
+    - field: has_sunni_parallel
+      category: todo-rationalize
+      issue: noorinalabs/noorinalabs-isnad-graph#24
+      note: derived field; emitted by normalize? Verify before promote.
+  Narrator:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET (per workers/ingest/schema.py docstring)
+    - field: aliases
+      category: todo-rationalize
+      issue: noorinalabs/noorinalabs-isnad-graph#24
+      note: list[str] alternate name forms; likely should be ingested. Pending data-team decision.
+    - field: betweenness_centrality
+      category: enrichment-only
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: exclusively populated by post-ingest enrichment (narrator centrality); excluded so unenriched batch doesn't wipe it out
+    - field: in_degree
+      category: enrichment-only
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: exclusively populated by post-ingest enrichment; excluded so unenriched batch doesn't wipe it out
+    - field: out_degree
+      category: enrichment-only
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: exclusively populated by post-ingest enrichment; excluded so unenriched batch doesn't wipe it out
+    - field: pagerank
+      category: enrichment-only
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: exclusively populated by post-ingest enrichment (pagerank); excluded so unenriched batch doesn't wipe it out
+    - field: community_id
+      category: enrichment-only
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: exclusively populated by post-ingest enrichment (Louvain); excluded so unenriched batch doesn't wipe it out
+  Collection:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET
+  Chain:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET
+  Grading:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET
+  HistoricalEvent:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET
+  Location:
+    - field: id
+      category: merge-key
+      issue: noorinalabs/noorinalabs-isnad-ingest-platform#18
+      note: matched in MERGE clause, never re-SET
+
+edges:
+  # Phase-3 edges currently align cleanly with edge models. New entries follow the
+  # same shape as nodes when divergence is introduced.


### PR DESCRIPTION
## Summary

Implements the **isnad-graph side** of noorinalabs/noorinalabs-isnad-ingest-platform#24 — a cross-repo Pydantic-model → ingest-allow-list codegen tool plus a CI drift gate that fails any PR introducing unrationalized divergence between this repo's `src/models/*.py` and `noorinalabs-isnad-ingest-platform/workers/ingest/schema.py`.

Closes noorinalabs/noorinalabs-isnad-ingest-platform#24.

Pair with the parallel **ingest-platform marker PR** (1-line docstring update in `workers/ingest/schema.py`: `#192` → `#24`) that ships in noorinalabs-isnad-ingest-platform under Sayed Reza's identity.

## Cross-repo coordination + identity-charter pivot

Sayed Reza (ingest-platform System Architect) authored the implementation in his own isnad-graph worktree as the cross-repo coordinator. The isnad-graph identity hook (Hook 5) correctly blocked him from committing under his own identity in this repo — committers in a child repo must come from that repo's own roster per [`feedback_child_repo_implementer_rule`](../../noorinalabs-main/.claude/) ("Child-repo implementer rule"). Arjun Raghavan (isnad-graph System Architect) commits the code with full Co-Authored-By credit; Sayed ships the parallel marker PR in ingest-platform under his own identity (valid there).

This is the **identity-charter pivot** referenced in the brief: the cross-repo design work belongs to Sayed, the in-repo commit identity belongs to Arjun.

## What's in this PR

| File | LOC | Purpose |
|---|---|---|
| `scripts/emit_ingest_schema.py` | 336 | `emit` + `check` subcommands. AST-based ingest parsing (no runtime execution). Bidirectional drift logic. |
| `scripts/model-extras.yaml` | 104 | 16 entries: 5 enrichment-only + 7 merge-key + 4 todo-rationalize. Model fields ingest deliberately omits. |
| `scripts/ingest-extras.yaml` | 78 | 12 entries: phase-3-legacy fields ingest accepts but model doesn't define (all → ingest-platform#35 for rationalization). |
| `.github/workflows/schema-drift.yml` | 88 | Sparse-checkout sibling repo, wave-aware ref resolution, fail-on-divergence gate. |

## Sayed's bidirectional-drift design rationale

The drift detector catches **two failure modes**:

1. **Model → ingest drop** (the failure case ingest-platform#24 was filed to catch): a Pydantic model field that ingest does NOT accept AND is NOT excused in `model-extras.yaml`. Today this means an unrationalized silent prop-drop; without this gate, the bug would only surface when query layer reads the missing field.
2. **Ingest → model phantom**: a field in ingest's allow-list that is NOT on the Pydantic model AND is NOT excused in `ingest-extras.yaml`. Catches the inverse case — model field renamed/removed but ingest still merging the old name.

The **two-YAML split** with distinct category enums reflects an intentional asymmetry: model is the canonical schema, ingest is a downstream consumer with its own constraints (security allow-list + Phase-3 legacy denormalized fields). Collapsing into a single exclusions file would hide which side is the source of truth.

The **`todo-rationalize` category** (4 entries — Hadith `topic_tags`/`has_shia_parallel`/`has_sunni_parallel`, Narrator `aliases`) is the gate's first-class mechanism for "needs a decision" — it stops silent drops without forcing a premature promote/keep call. Decisions tracked under #24.

The **`phase-3-legacy` category** (12 entries) routes through ingest-platform#35 (the legacy-rationalization follow-up Sayed filed) — promote-to-model vs. keep-ingest-only vs. remove-from-ingest decisions are bulked there rather than scattered.

The **per-relationship `EDGE_ENDPOINT_FIELDS`** correctly handles the subtle case where the same field name is an endpoint on one relationship and a SET-property on another (e.g. `location_id` is the TO-endpoint of `BASED_IN` but a SET property on `STUDIED_UNDER`). A global endpoints set would mishandle this.

## Live-trace verification (Arjun, independent re-run)

Per [[feedback_live_trace_over_synthetic_acceptance]] — re-ran Sayed's three verification scenarios in my own isolation worktree against `origin/deployments/phase-3/wave-11` HEAD of both repos:

**TEST 1 — clean state** (unmodified `origin/deployments/phase-3/wave-11:workers/ingest/schema.py` copied to `/tmp`):
```
$ uv run python scripts/emit_ingest_schema.py check --ingest-schema /tmp/ingest_schema_clean.py
schema-drift: clean. Models and ingest allow-list converge (after applying rationalized extras).
exit=0
```

**TEST 2 — synthetic drift-1** (deleted `matn_ar` from a `/tmp` copy of ingest schema):
```
$ uv run python scripts/emit_ingest_schema.py check --ingest-schema /tmp/ingest_schema_drift1.py
schema-drift: found 1 unrationalized divergence(s) ...
  - [node:Hadith] model field 'matn_ar' is NOT in ingest NODE_PROPERTY_MAP/EDGE_PROPERTY_MAP and NOT in model-extras.yaml. ...
exit=1
```

**TEST 3 — synthetic drift-2** (injected `fake_phantom_field` into `/tmp` copy of ingest schema):
```
$ uv run python scripts/emit_ingest_schema.py check --ingest-schema /tmp/ingest_schema_drift2.py
schema-drift: found 1 unrationalized divergence(s) ...
  - [node:Hadith] ingest allow-list contains 'fake_phantom_field' which is NOT on the Pydantic model AND NOT in scripts/ingest-extras.yaml. ...
exit=1
```

All three behaved exactly as Sayed reported.

## Additional verification

- **Independent extras-coverage check**: derived the divergence set from `git show origin/deployments/phase-3/wave-11:src/models/*.py` against `origin/deployments/phase-3/wave-11:workers/ingest/schema.py` in both repos. Sayed's `model-extras.yaml` + `ingest-extras.yaml` cover EXACTLY the divergence — zero silent drops, zero unrationalized phantoms. (Per [[feedback_origin_over_local_for_still_has_claims]] / [[feedback_canonical_source_via_git_show]] — read from `git show origin/...`, not worktree.)
- **`ruff check` + `ruff format --check`** at pinned `0.15.11`: both clean ([[feedback_ruff_format_check_before_push]] — pre-push, not post-CI-fail).
- **`actionlint`** with `shellcheck` on PATH ([[feedback_actionlint_needs_shellcheck]]): clean.
- **Wave-aware sibling ref resolution** via `gh api repos/.../branches/$BASE_REF` with explicit main fallback per [[feedback_cross_repo_wave_ref_resolution]] (deploy#159 W10 lesson).
- **Sparse-checkout-failure guard** (`if [ ! -f _sibling/workers/ingest/schema.py ]; then ... exit 1; fi`) catches the silent-no-op family per [[feedback_gh_pr_edit_silent_noop]].

## Architect review (Arjun)

Reviewed Sayed's code + design in full before commit. **No refinements applied; committing verbatim.**

- **Drift logic** — bidirectional check is correct; AST-based parsing is the right trade-off (CI doesn't need ingest's runtime env, just its schema file).
- **Two-YAML asymmetry** — correct factoring. Single combined file would conflate source-of-truth with consumer constraint.
- **Per-relationship endpoint set** — handles the `location_id` cross-edge semantic subtlety.
- **Workflow shape** — sparse-checkout (minimal blast radius), wave-aware ref, pinned-major actions, explicit sparse-failure guard. Meets W11 charter.

## TechDebt

**TechDebt: none**

This PR adds no new TODO/FIXME markers, no skipped tests, no `# noqa`/`// nolint` pragmas, and no temporary scaffolding. All extras entries carry explicit rationale + tracking-issue refs per the gate's own contract. The 4 `todo-rationalize` entries are the gate's first-class mechanism for tracking "needs a decision" fields without silently dropping them — they're a feature of the design, not tech debt.

## Reviewers

- **Primary**: @anya-kowalczyk — model schema + code logic (Pydantic introspection, AST parsing, bidirectional drift correctness)
- **Secondary**: @jelani-mwangi — workflow file + cross-repo ref resolution (sparse-checkout, wave-aware ref, sparse-failure guard)

## Test plan

- [x] `uv run python scripts/emit_ingest_schema.py check --ingest-schema <clean>` exits 0 (re-run in worktree against origin HEAD)
- [x] `uv run python scripts/emit_ingest_schema.py check --ingest-schema <drift-1>` exits 1 with correct model→ingest message
- [x] `uv run python scripts/emit_ingest_schema.py check --ingest-schema <drift-2>` exits 1 with correct ingest→model message
- [x] `ruff check scripts/emit_ingest_schema.py` clean (pinned 0.15.11)
- [x] `ruff format --check scripts/emit_ingest_schema.py` clean
- [x] `actionlint .github/workflows/schema-drift.yml` clean (with shellcheck on PATH)
- [x] Independent extras-coverage diff: `model-extras.yaml` + `ingest-extras.yaml` exactly cover all model↔ingest divergence at `origin/deployments/phase-3/wave-11` HEAD
- [ ] CI `schema-drift` job passes on this PR (verify in checks)
- [ ] Sayed's parallel ingest-platform marker PR opens + cross-refs back to this PR
