### PR TITLE
ci: bump Node-20 actions to Node-24 (#928)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
           uv run pip-audit --strict --desc -r /tmp/requirements.txt --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645
       - name: Secret detection with gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v2.3.9 # node20 runtime: no node24 release on gitleaks-action; accepted-with-warning per owner 2026-05-28, revisit #929
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -87,7 +87,7 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           # @noorinalabs/* resolves from GitHub Packages (see ds#81 / wave-10
@@ -194,7 +194,7 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           # See frontend-lint-and-test job for context on the registry-url +

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -72,14 +72,14 @@ jobs:
             platforms: linux/amd64
     steps:
       - name: Checkout (isnad-graph)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Frontend only: stage the design-system tarball into the build context
       # so the Dockerfile's `COPY noorinalabs-design-system-0.0.1.tgz /` works.
       # GITHUB_TOKEN works cross-repo because both repos are in the same org.
       - name: Checkout design-system (frontend only)
         if: matrix.component == 'frontend'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: noorinalabs/noorinalabs-design-system
           ref: ${{ env.DESIGN_SYSTEM_REF }}
@@ -128,13 +128,13 @@ jobs:
 
       - name: Set up QEMU (multi-arch)
         if: contains(matrix.platforms, 'arm64')
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image }}
           # Tag scheme (isnad-graph#815 Contract v5 = option C, 2026-04-23):
@@ -172,7 +172,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -221,7 +221,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Trigger deploy repo
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DEPLOY_REPO_PAT }}
           repository: noorinalabs/noorinalabs-deploy


### PR DESCRIPTION
## Summary

GitHub forces all actions to the **Node.js 24 runtime on 2026-06-02** and deprecates Node-20 actions. This bumps the affected actions across both isnad-graph workflows.

### `ci.yml`
- `actions/setup-node@v4` → `@v6` (2 occurrences; tag-pinned)
- `gitleaks/gitleaks-action@v2` → `@v2.3.9` — **intentionally left at v2**: gitleaks-action has no Node-24 release. Pinned to the latest v2 tag (was floating `@v2`) with an inline `# node20 runtime: ... accepted-with-warning per owner 2026-05-28, revisit #929` comment. Left fully functional, not replaced.

### `ghcr-publish.yml` (SHA-pinned — hardening preserved)
Re-pinned each to the **new major's current commit SHA** (not switched to floating tags), keeping supply-chain hardening intact:

| Action | Old | New SHA | Tag |
|---|---|---|---|
| `actions/checkout` | v4.2.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6 |
| `docker/setup-qemu-action` | v3.6.0 | `06116385d9baf250c9f4dcb4858b16962ea869c3` | v4 |
| `docker/setup-buildx-action` | v3.10.0 | `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` | v4 |
| `docker/login-action` | v3.4.0 | `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` | v4 |
| `docker/metadata-action` | v5.7.0 | `80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9` | v6 |
| `docker/build-push-action` | v6.16.0 | `f9f3042f7e2789586610d6e8b85c8f03e5195baf` | v7 |
| `peter-evans/repository-dispatch` | @v3 | _(tag-pinned)_ | @v4 |

`checkout` appears twice (isnad-graph + design-system) — both re-pinned.

### Notes
- All target majors verified `using: node24` via each action's `action.yml`.
- `trivy-action` is a **composite** action (no Node runtime — unaffected); `setup-uv@v7` / `cache@v5` / `upload-artifact@v7` were already on node24 majors, so no further bumps needed.
- The `notify-deploy` dispatch contract (`event-type: deploy-noorinalabs-isnad-graph`, `client-payload`) is unchanged.

Closes #928
Refs noorinalabs/noorinalabs-main#536

TechDebt: none
