### PR TITLE
tech-debt(frontend): runtime-config.js for env-specific origins (Refs #932)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,7 +21,18 @@ RUN npm run build
 # alpine 3.23 patch lifecycle. Re-pin to a newer digest on each minor nginx
 # bump (or alpine 3.24+ when nginx publishes it).
 FROM nginx:stable-alpine3.23@sha256:0272e4604ed93c1792f03695a033a6e8546840f86e0de20a884bb17d2c924883
-RUN apk upgrade --no-cache
+# gettext provides `envsubst`, used by entrypoint.sh to render runtime-config.js
+# from its template at container start (isnad-graph#932).
+RUN apk upgrade --no-cache && apk add --no-cache gettext
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Runtime-config injection: the entrypoint renders /runtime-config.js from the
+# committed template (envsubst with USER_SERVICE_ORIGIN from the compose
+# environment) before handing off to nginx. Lets one image digest target
+# env-specific origins at runtime. See isnad-graph#932 / deploy#245 step 5.
+COPY runtime-config.js.template /runtime-config.js.template
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Container entrypoint: render runtime-config.js from its committed template
+# before starting nginx. envsubst (from the gettext package, installed in the
+# final Dockerfile stage) substitutes only the variables we name explicitly so
+# stray `$`-sequences elsewhere are left untouched.
+#
+# USER_SERVICE_ORIGIN is supplied by the compose `environment:` block
+# (noorinalabs-deploy, templated per env via write-deploy-env). When unset it
+# substitutes to the empty string, preserving the same-origin fallback that the
+# transitional dual-bind relied on. See isnad-graph#932 / deploy#245 step 5.
+set -eu
+
+TEMPLATE=/runtime-config.js.template
+OUTPUT=/usr/share/nginx/html/runtime-config.js
+
+# The single-quoted SHELL-FORMAT argument is deliberate: it is an envsubst
+# allowlist, not a shell expansion. Only ${USER_SERVICE_ORIGIN} is substituted;
+# every other `$`-sequence in the template is left verbatim. shellcheck SC2016
+# would have us double-quote it, which would break the intended behaviour.
+# shellcheck disable=SC2016
+envsubst '${USER_SERVICE_ORIGIN}' < "$TEMPLATE" > "$OUTPUT"
+
+exec "$@"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,11 @@
       rel="stylesheet"
     />
     <title>Isnad Graph — Hadith Analysis Platform</title>
+    <!-- Runtime config: rendered by the container entrypoint (envsubst over
+         runtime-config.js.template). Must load before any module code so
+         window.RUNTIME_CONFIG is set first. 404s in local `npm run dev`
+         (no entrypoint) — readers fall back to VITE_*. See isnad-graph#932. -->
+    <script src="/runtime-config.js"></script>
     <script src="/theme-init.js"></script>
   </head>
   <body>

--- a/frontend/runtime-config.js.template
+++ b/frontend/runtime-config.js.template
@@ -1,0 +1,13 @@
+// Runtime-injected config. The container entrypoint (entrypoint.sh) runs
+// `envsubst` over this template at start-up, writing the result to
+// /usr/share/nginx/html/runtime-config.js, which nginx serves as a static
+// asset. index.html loads it as the first <script> so window.RUNTIME_CONFIG
+// is populated before any module code runs.
+//
+// This indirection lets a single image digest (Contract v6, #815) target
+// env-specific origins at runtime instead of build time — Vite bakes
+// `import.meta.env.VITE_*` into the bundle, which can encode only one value.
+// See isnad-graph#932 / deploy#245 step 5.
+window.RUNTIME_CONFIG = {
+  USER_SERVICE_ORIGIN: "${USER_SERVICE_ORIGIN}",
+};

--- a/frontend/src/__tests__/runtime-config.test.ts
+++ b/frontend/src/__tests__/runtime-config.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Exercises the runtime-config resolution order used at the three
+ * user-service-origin call sites (useAuth.ts, LoginPage.tsx, profile-client.ts):
+ *
+ *   window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN  // runtime (entrypoint-injected)
+ *     || import.meta.env.VITE_USER_SERVICE_ORIGIN  // build-time (local dev)
+ *     || ''                                        // same-origin fallback
+ *
+ * The call sites compute this as a module-level constant at import time, so we
+ * mirror the expression here and drive it with different window/env states.
+ * See isnad-graph#932 / deploy#245 step 5.
+ */
+function resolveOrigin(env: { VITE_USER_SERVICE_ORIGIN?: string }): string {
+  return (
+    (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+    env.VITE_USER_SERVICE_ORIGIN ||
+    ''
+  )
+}
+
+describe('runtime-config origin resolution', () => {
+  beforeEach(() => {
+    delete window.RUNTIME_CONFIG
+  })
+
+  afterEach(() => {
+    delete window.RUNTIME_CONFIG
+  })
+
+  it('prefers window.RUNTIME_CONFIG over the build-time VITE value', () => {
+    window.RUNTIME_CONFIG = { USER_SERVICE_ORIGIN: 'https://users.stg.noorinalabs.com' }
+    expect(resolveOrigin({ VITE_USER_SERVICE_ORIGIN: 'https://build-time.example' })).toBe(
+      'https://users.stg.noorinalabs.com',
+    )
+  })
+
+  it('falls back to the build-time VITE value when RUNTIME_CONFIG is absent (local dev)', () => {
+    // /runtime-config.js 404s under `npm run dev`, so window.RUNTIME_CONFIG stays undefined.
+    expect(resolveOrigin({ VITE_USER_SERVICE_ORIGIN: 'https://users.local.example' })).toBe(
+      'https://users.local.example',
+    )
+  })
+
+  it('falls back to the build-time VITE value when RUNTIME_CONFIG has no origin set', () => {
+    window.RUNTIME_CONFIG = {}
+    expect(resolveOrigin({ VITE_USER_SERVICE_ORIGIN: 'https://users.local.example' })).toBe(
+      'https://users.local.example',
+    )
+  })
+
+  it('treats an empty runtime origin as unset and falls through (envsubst with USER_SERVICE_ORIGIN unset)', () => {
+    window.RUNTIME_CONFIG = { USER_SERVICE_ORIGIN: '' }
+    expect(resolveOrigin({ VITE_USER_SERVICE_ORIGIN: 'https://users.local.example' })).toBe(
+      'https://users.local.example',
+    )
+  })
+
+  it('resolves to same-origin ("") when neither runtime nor build-time origin is set', () => {
+    expect(resolveOrigin({})).toBe('')
+  })
+})
+
+describe('runtime-config module call sites', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    delete window.RUNTIME_CONFIG
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    delete window.RUNTIME_CONFIG
+  })
+
+  it('profile-client picks up the runtime origin set before module import', async () => {
+    window.RUNTIME_CONFIG = { USER_SERVICE_ORIGIN: 'https://users.prod.noorinalabs.com' }
+    // Importing after setting RUNTIME_CONFIG mirrors index.html loading
+    // /runtime-config.js as the first <script>, before the module bundle.
+    const mod = await import('../api/profile-client')
+    // The module computes API_BASE from USER_SERVICE_ORIGIN at import time.
+    // We can't read the private constant, but a fetch through it must target
+    // the runtime origin — assert via a stubbed fetch.
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+    try {
+      // fetchProfile is the public surface; it issues GET against API_BASE.
+      await mod.fetchProfile()
+    } catch {
+      // ignore non-2xx parsing; we only care about the URL the fetch saw
+    }
+    const calledUrl = String(fetchSpy.mock.calls[0]?.[0] ?? '')
+    expect(calledUrl).toContain('https://users.prod.noorinalabs.com')
+    fetchSpy.mockRestore()
+  })
+})

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -1,9 +1,13 @@
 import { emitSessionExpired } from '../hooks/useAuth'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
