### PR TITLE
security: bump starlette 0.52.1->1.2.0 (PYSEC-2026-161 Host-header auth-bypass)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "structlog>=24.1",
     "python-dotenv>=1.0",
     "fastapi>=0.115",
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.34",
     "authlib>=1.3",
     "python-jose[cryptography]>=3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -498,6 +498,7 @@ dependencies = [
     { name = "python-jose", extra = ["cryptography"] },
     { name = "pyyaml" },
     { name = "redis" },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -535,6 +536,7 @@ requires-dist = [
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "redis", specifier = ">=5.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
@@ -848,15 +850,15 @@ wheels = [
 
 [[package]]
 name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prometheus-client" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357, upload-time = "2026-05-29T13:04:43.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ad/b14ed2fe73bb1d37bcc947e75afae018f795526415d5b849aeb99c403cd1/prometheus_fastapi_instrumentator-8.0.0-py3-none-any.whl", hash = "sha256:e3c967c402124dfe81cf5aad35208d9f96db5452c6cb752350d9358ca0a96198", size = 19411, upload-time = "2026-05-29T13:04:44.17Z" },
 ]
 
 [[package]]
@@ -1297,14 +1299,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**PYSEC-2026-161** — Host-header auth-bypass in starlette < 1.0.1. isnad-graph was pinned at starlette 0.52.1 (transitively, via fastapi `>=0.115` with no explicit floor). This adds an explicit `starlette>=1.0.1` pin in `pyproject.toml` and regenerates the lockfile; the resolver picked starlette 1.2.0 (latest at lock time, above the security floor).

Companion to noorinalabs/noorinalabs-user-service#135 (M.Salazar, merged 2026-05-28). That was a trivial 1.0.0→1.0.1 patch since user-service was already on 1.0.x. This is the harder **0.52.1 → 1.2.0 major-version jump** for isnad-graph.

## Changes

- `pyproject.toml`: add `starlette>=1.0.1` (explicit floor)
- `uv.lock`: regenerate — starlette `0.52.1 → 1.2.0`. Transitively bumps `prometheus-fastapi-instrumentator 7.1.0 → 8.0.0` (instrumentator's required dep for starlette 1.x ABI; clean major). fastapi unchanged at 0.135.2 (per user-service#134 evidence: fastapi 0.135.x supports starlette 1.x).

## Verification (audited at HEAD, no app code changes)

Starlette imports audited across isnad-graph source tree:

- `src/api/middleware.py` (3 imports): `BaseHTTPMiddleware`, `RequestResponseEndpoint`, `Request`, `Response` — all stable across the 1.0 ABI (no `dispatch` signature change, no method removal).
- `tests/test_api/test_request_logging.py` (5 imports): `Starlette`, `Request`, `JSONResponse`, `Route`, `TestClient` — all stable.
- **No `SessionMiddleware` / `TrustedHostMiddleware` / `HTTPSRedirectMiddleware` uses anywhere** — the PYSEC-2026-161 surface itself (Host-header validation) isn't directly invoked by isnad-graph code. The fix is purely the dep bump.

CI security-audit will rerun on push and should resolve PYSEC-2026-161 cleanly. Test job will verify no functional regression.

## Downstream

Unblocks **PR #930**'s `security-audit` check, which has been RED on main due to this vuln since the audit gate was added.

## Notes on authorship

Audit work (starlette import enumeration, ABI stability assessment, fastapi compat verification) is Idris Yusuf's. Final commit/push performed by the orchestrator after a 9-hour throttle stall in the implementer's session post-pytest-launch; per the team's throttle-takeover pattern (`feedback_throttle_takeover`), the orchestrator preserves the implementer's commit identity rather than respawning. The verification work was complete before the stall; only the commit/push step needed handoff.

Closes #931
Refs noorinalabs/noorinalabs-main#536

TechDebt: none
