### PR TITLE
ci(P3W15): retire actionlint -ignores in docs.yml gate (#939)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         run: npx vite preview --port 4173 &
       - name: Wait for server
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             curl -s http://localhost:4173 > /dev/null && exit 0
             sleep 1
           done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -165,6 +165,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (noorinalabs-main#578): fetching+executing latest-of-main each run
+          # is a supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
@@ -182,14 +204,14 @@ jobs:
         #     mock-auth-refresh, isnad-graph#812, which carries a documented
         #     re-enable contract). This is an intentional kill-switch, not debt
         #     to fix here; it disappears on its own when #812 re-enables e2e and
-        #     removes the `if:`. Until then the ignore stays. (Note: this finding
-        #     is version-dependent — actionlint 1.7.7 does not emit it, but the
-        #     CI-downloaded latest does, so the ignore is required for CI green.)
+        #     removes the `if:`. Until then the ignore stays. The pinned v1.7.12
+        #     above (noorinalabs-main#578) emits this finding, so the ignore is
+        #     required for the gate to stay green — and is now deterministic
+        #     rather than version-skew-dependent on whatever `main` resolves to.
         # New defects in NEWLY-edited workflows are still caught — the ignore is a
         # narrow, finding-specific pattern.
         run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color \
+          actionlint -color \
             -ignore 'constant expression "false" in condition'
 
   precommit-ci-sync:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -170,26 +170,27 @@ jobs:
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
         #
-        # Three PRE-EXISTING findings in workflows outside this W14 docs/config
-        # rollout's scope are -ignore'd so the gate goes green on the artifacts it
-        # actually owns, rather than failing on debt this PR did not introduce.
-        # They are tracked for a focused follow-up (isnad-graph#939):
-        #   * `constant expression "false"` — ci.yml's `e2e` job is deliberately
-        #     `if: false` (disabled pending the mock-auth-refresh, isnad-graph#812,
-        #     which carries a documented re-enable contract). This is an
-        #     intentional kill-switch, not a defect.
-        #   * `SC2034` — ci.yml's e2e wait-for-server loop has an unused `$i`.
-        #   * `SC2129` — ghcr-publish.yml's summary step uses individual `>>`
-        #     redirects (the GHCR-publish workflow is explicitly out of this
-        #     PR's scope).
-        # New defects in NEWLY-edited workflows (this docs.yml, future edits) are
-        # still caught — the ignores are narrow, finding-specific patterns.
+        # The two GENUINE pre-existing debt findings the W14 rollout (#938) had
+        # narrowly ignored are now fixed at source (isnad-graph#939), so their
+        # ignores are retired:
+        #   * `SC2034` — ci.yml's e2e wait-for-server loop: unused `$i` → `_`.
+        #   * `SC2129` — ghcr-publish.yml's summary step: grouped into a single
+        #     `{ … } >>` redirect.
+        # ONE narrow ignore is intentionally RETAINED:
+        #   * `constant expression "false" in condition` — ci.yml's `e2e` job is
+        #     deliberately `if: false` (the e2e suite is disabled pending the
+        #     mock-auth-refresh, isnad-graph#812, which carries a documented
+        #     re-enable contract). This is an intentional kill-switch, not debt
+        #     to fix here; it disappears on its own when #812 re-enables e2e and
+        #     removes the `if:`. Until then the ignore stays. (Note: this finding
+        #     is version-dependent — actionlint 1.7.7 does not emit it, but the
+        #     CI-downloaded latest does, so the ignore is required for CI green.)
+        # New defects in NEWLY-edited workflows are still caught — the ignore is a
+        # narrow, finding-specific pattern.
         run: |
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color \
-            -ignore 'constant expression "false" in condition' \
-            -ignore 'SC2034:' \
-            -ignore 'SC2129:'
+            -ignore 'constant expression "false" in condition'
 
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -155,13 +155,15 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          echo "## GHCR Publish (${{ matrix.component }}): ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Ref:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Image:** ${{ env.REGISTRY }}/${{ matrix.image }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Platforms:** ${{ matrix.platforms }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **SHA:** ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Digest:** ${{ steps.build.outputs.digest }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## GHCR Publish (${{ matrix.component }}): ${{ job.status }}"
+            echo ""
+            echo "- **Ref:** ${{ github.ref_name }}"
+            echo "- **Image:** ${{ env.REGISTRY }}/${{ matrix.image }}"
+            echo "- **Platforms:** ${{ matrix.platforms }}"
+            echo "- **SHA:** ${{ github.sha }}"
+            echo "- **Digest:** ${{ steps.build.outputs.digest }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Fire repository_dispatch to noorinalabs-deploy AFTER both images published.
   # Gated to main-branch pushes only — tag pushes and manual dispatches do NOT


### PR DESCRIPTION
## Summary

Retires the **two genuine debt** `-ignore` flags that PR #938 (P3W14 end-state docs-CI rollout) shipped in the `docs.yml` actionlint gate, by fixing them at source. **One** intentional-kill-switch ignore is deliberately retained (see below).

## Changes

| Finding | Workflow | Disposition |
|---------|----------|-------------|
| `SC2034` (`i` unused) | `ci.yml` e2e wait-for-server loop | **Fixed at source** — `for i in $(seq 1 30)` → `for _ in $(seq 1 30)`; ignore retired. |
| `SC2129` (individual `>>`) | `ghcr-publish.yml` Summary step | **Fixed at source** — grouped 7 `echo … >> $GITHUB_STEP_SUMMARY` lines into one `{ …; } >> "$GITHUB_STEP_SUMMARY"` block; ignore retired. |
| `constant expression "false"` | `ci.yml` `e2e` `if: false` kill-switch | **Ignore RETAINED** — the e2e job is intentionally `if: false` (disabled pending the mock-auth-refresh, #812, documented re-enable contract). Not debt to fix here; the finding disappears on its own when #812 re-enables e2e. |

`docs.yml` actionlint step: removed the two retired `-ignore` flags, kept the single `-ignore 'constant expression "false" in condition'`, and rewrote the comment block to document the retired-vs-retained split.

## Why one ignore is retained (version skew caught in CI)

This finding is **actionlint-version-dependent**. The locally-pinned actionlint 1.7.7 does **not** emit it, but the CI gate downloads the **latest** actionlint via `download-actionlint.bash` (currently 1.7.12), which **does** flag the literal `if: false`. The first push (0 ignores) went green locally on 1.7.7 but **failed the CI actionlint job** on the downloaded latest. Retaining the single narrow ignore is required for CI green and is the correct disposition for an intentional kill-switch tracked by #812.

## Verification

Re-verified against the **CI version** (latest 1.7.12, downloaded via the same `download-actionlint.bash` script CI uses), with shellcheck 0.10.0 on PATH so the embedded shellcheck integration runs:

```
$ ./actionlint -color -ignore 'constant expression "false" in condition'
EXIT: 0   # CI command — clean

$ ./actionlint -color   # no ignore
.github/workflows/ci.yml:187:9: constant expression "false" in condition ...
EXIT: 1   # ONLY the if:false kill-switch remains → SC2034/SC2129 genuinely fixed
```

## Add-on: #578 actionlint installer pin

This PR also carries the **isnad-graph slice of noorinalabs-main#578** (pin the docs.yml actionlint installer), folded in here because #578 and ig#939 edit the **same** `actionlint:` job — a separate PR would conflict.

- Replaced the unpinned, no-checksum `curl|bash` of `download-actionlint.bash` off `main` with the canonical **two-step** pattern: a pinned download + `sha256sum -c` verify step (**v1.7.12**, linux_amd64 SHA256 `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`), then the run step. `actionlint` now installs to `/usr/local/bin`, so the run command drops the `./` prefix.
- **SHA re-verified** against upstream's published `actionlint_1.7.12_checksums.txt` (verify-third-party-integrity rule), not just trusted from the patch.
- **Retained-ignore interaction confirmed:** the pin nails the version to exactly **1.7.12** — the same version CI was already downloading — which **does** emit the `constant expression "false"` finding for the `if: false` e2e kill-switch (#812). Verified against the exact SHA-checked v1.7.12 binary that `actionlint -ignore 'constant expression "false" in condition'` exits 0, and that without it only the if:false finding remains. The retained-ignore decision from ig#939 still holds and is now **deterministic** (no longer dependent on whatever `main` resolves to).

Closes #939
Refs noorinalabs-main#326
Refs noorinalabs-main#578
