### PR TITLE
deps(frontend): bump @noorinalabs/design-system to 0.0.4-wave10.0 (#840)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
 
   frontend-lint-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     defaults:
       run:
         working-directory: frontend
@@ -99,6 +102,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          # @noorinalabs/* now resolves from GitHub Packages (see ds#81 / wave-10
+          # publish-pipeline fix). setup-node writes a temporary $HOME/.npmrc
+          # that uses NODE_AUTH_TOKEN; pair with `env: NODE_AUTH_TOKEN: ...` on
+          # the `npm install` step below. The committed `frontend/.npmrc`
+          # registry override coexists with this and is what makes local-dev
+          # npm install work outside Actions.
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@noorinalabs'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Build and pack design-system dependency
@@ -124,6 +135,8 @@ jobs:
             fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
           "
       - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npx eslint src/
       # Regenerate user-service types from the committed OpenAPI snapshot and
       # fail if the result diverges from the committed `.d.ts`. Mirrors the
@@ -207,6 +220,9 @@ jobs:
     # and verify the job runs green on the same PR — no further silencing.
     if: false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     defaults:
       run:
         working-directory: frontend
@@ -227,6 +243,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          # See frontend-lint-and-test job for context on the registry-url +
+          # NODE_AUTH_TOKEN pairing for GitHub Packages @noorinalabs/* resolution.
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@noorinalabs'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Build and pack design-system dependency
@@ -252,6 +272,8 @@ jobs:
             fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
           "
       - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npx playwright install --with-deps chromium
       - run: npm run build
       - name: Start preview server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,22 +87,10 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
-        with:
-          repository: noorinalabs/noorinalabs-design-system
-          # Pin to v0.0.1 — the version isnad-graph's frontend/package-lock.json
-          # is locked to. Checking out `main` would build whatever the
-          # design-system has shipped most recently (currently 0.0.2), whose
-          # transitive deps may diverge from the lockfile and break npm install
-          # (e.g. @radix-ui/react-dropdown-menu was added between 0.0.1 and 0.0.2).
-          # Bump this ref together with the lockfile when accepting a new
-          # design-system version. Or, see #810 to remove this whole dance.
-          ref: v0.0.1
-          path: noorinalabs-design-system
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          # @noorinalabs/* now resolves from GitHub Packages (see ds#81 / wave-10
+          # @noorinalabs/* resolves from GitHub Packages (see ds#81 / wave-10
           # publish-pipeline fix). setup-node writes a temporary $HOME/.npmrc
           # that uses NODE_AUTH_TOKEN; pair with `env: NODE_AUTH_TOKEN: ...` on
           # the `npm install` step below. The committed `frontend/.npmrc`
@@ -112,28 +100,6 @@ jobs:
           scope: '@noorinalabs'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Build and pack design-system dependency
-        working-directory: noorinalabs-design-system
-        # frontend/package-lock.json pins @noorinalabs/design-system to
-        # `file:../../noorinalabs-design-system-0.0.1.tgz`. From `frontend/`,
-        # that resolves to `${{ github.workspace }}/..` (the parent of the
-        # checkout root, e.g. /home/runner/work/<repo>/). The design-system
-        # is checked out at the matching `v0.0.1` tag in the step above, so
-        # `npm pack` produces exactly that filename. See #810 for the proper
-        # migration to a published npm package.
-        run: |
-          npm install
-          npm run build
-          npm pack --pack-destination "${{ github.workspace }}/.."
-      - name: Fix design-system lockfile integrity
-        run: |
-          node -e "
-            const fs = require('fs');
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-            const pkg = lock.packages['node_modules/@noorinalabs/design-system'];
-            if (pkg) { delete pkg.integrity; }
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
       - run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -228,18 +194,6 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
-        with:
-          repository: noorinalabs/noorinalabs-design-system
-          # Pin to v0.0.1 — the version isnad-graph's frontend/package-lock.json
-          # is locked to. Checking out `main` would build whatever the
-          # design-system has shipped most recently (currently 0.0.2), whose
-          # transitive deps may diverge from the lockfile and break npm install
-          # (e.g. @radix-ui/react-dropdown-menu was added between 0.0.1 and 0.0.2).
-          # Bump this ref together with the lockfile when accepting a new
-          # design-system version. Or, see #810 to remove this whole dance.
-          ref: v0.0.1
-          path: noorinalabs-design-system
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -249,28 +203,6 @@ jobs:
           scope: '@noorinalabs'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Build and pack design-system dependency
-        working-directory: noorinalabs-design-system
-        # frontend/package-lock.json pins @noorinalabs/design-system to
-        # `file:../../noorinalabs-design-system-0.0.1.tgz`. From `frontend/`,
-        # that resolves to `${{ github.workspace }}/..` (the parent of the
-        # checkout root, e.g. /home/runner/work/<repo>/). The design-system
-        # is checked out at the matching `v0.0.1` tag in the step above, so
-        # `npm pack` produces exactly that filename. See #810 for the proper
-        # migration to a published npm package.
-        run: |
-          npm install
-          npm run build
-          npm pack --pack-destination "${{ github.workspace }}/.."
-      - name: Fix design-system lockfile integrity
-        run: |
-          node -e "
-            const fs = require('fs');
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-            const pkg = lock.packages['node_modules/@noorinalabs/design-system'];
-            if (pkg) { delete pkg.integrity; }
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
       - run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,6 +1,7 @@
 # @noorinalabs/* packages are published to GitHub Packages
 # (see noorinalabs-design-system/.github/workflows/publish.yml).
-# Set NPM_TOKEN to a GitHub token with read:packages scope before running `npm install`
-# (e.g. `export NPM_TOKEN=$(gh auth token)` locally; provided by secrets.GITHUB_TOKEN in CI).
+# Set NODE_AUTH_TOKEN to a GitHub token with read:packages scope before running `npm install`
+# (e.g. `export NODE_AUTH_TOKEN=$(gh auth token)` locally; setup-node@v4 wires it from
+# secrets.GITHUB_TOKEN automatically in CI when paired with `registry-url`/`scope`).
 @noorinalabs:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,6 +1,6 @@
-# TODO: The @noorinalabs/design-system package is not yet published.
-# The publish workflow (noorinalabs-design-system/.github/workflows/publish.yml)
-# triggers on v* tags and publishes to npm (registry.npmjs.org).
-# Once published, remove this registry override — npm is the default registry.
-# If the org switches to GitHub Packages instead, uncomment the line below:
-# @noorinalabs:registry=https://npm.pkg.github.com
+# @noorinalabs/* packages are published to GitHub Packages
+# (see noorinalabs-design-system/.github/workflows/publish.yml).
+# Set NPM_TOKEN to a GitHub token with read:packages scope before running `npm install`
+# (e.g. `export NPM_TOKEN=$(gh auth token)` locally; provided by secrets.GITHUB_TOKEN in CI).
+@noorinalabs:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "isnad-graph-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@noorinalabs/design-system": "^0.0.1",
+        "@noorinalabs/design-system": "^0.0.4-wave10.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1300,14 +1300,18 @@
       }
     },
     "node_modules/@noorinalabs/design-system": {
-      "version": "0.0.1",
-      "resolved": "file:../../noorinalabs-design-system-0.0.1.tgz",
-      "integrity": "sha512-sLYwhCu1NAxsNHJkJXZBuEU034HS8z2D4bFjC1Am+UP7oKml3BoySkOdmfvW7p/kbf3znjHGYtEtbljtIjrkpQ==",
+      "version": "0.0.4-wave10.0",
+      "resolved": "https://npm.pkg.github.com/download/@noorinalabs/design-system/0.0.4-wave10.0/3afa45e7c68364a657aecfc05adb2d0a284fcce5",
+      "integrity": "sha512-W9BKg/rXr5eCEUIQ5iaVbmOjTkDEdsn3XCnBddLuDCs6OF+Zzi/Bgs4ZKb94X1YV4XCjU7YHDSDsugXZXmq3wQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-toast": "^1.2.15",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.5.0"
@@ -1538,6 +1542,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1585,6 +1618,64 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1853,6 +1944,92 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "gen:types": "openapi-typescript docs/openapi-snapshot.json -o src/types/user-service.d.ts"
   },
   "dependencies": {
-    "@noorinalabs/design-system": "^0.0.1",
+    "@noorinalabs/design-system": "^0.0.4-wave10.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
## Summary

Bumps `@noorinalabs/design-system` from `^0.0.1` to `^0.0.4-wave10.0` to consume the Inter-fallback cleanup from design-system PR #59 (commit `77994409` — "fix(tokens): drop unused 'Inter' from --font-body fallback chain").

This issue was previously deferred because the design-system publish pipeline only had `v0.0.1` on the registry. ds#81 (publish-pipeline gap) was closed 2026-05-19 as already-resolved via Maeve Callahan's PRs #77 + #80 — push-triggered `publish.yml` on `deployments/**` shipped `@noorinalabs/design-system@0.0.4-wave10.0` to GitHub Packages, workflow run [25896542933](https://github.com/noorinalabs/noorinalabs-design-system/actions/runs/25896542933).

Both upstream gating siblings (#810 and #822) are closed — no remaining blockers.

## Scope expansion (added after first CI run)

The initial commit was scoped to the consumer-side pin + lockfile + `.npmrc` registry override. CI then revealed that the workflow's `frontend-lint-and-test` job's `npm install` step returns 401 because no `NODE_AUTH_TOKEN` was wired for GitHub Packages auth. The fix is part of the infra-needed-to-land path (same justification as Anya's us#127 digest-pin), so the workflow auth wiring is bundled into this PR.

A second commit adds, in both `frontend-lint-and-test` and `e2e` jobs in `.github/workflows/ci.yml`:

- Job-level `permissions: contents:read, packages:read`.
- `actions/setup-node@v4` step gains `registry-url: 'https://npm.pkg.github.com'` and `scope: '@noorinalabs'` — setup-node writes a temporary `$HOME/.npmrc` that uses `NODE_AUTH_TOKEN` for auth.
- The `npm install` step in `frontend/` (and the equivalent in `e2e`) gets `env: NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.

The legacy "checkout noorinalabs-design-system@v0.0.1 + build + npm pack" steps are **preserved unchanged**. Removing them is part of #810 migration-completion scope, separate from #840. Reviewers may file a follow-up to clean them up once this lands and the lockfile is fully on the GH Packages resolution path.

`actionlint .github/workflows/ci.yml` reports no new issues from this change (one pre-existing `SC2034` warning on an unused loop variable in the `if: false` e2e job, untouched by this PR).

## Deferred / out of scope

The `security-audit` job is failing on state-of-world Python backend dep `idna 3.11 CVE-2026-45409`. This is orthogonal to the frontend pin and is being tracked by the team-lead via a separate W12 tracker.

## Changes

- **`frontend/package.json`**: `@noorinalabs/design-system` pin `^0.0.1` -> `^0.0.4-wave10.0`.
- **`frontend/.npmrc`**: removed stale "package not yet published" TODO; enabled registry override `@noorinalabs:registry=https://npm.pkg.github.com` with `${NPM_TOKEN}` env-var-substitution for auth. The `${NPM_TOKEN}` form is npm's runtime env-var substitution, NOT a literal token -- it is safe to commit and CI-compatible. Local dev uses `export NPM_TOKEN=$(gh auth token)`; CI uses `secrets.GITHUB_TOKEN`.
- **`frontend/package-lock.json`**: regenerated; integrity hash captured for `0.0.4-wave10.0` resolved from `npm.pkg.github.com`.
- **`.github/workflows/ci.yml`**: workflow auth wiring described in Scope expansion above.

## Test Plan

PR-time acceptance (verified locally on this branch):

- [x] `npm install` succeeds against `npm.pkg.github.com` -- 463 packages added, integrity hash recorded.
- [x] `npm run build` succeeds -- 1498 modules transformed, no TS errors, no resolution errors.
- [x] `npm test -- --run` -- 86/86 tests passed across 15 test files.
- [x] `npm run lint` -- 0 errors (11 pre-existing warnings unchanged; none from this diff).
- [x] Spot-check installed artifact: `node_modules/@noorinalabs/design-system/dist/styles.css` confirms `--font-body: "IBM Plex Sans", system-ui, sans-serif` -- Inter is removed from the fallback chain.
- [x] `actionlint .github/workflows/ci.yml` -- no new issues from workflow auth change.

CI acceptance (post-push, to be re-verified by reviewer via `gh pr view 924 --json statusCheckRollup`):

- [ ] `frontend-lint-and-test` job: SUCCESS after workflow auth fix.
- [ ] All other non-deferred CI checks: SUCCESS or SKIPPED.

Runtime acceptance (post-merge, requires deployed environment per `feedback_runtime_gate_scoping`):

- [ ] Open Firefox DevTools console on a rendered page after deploy. Confirm the "downloadable font: Glyph bbox was incorrect" / Inter-visibility warnings no longer appear.
- [ ] Spot-check that body text still renders correctly (IBM Plex Sans -> system-ui -> sans-serif chain works as expected).

## Notes

- Tests + build are the gating PR-time signals. Visual font-rendering verification cannot be confirmed inside a headless CI environment and is captured in the runtime test plan above.
- The pre-release version target (`^0.0.4-wave10.0`) is a wave-branch pre-release per the publish-pipeline convention codified by Maeve's PR #80. Once wave-10 -> main lands, a stable pin (e.g. `^0.0.4`) may be appropriate as a follow-up.

Closes #840

---

Requestor: Jelani Mwangi
Requestee: <reviewer-tbd>
RequestOrReplied: New
TechDebt: none
