### PR TITLE
fix(ci): complete design-system registry migration for GHCR frontend publish (Refs #940)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -15,12 +15,13 @@
 # workflow dispatched noorinalabs-deploy on every push-to-main without waiting
 # for publish. See isnad-graph#817 and main#145.
 #
-# The frontend build needs the design-system tarball staged into the frontend
-# build context. We check out noorinalabs-design-system @ v0.0.1, run
-# `npm install --omit=dev && npm pack`, and move the .tgz into ./frontend/
-# before docker/build-push-action runs. The frontend Dockerfile's
-# `COPY noorinalabs-design-system-0.0.1.tgz /` step (fixed in #820) expects
-# the tarball at the root of its build context.
+# The frontend build resolves @noorinalabs/design-system from GitHub Packages
+# (npm.pkg.github.com), pinned in frontend/package-lock.json to a registry
+# version. The Dockerfile's `npm ci` reads the read-token from a BuildKit
+# secret (id=node_auth_token); we source that secret from GITHUB_TOKEN
+# (packages:read) below. This replaced the legacy build-time tarball staging
+# (check out design-system @ vX, npm pack, drop the .tgz into ./frontend/) once
+# the lockfile moved to the registry version — see #940 and design-system#57.
 
 name: Publish to GHCR
 
@@ -42,10 +43,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  # Pinned to the version frontend/package-lock.json references. When the
-  # frontend bumps to 0.0.2 (isnad-graph#818), update this AND the
-  # Dockerfile's COPY line and the package-lock together.
-  DESIGN_SYSTEM_REF: v0.0.1
 
 jobs:
   build-and-push:
@@ -73,58 +70,6 @@ jobs:
     steps:
       - name: Checkout (isnad-graph)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      # Frontend only: stage the design-system tarball into the build context
-      # so the Dockerfile's `COPY noorinalabs-design-system-0.0.1.tgz /` works.
-      # GITHUB_TOKEN works cross-repo because both repos are in the same org.
-      - name: Checkout design-system (frontend only)
-        if: matrix.component == 'frontend'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: noorinalabs/noorinalabs-design-system
-          ref: ${{ env.DESIGN_SYSTEM_REF }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: design-system-src
-
-      - name: Build and pack design-system (frontend only)
-        if: matrix.component == 'frontend'
-        working-directory: design-system-src
-        # CRITICAL pattern from ci.yml@f5f413f (Marisol, 2026-04-06):
-        # v0.0.1's package.json declares `files: ["dist"]` with NO prepack /
-        # prepare hook, and `dist/` is not committed. A fresh clone packs an
-        # empty 172-byte tarball (just package.json metadata) unless we run
-        # the build first. We also MUST use plain `npm install` — NOT
-        # `--omit=dev` — because Vite (the builder) is a devDependency.
-        # Sequence: install ALL deps → run build (populates dist/) → pack.
-        run: |
-          npm install
-          npm run build
-          npm pack
-          ls -lh ./*.tgz
-          mv ./noorinalabs-design-system-*.tgz ../frontend/
-
-      - name: Fix design-system lockfile integrity (frontend only)
-        if: matrix.component == 'frontend'
-        working-directory: frontend
-        # Pattern from ci.yml@615a692 (Marisol, 2026-04-06). The committed
-        # frontend/package-lock.json records the integrity hash of the v0.0.1
-        # tarball that was built and packed at release time. A freshly-packed
-        # tarball from source has a different hash (timestamps / filesystem
-        # ordering), which makes `npm ci` inside the Dockerfile fail with
-        # EINTEGRITY. Strip the integrity field from the lockfile entry;
-        # npm then trusts the resolved `file:` path without checksum.
-        # Because this rewrites the lockfile inside the frontend/ build
-        # context (before docker/build-push-action uploads the context),
-        # the Dockerfile's `COPY package.json package-lock.json ./` + `npm ci`
-        # see the patched lockfile and succeed.
-        run: |
-          node -e "
-            const fs = require('fs');
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-            const pkg = lock.packages['node_modules/@noorinalabs/design-system'];
-            if (pkg) { delete pkg.integrity; }
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
 
       - name: Set up QEMU (multi-arch)
         if: contains(matrix.platforms, 'arm64')
@@ -184,6 +129,14 @@ jobs:
           # other's layers during parallel matrix builds.
           cache-from: type=gha,scope=${{ matrix.component }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+          # BuildKit secret consumed by the frontend Dockerfile's `npm ci`
+          # (RUN --mount=type=secret,id=node_auth_token) to read
+          # @noorinalabs/design-system from GitHub Packages. GITHUB_TOKEN has
+          # packages:read (this workflow grants packages:write). Secret-mounted,
+          # never a build-arg/layer, so it is not baked into the image. The API
+          # build does not mount it, so passing it there is a harmless no-op. #940
+          secrets: |
+            node_auth_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -4,10 +4,10 @@
 # each run if this file is missing or too permissive). 240MB+ of node_modules
 # alone would noticeably slow every publish.
 #
-# NOTE: the design-system tarball (noorinalabs-design-system-*.tgz) is staged
-# into this directory by the publish workflow BEFORE docker build and MUST NOT
-# be ignored — the Dockerfile's `COPY noorinalabs-design-system-0.0.1.tgz /`
-# depends on it being present in the build context.
+# NOTE: .npmrc MUST stay in the build context — the Dockerfile COPYs it so
+# `npm ci` can resolve @noorinalabs/design-system from GitHub Packages with the
+# BuildKit-secret token (#940). It carries no secret itself (only the
+# `${NODE_AUTH_TOKEN}` placeholder), so it is safe in the context.
 
 # Node artefacts (reinstalled inside the image by `npm ci`)
 node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,15 @@
 FROM node:24-alpine AS build
 WORKDIR /app
-COPY package.json package-lock.json ./
-# package-lock.json references @noorinalabs/design-system via a file: path
-# pointing at /noorinalabs-design-system-0.0.1.tgz. The deploy script stages
-# this tarball into the build context root before docker build (see #818).
-# Long-term: switch to GHCR-published image (#817) or npm registry
-# (design-system#57) and drop this implicit-contract copy.
-COPY noorinalabs-design-system-0.0.1.tgz /
-RUN npm ci
+# package-lock.json resolves @noorinalabs/design-system from GitHub Packages
+# (npm.pkg.github.com) — see #940. .npmrc points the @noorinalabs scope at that
+# registry and reads the token from ${NODE_AUTH_TOKEN}; the token is supplied to
+# `npm ci` below via a BuildKit secret (never a build-arg/layer), so it is not
+# baked into the image. Package is org-public but the registry still requires a
+# read token, hence the secret. ghcr-publish.yml sources it from GITHUB_TOKEN
+# (packages:read). Local builds: `--secret id=node_auth_token,env=NODE_AUTH_TOKEN`.
+COPY package.json package-lock.json .npmrc ./
+RUN --mount=type=secret,id=node_auth_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm ci
 # Cache-bust: ARG changes invalidate all subsequent layers
 ARG CACHEBUST=1
 COPY . .


### PR DESCRIPTION
## Summary

`Publish to GHCR` was **red on main** — the frontend image's `npm ci` 401'd. #840 moved `@noorinalabs/design-system` in `frontend/package-lock.json` to a GitHub Packages **registry** version (`0.0.4-wave10.0`) while the Dockerfile + workflow still implemented the old build-time `file:`-tgz contract with no registry auth in the Docker build. **Direction A** (per issue + task brief): complete the registry migration.

## Investigation (confirmed before coding)

- `@noorinalabs/design-system@0.0.4-wave10.0` **is published** to `npm.pkg.github.com` (org package, `public` visibility, 3 versions).
- The registry endpoint **401s without a token** (`curl` to `npm.pkg.github.com/@noorinalabs/design-system` → 401 tokenless, 200 with `gh auth token`) — so a `packages:read` token is genuinely required inside the build.
- `package-lock.json` resolves to the registry URL with a real integrity hash → the old integrity-strip step is now wrong and removed.
- Only `ghcr-publish.yml` builds the frontend image. `ci.yml`'s frontend jobs already resolve the registry version via `setup-node` + `GITHUB_TOKEN`.

## Changes

- **`frontend/Dockerfile`** — drop `COPY noorinalabs-design-system-0.0.1.tgz /`; `COPY ... .npmrc ./`; run `npm ci` under a BuildKit secret (`RUN --mount=type=secret,id=node_auth_token`) sourcing `NODE_AUTH_TOKEN` from `/run/secrets`. **Token is never a build-arg or persisted layer.**
- **`.github/workflows/ghcr-publish.yml`** — remove the design-system checkout / build-and-pack / lockfile-integrity-strip steps and the `DESIGN_SYSTEM_REF` env (all `file:`-contract scaffolding, -74 lines); pass `secrets: node_auth_token=${{ secrets.GITHUB_TOKEN }}` to `build-push-action` (already grants `packages: write` ⊇ read).
- **`frontend/.dockerignore`** — replace the stale tgz NOTE with one explaining `.npmrc` must stay in context (carries only the `${NODE_AUTH_TOKEN}` placeholder, no secret).

## Verification

- **Live-trace:** `npm ci` against the committed `.npmrc` + `NODE_AUTH_TOKEN` resolves and installs `@noorinalabs/design-system@0.0.4-wave10.0` from `npm.pkg.github.com` — the exact operation the Dockerfile `RUN` performs.
- `actionlint` clean on the workflow (the one SC2129 finding is the **pre-existing** `Summary` step, present at the wave-14 baseline, untouched here — no new findings).
- YAML parses; BuildKit secret default target path `/run/secrets/<id>` matches the `cat`.
- **Not locally runnable:** the Docker image build itself — Docker daemon is unavailable in this WSL distro. The real proof is CI's frontend image build on this PR. The BuildKit secret-mount is a standard documented directive; the npm-resolution half is proven above.

## Acceptance mapping

- Frontend image builds + pushes without a token-less registry fetch → exercised by CI here; `npm ci` resolution proven locally.
- design-system dep resolves consistently across lockfile + Dockerfile build (deploy-staging script is in noorinalabs-deploy — out of scope for this repo's PR; tracked under #818 / deploy side).
- Token injected as a build **secret**, never a layer/arg; `.npmrc` uses `${NODE_AUTH_TOKEN}`. ✓

## TechDebt

TechDebt: none

Refs #940, #840, design-system#57
