### PR TITLE
ci(gitleaks): bump gitleaks-action v2.3.9 → v3.0.0 (node24 runtime) — closes #929

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           uv export --no-hashes --frozen --no-emit-project > /tmp/requirements.txt
           uv run pip-audit --strict --desc -r /tmp/requirements.txt --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645
       - name: Secret detection with gitleaks
-        uses: gitleaks/gitleaks-action@v2.3.9 # node20 runtime: no node24 release on gitleaks-action; accepted-with-warning per owner 2026-05-28, revisit #929
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0 — node24 runtime (resolves #929)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary

Resolves the accepted-with-warning tech-debt tracked in #929. When that issue was filed (2026-05-28), `gitleaks/gitleaks-action`'s latest maintained tag (v2.3.9) was still `runs.using: node20`, with no node24 release to bump to — the owner accepted the forced-node24 warning and set "revisit when upstream ships a node24 release."

**Upstream shipped it.** `gitleaks-action` released **v3.0.0 on 2026-05-30**, which migrates the action runtime from node20 → node24 with **no changes to inputs, outputs, or behavior** (per the [v3.0.0 release notes](https://github.com/gitleaks/gitleaks-action/releases/tag/v3.0.0)). This is exactly the resolution path #929 anticipated, so the alternative (direct gitleaks binary with sha256-verified download) is unnecessary — the maintained-action route is the more maintainable option.

## Change

```diff
- uses: gitleaks/gitleaks-action@v2.3.9 # node20 runtime: ... accepted-with-warning per owner 2026-05-28, revisit #929
+ uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0 — node24 runtime (resolves #929)
```

One line in `.github/workflows/ci.yml`. Removes the dependency on GitHub's `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out ahead of the **June 2, 2026 node24 default flip** and the **Sept 16, 2026 node20 removal**.

## Integrity verification (not a claim — verified)

- **Pinned by full commit SHA** `e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e`, not the mutable `v3.0.0` tag, for supply-chain integrity on a secret-scanning step. SHA resolved via `gh api repos/gitleaks/gitleaks-action/git/ref/tags/v3.0.0` (lightweight tag → commit `e0c47f4`).
- **Verified node24 at the pinned commit** (not just at the tag): `action.yml?ref=e0c47f4...` declares `runs.using: "node24"` / `main: "dist/index.js"`.
- Trailing comment annotates the SHA with the human-readable `v3.0.0` tag.

## Trade-off note

Repo convention tag-pins first-party actions (`actions/checkout@v6`). Third-party action in a sensitive secret-scanning role + explicit #929 directive to "pin by full commit SHA (not tag)" → SHA-pinned here deliberately. Inputs (`GITHUB_TOKEN`, `GITLEAKS_LICENSE`) are unchanged; v3 is input/output/behavior-compatible with v2.

## Self-hosted runners

v3 requires runner `>= v2.327.1` for node24. CI runs on GitHub-hosted `ubuntu-latest`, so this is not applicable here.

## Test plan

- [ ] CI `Secret detection with gitleaks` step runs green on this PR (the action will now execute under node24).

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