-// useAuth.ts for the full BASE-constant set; kept duplicated here to avoid
-// a barrel-export refactor inside this PR.
-const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
+// useAuth.ts for the full BASE-constant set and the runtime-vs-build-time
+// resolution rationale; kept duplicated here to avoid a barrel-export refactor
+// inside this PR.
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
 const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
 
 function getAuthHeaders(): HeadersInit {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -72,11 +72,16 @@ export function deriveHighestRole(roleNames: string[]): UserRole {
   return 'trial'
 }
 
-// Absolute URLs targeting the user-service vhost (`users.{base}`). Sourced
-// from `VITE_USER_SERVICE_ORIGIN` so a single image works across environments.
-// Empty/undefined falls back to same-origin (transitional dual-bind on
-// `isnad.{base}` — retired in a separate PR per deploy#245 phase 2 part 2).
-const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
+// Absolute URLs targeting the user-service vhost (`users.{base}`). Resolved at
+// runtime from `window.RUNTIME_CONFIG` (injected by the container entrypoint via
+// /runtime-config.js) so a single image digest targets env-specific origins —
+// Vite can bake only one VITE_* value into the bundle (Contract v6, #815).
+// Falls back to the build-time `VITE_USER_SERVICE_ORIGIN` for local `npm run dev`
+// (no entrypoint), then to '' (same-origin). See isnad-graph#932 / deploy#245 step 5.
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
 const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
 const USER_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users`
 const SESSIONS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/sessions`

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,9 +5,13 @@ import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
-// useAuth.ts for the full BASE-constant set; kept duplicated here to avoid
-// a barrel-export refactor inside this PR.
-const USER_SERVICE_ORIGIN = import.meta.env.VITE_USER_SERVICE_ORIGIN ?? ''
+// useAuth.ts for the full BASE-constant set and the runtime-vs-build-time
+// resolution rationale; kept duplicated here to avoid a barrel-export refactor
+// inside this PR.
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
 const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
 
 function GoogleIcon() {

--- a/frontend/src/runtime-config.d.ts
+++ b/frontend/src/runtime-config.d.ts
@@ -1,0 +1,12 @@
+// Runtime config injected by the container entrypoint via /runtime-config.js
+// (envsubst over runtime-config.js.template). Loaded as the first <script> in
+// index.html so `window.RUNTIME_CONFIG` is populated before any module code
+// runs. Absent in local `npm run dev` (no entrypoint) — readers fall back to
+// `import.meta.env.VITE_USER_SERVICE_ORIGIN`. See isnad-graph#932.
+interface RuntimeConfig {
+  USER_SERVICE_ORIGIN?: string
+}
+
+interface Window {
+  RUNTIME_CONFIG?: RuntimeConfig
+}


### PR DESCRIPTION
## Summary

Runtime-config injection so a single image digest (Contract v6, #815) targets env-specific `USER_SERVICE_ORIGIN` values at runtime instead of Vite build time. **Prereq for deploy#245 step 5** (dropping the transitional user-service dual-bind on `isnad.{base}`).

## Changes

- `frontend/runtime-config.js.template` — committed template; sets `window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN` from `${USER_SERVICE_ORIGIN}`.
- `frontend/entrypoint.sh` — `envsubst` (allowlisted to `USER_SERVICE_ORIGIN`) renders the template into the nginx html root, then `exec "$@"`.
- `frontend/Dockerfile` — `apk add gettext`; COPY template + entrypoint; `ENTRYPOINT ["/entrypoint.sh"]` + `CMD ["nginx", "-g", "daemon off;"]`.
- `frontend/index.html` — `/runtime-config.js` loaded as the first classic `<script>`, before theme-init and the module bundle (verified in built `dist/index.html`).
- `frontend/src/runtime-config.d.ts` — global `window.RUNTIME_CONFIG` declaration.
- `useAuth.ts` / `LoginPage.tsx` / `profile-client.ts` — resolve `window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN || import.meta.env.VITE_USER_SERVICE_ORIGIN || ''` (runtime → build-time-for-local-dev → same-origin).
- `src/__tests__/runtime-config.test.ts` — 6 tests: resolution order + hydration + empty-origin fall-through.

## Verification (local)

- `npm run lint` — 0 errors (pre-existing warnings only, none in changed files).
- `npm run build` (tsc + vite) — clean; built `dist/index.html` preserves script order `runtime-config.js` → `theme-init.js` → module bundle.
- `npx vitest run` — 16 files / 92 tests pass (incl. 6 new).
- `envsubst` render verified both ways: origin set → literal value; origin unset → `""` (same-origin fallback preserved).

## Notes

- Local `npm run dev` keeps working: `/runtime-config.js` 404s (no entrypoint), `RUNTIME_CONFIG` stays undefined, VITE fallback applies.
- Test placed under `src/__tests__/` (repo convention, inside vitest's `src/**` glob) rather than the issue's `frontend/test/` path, which is outside the include glob and would not run.
- Compose wiring (`environment: USER_SERVICE_ORIGIN=https://users.${BASE_DOMAIN}`) lands in noorinalabs-deploy under deploy#245 step 5 — out of scope for this repo's PR.

## TechDebt

TechDebt: none

Refs #932
