### PR TITLE
models: promote 4 ratified ingest fields to Phase-4 Pydantic models (#35)

### DIFF
--- a/src/models/collection.py
+++ b/src/models/collection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from src.models.enums import Sect
+from src.models.enums import Sect, SourceCorpus
 
 __all__ = ["Collection"]
 
@@ -32,6 +32,8 @@ class Collection(BaseModel):
     """Year of compilation in Hijri calendar."""
     sect: Sect
     """Sectarian tradition (Sunni or Shia)."""
+    source_corpus: SourceCorpus
+    """Source corpus from which this collection was acquired."""
     canonical_rank: int | None = None
     """Canonical rank within its tradition (1 = highest authority)."""
     total_hadiths: int | None = None

--- a/src/models/hadith.py
+++ b/src/models/hadith.py
@@ -32,6 +32,10 @@ class Hadith(BaseModel):
     """Consensus or primary grade string."""
     topic_tags: list[str] = Field(default_factory=list)
     """Topic tags populated in Phase 4."""
+    chapter_name_ar: str | None = None
+    """Arabic chapter (bab) title for the hadith's location in its collection."""
+    chapter_name_en: str | None = None
+    """English chapter (bab) title for the hadith's location in its collection."""
     source_corpus: SourceCorpus
     """Source corpus from which this hadith was acquired."""
     has_shia_parallel: bool = False

--- a/src/models/narrator.py
+++ b/src/models/narrator.py
@@ -24,6 +24,8 @@ class Narrator(BaseModel):
     """Full Arabic name."""
     name_en: str
     """Full English transliteration."""
+    name_ar_normalized: str | None = None
+    """Pre-computed normalized form of ``name_ar`` for index/lookup matching."""
     kunya: str | None = None
     """Patronymic, e.g. 'Abu Hurayra'."""
     nisba: str | None = None

--- a/tests/test_models/test_all_models.py
+++ b/tests/test_models/test_all_models.py
@@ -72,6 +72,7 @@ def _collection(**overrides: object) -> Collection:
         "name_ar": "صحيح البخاري",
         "name_en": "Sahih al-Bukhari",
         "sect": Sect.SUNNI,
+        "source_corpus": SourceCorpus.SUNNAH,
     }
     defaults.update(overrides)
     return Collection(**defaults)  # type: ignore[arg-type]
@@ -144,6 +145,7 @@ class TestInstantiation:
         c = _collection()
         assert c.id == "col:test-001"
         assert c.sect == Sect.SUNNI
+        assert c.source_corpus == SourceCorpus.SUNNAH
 
     def test_chain(self) -> None:
         ch = _chain()
@@ -230,6 +232,14 @@ class TestValidation:
     def test_collection_missing_sect(self) -> None:
         with pytest.raises(ValidationError):
             Collection(id="col:x", name_ar="a", name_en="A")  # type: ignore[call-arg]
+
+    def test_collection_missing_source_corpus(self) -> None:
+        with pytest.raises(ValidationError):
+            Collection(id="col:x", name_ar="a", name_en="A", sect=Sect.SUNNI)  # type: ignore[call-arg]
+
+    def test_collection_bad_source_corpus(self) -> None:
+        with pytest.raises(ValidationError):
+            _collection(source_corpus="invalid_corpus")
 
     def test_chain_missing_chain_length(self) -> None:
         with pytest.raises(ValidationError):
@@ -401,7 +411,11 @@ class TestRoundTrip:
     """model_dump() output can reconstruct an identical instance."""
 
     def test_narrator_round_trip(self) -> None:
-        original = _narrator(aliases=["Alias1", "Alias2"], kunya="Abu Test")
+        original = _narrator(
+            aliases=["Alias1", "Alias2"],
+            kunya="Abu Test",
+            name_ar_normalized="اسم",
+        )
         data = original.model_dump()
         rebuilt = Narrator(**data)
         assert rebuilt == original
@@ -410,6 +424,8 @@ class TestRoundTrip:
         original = _hadith(
             matn_en="Deeds are by intentions",
             topic_tags=["faith", "intention"],
+            chapter_name_ar="باب النية",
+            chapter_name_en="Chapter on Intention",
         )
         data = original.model_dump()
         rebuilt = Hadith(**data)
@@ -526,6 +542,7 @@ class TestDefaults:
         assert n.birth_year_ah is None
         assert n.death_year_ah is None
         assert n.aliases == []
+        assert n.name_ar_normalized is None
         assert n.betweenness_centrality is None
         assert n.pagerank is None
 
@@ -534,6 +551,8 @@ class TestDefaults:
         assert h.matn_en is None
         assert h.isnad_raw_ar is None
         assert h.topic_tags == []
+        assert h.chapter_name_ar is None
+        assert h.chapter_name_en is None
         assert h.has_shia_parallel is False
         assert h.has_sunni_parallel is False
 


### PR DESCRIPTION
## What

Owner-ratified resolution of the 4 **PROMOTE** rulings from the #35 rationalization (cross-repo: `noorinalabs/noorinalabs-isnad-ingest-platform#35`). Adds the corresponding fields to the Phase-4 Pydantic node models so the ingest-side schema-drift allow-list entries can be retired.

| Model | Field added | Type | Nullability | Rationale |
|---|---|---|---|---|
| `Hadith` | `chapter_name_ar` | `str \| None` | nullable | Denormalized Arabic chapter (bab) title; real source data with no prior model home. |
| `Hadith` | `chapter_name_en` | `str \| None` | nullable | English counterpart; ruled together with `chapter_name_ar`. |
| `Narrator` | `name_ar_normalized` | `str \| None` | nullable | Pre-computed normalized Arabic name form for index/lookup matching. |
| `Collection` | `source_corpus` | `SourceCorpus` | **non-nullable** | Acquisition provenance of the collection. Mirrors `Hadith.source_corpus` and matches `COLLECTION_SCHEMA`'s `source_corpus` (`nullable=False`). Enum already existed. |

The other 7 ingest-only fields (the KEEP/REMOVE rulings — `grade`, `sect`, `collection_name`, `book_number`, `chapter_number`, `hadith_number`, `transmission_method`) are **not** touched here; they remain ingest-extras (denormalizations of already-modeled node/edge attributes) per the ratified ruling.

## Tests

- `tests/test_models/test_all_models.py`:
  - `_collection` factory now supplies the newly-required `source_corpus`.
  - Added `test_collection_missing_source_corpus` and `test_collection_bad_source_corpus` validation cases.
  - Instantiation + defaults assertions for the new fields; promoted fields exercised in round-trip serialization.
- Local: `ruff@0.15.11 format --check` + `check` clean; `mypy` (strict) clean on the 3 model files; `pytest tests/test_models/test_all_models.py` → 60 passed.

## Sequencing

This PR is the **prerequisite** for the matching `scripts/ingest-extras.yaml` removals on the ingest side — those land only after these model fields merge. The schema-drift gate stays green throughout (the seed still covers every entry until the extras drop).

Refs noorinalabs/noorinalabs-isnad-ingest-platform#35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
