### PR TITLE
fix(frontend): render runtime-config.js to /tmp so it survives read_only rootfs (ig#949)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,81 @@ jobs:
           fi
           echo "No local paths found in package-lock.json"
 
+  # Build the frontend image and run it under the SAME hardening the deploy
+  # compose applies (read_only rootfs + tmpfs-only writable mounts), then assert
+  # the container reaches healthy and serves the rendered runtime-config.js.
+  # This closes the CI-vs-runtime gap that let ig#949 ship: CI built the image
+  # but never ran it with `read_only: true`, so the entrypoint's write to the
+  # read-only html root was only discovered live on staging. The tmpfs sizes
+  # and the healthcheck command mirror noorinalabs-deploy compose/
+  # docker-compose.prod.yml `frontend:` — keep them in sync if either changes.
+  frontend-readonly-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - name: Build frontend image (load to local docker)
+        uses: docker/build-push-action@v7
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          load: true
+          tags: isnad-frontend:ci-readonly
+          # Same BuildKit secret the publish workflow uses so `npm ci` can read
+          # @noorinalabs/design-system from GitHub Packages (#940). Secret-
+          # mounted, never a layer.
+          secrets: |
+            node_auth_token=${{ secrets.GITHUB_TOKEN }}
+      - name: Run container with deploy's read-only hardening
+        run: |
+          docker run -d --name fe-readonly \
+            --read-only \
+            --tmpfs /tmp:size=64M \
+            --tmpfs /var/cache/nginx:size=128M \
+            --tmpfs /run:size=16M \
+            -e USER_SERVICE_ORIGIN=https://users.test.example \
+            -p 8080:80 \
+            isnad-frontend:ci-readonly
+      - name: Wait for container healthy (mirrors compose healthcheck)
+        run: |
+          for _ in $(seq 1 20); do
+            if curl -sf http://localhost:8080/ >/dev/null; then
+              echo "Container serving / — healthy."
+              exit 0
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' fe-readonly 2>/dev/null)" != "true" ]; then
+              echo "::error::Container exited (crash loop). Logs:"
+              docker logs fe-readonly || true
+              exit 1
+            fi
+            sleep 3
+          done
+          echo "::error::Container never became healthy. Logs:"
+          docker logs fe-readonly || true
+          exit 1
+      - name: Assert runtime-config.js is rendered and substituted
+        run: |
+          BODY="$(curl -sf http://localhost:8080/runtime-config.js)"
+          echo "$BODY"
+          # The #934 contract: USER_SERVICE_ORIGIN is substituted into the body...
+          echo "$BODY" | grep -qF 'https://users.test.example' \
+            || { echo "::error::runtime-config.js missing substituted USER_SERVICE_ORIGIN"; exit 1; }
+          # ...and the literal envsubst placeholder must NOT survive. The single
+          # quotes are intentional: we grep for the verbatim ${...} placeholder
+          # text, not a shell expansion.
+          # shellcheck disable=SC2016
+          if echo "$BODY" | grep -qF '${USER_SERVICE_ORIGIN}'; then
+            echo "::error::runtime-config.js still contains the un-substituted \${USER_SERVICE_ORIGIN} placeholder"
+            exit 1
+          fi
+          echo "runtime-config.js rendered and substituted correctly under read-only rootfs."
+      - name: Container logs (always)
+        if: always()
+        run: docker logs fe-readonly || true
+
   e2e:
     needs: lint-and-typecheck
     # Disabled pending mock-auth-refresh — see noorinalabs/noorinalabs-isnad-graph#812.

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -11,7 +11,13 @@
 set -eu
 
 TEMPLATE=/runtime-config.js.template
-OUTPUT=/usr/share/nginx/html/runtime-config.js
+# Render to /tmp, not the html root: the deploy compose runs this container with
+# `read_only: true` and only /tmp, /var/cache/nginx, /run are tmpfs (writable).
+# Writing under /usr/share/nginx/html (the read-only rootfs) crash-loops the
+# container at start (ig#949). nginx serves this path back at the original
+# /runtime-config.js URL via an `alias` in nginx.conf, so index.html's
+# `<script src="/runtime-config.js">` is unchanged.
+OUTPUT=/tmp/runtime-config.js
 
 # The single-quoted SHELL-FORMAT argument is deliberate: it is an envsubst
 # allowlist, not a shell expansion. Only ${USER_SERVICE_ORIGIN} is substituted;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,6 +3,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # runtime-config.js is rendered at container start by entrypoint.sh into
+    # /tmp (tmpfs) rather than the read-only html root (ig#949). Serve it back
+    # at the original URL so index.html's <script src="/runtime-config.js">
+    # keeps working. Exact-match (`= `) wins over the SPA catch-all below.
+    location = /runtime-config.js {
+        alias /tmp/runtime-config.js;
+        default_type application/javascript;
+        add_header Cache-Control "no-store";
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

**Hotfix** for the last staging blocker: the frontend container crash-loops under deploy's `read_only: true` rootfs because the #934 runtime-config entrypoint writes to `/usr/share/nginx/html/runtime-config.js`, which is on the read-only filesystem. `set -eu` exits → restart loop → healthcheck never passes → deploy aborts on `depends_on: service_healthy`.

This is a forward-fix (rolling back pre-#934 doesn't restore staging — the old same-origin relative URLs broke when the Caddy dual-bind was dropped in deploy#389).

Closes #949

## The fix (single-repo; deploy's hardening untouched)

1. **`frontend/entrypoint.sh`** — render to `/tmp/runtime-config.js` (tmpfs, writable in the deploy compose) instead of the read-only html root.
2. **`frontend/nginx.conf`** — add `location = /runtime-config.js { alias /tmp/runtime-config.js; ... }` so the same `/runtime-config.js` URL keeps working. `index.html`'s `<script src="/runtime-config.js">` is unchanged. Added `Cache-Control: no-store` so the per-env runtime config is never served stale.
3. **`.github/workflows/ci.yml`** — new `frontend-readonly-container` job that builds the image and runs it with `--read-only --tmpfs /tmp:size=64M --tmpfs /var/cache/nginx:size=128M --tmpfs /run:size=16M -e USER_SERVICE_ORIGIN=...` (mirroring `noorinalabs-deploy` compose `frontend:` exactly), then asserts the container reaches healthy (`curl -sf http://localhost/`, the compose healthcheck) AND serves a `runtime-config.js` with the substituted origin and no surviving `${USER_SERVICE_ORIGIN}` placeholder.

No deploy-side change required; `read_only: true` + the three tmpfs mounts stay as-is.

## Why this was never caught (the CI-runtime gap)

CI built the frontend image but never *ran* it with `read_only: true`. The first execution against the production compose config was the failed staging deploy (run 26791516331). The new `frontend-readonly-container` job is exactly that missing runtime exercise — it would have failed on the old `OUTPUT=/usr/share/nginx/html/...`.

## #934 contract preserved

The served URL, the template, and the `window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN` resolution order are all unchanged, so `frontend/src/__tests__/runtime-config.test.ts` applies as-is (no edit). The new CI job additionally proves the substitution end-to-end in a real read-only container.

## Test Plan

- [x] `shellcheck frontend/entrypoint.sh` — clean.
- [x] `actionlint .github/workflows/ci.yml` (with shellcheck on PATH) — clean.
- [x] Confirmed the #934 contract test asserts client-side resolution only (independent of OUTPUT path / serving mechanism) → unchanged.
- [ ] CI `frontend-readonly-container` green — builds image, runs read-only, container healthy, `runtime-config.js` substituted. **This is the runtime proof** (docker isn't available in my local env; CI is authoritative).
- [ ] CI `frontend-lint-and-test` (vitest runtime-config contract) green.
- [ ] Full statusCheckRollup green on the new main branch-protection ruleset (7 required contexts).

## After merge

ghcr-publish auto-builds on the main push → `repository_dispatch` fires deploy-stg. Team lead verifies the deploy goes green end-to-end (kafka/api/user-service/landing already healthy in run 26791516331; frontend was the last red).

Refs noorinalabs-deploy#393, noorinalabs-main#325 (P3 staging criterion).
