### PR TITLE
fix(#520): recover true total-counts in search + timeline (ig#792)

### DIFF
--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -60,7 +60,12 @@ def search(
                 )
             )
 
-    return SearchResultsResponse(results=results, total=len(results), query=q)
+    # --- Total count across both result types ---
+    # The result list above is capped at ``limit``; ``total`` must reflect the
+    # full count of matching narrators + hadiths so clients can paginate.
+    total = _fulltext_narrator_count(neo4j, q) + _fulltext_hadith_count(neo4j, q)
+
+    return SearchResultsResponse(results=results, total=total, query=q)
 
 
 def _fulltext_narrator_search(neo4j: Neo4jClient, query: str, limit: int) -> list[dict[str, Any]]:
@@ -117,6 +122,54 @@ def _fulltext_hadith_search(neo4j: Neo4jClient, query: str, limit: int) -> list[
         )
 
 
+def _fulltext_narrator_count(neo4j: Neo4jClient, query: str) -> int:
+    """Count all narrators matching the query, using the same index/fallback as search."""
+    try:
+        rows = neo4j.execute_read(
+            """
+            CALL db.index.fulltext.queryNodes('narrator_search', $q)
+            YIELD node
+            RETURN count(node) AS total
+            """,
+            {"q": query},
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("fulltext narrator_search unavailable, counting via CONTAINS")
+        rows = neo4j.execute_read(
+            """
+            MATCH (n:Narrator)
+            WHERE n.name_ar CONTAINS $q OR n.name_en CONTAINS $q
+            RETURN count(n) AS total
+            """,
+            {"q": query},
+        )
+    return rows[0]["total"] if rows else 0
+
+
+def _fulltext_hadith_count(neo4j: Neo4jClient, query: str) -> int:
+    """Count all hadiths matching the query, using the same index/fallback as search."""
+    try:
+        rows = neo4j.execute_read(
+            """
+            CALL db.index.fulltext.queryNodes('hadith_search', $q)
+            YIELD node
+            RETURN count(node) AS total
+            """,
+            {"q": query},
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("fulltext hadith_search unavailable, counting via CONTAINS")
+        rows = neo4j.execute_read(
+            """
+            MATCH (h:Hadith)
+            WHERE h.matn_ar CONTAINS $q OR h.matn_en CONTAINS $q
+            RETURN count(h) AS total
+            """,
+            {"q": query},
+        )
+    return rows[0]["total"] if rows else 0
+
+
 @router.get("/search/semantic", response_model=SearchResultsResponse)
 def search_semantic(
     q: str = Query(..., min_length=1, max_length=500, description="Semantic search query"),
@@ -146,6 +199,15 @@ def search_semantic(
             """,
             (q, q, limit),
         )
+        # Total count of candidate hadiths (the LIMIT above caps ``rows`` at
+        # ``limit``; ``total`` must reflect the full searchable set).
+        count_rows = pg.execute(
+            """
+            SELECT count(*) AS total
+            FROM isnad_graph.hadith_embeddings e
+            JOIN isnad_graph.hadiths h ON h.id = e.hadith_id
+            """
+        )
     except Exception:  # noqa: BLE001
         log.debug("pgvector semantic search unavailable", exc_info=True)
         return JSONResponse(  # type: ignore[return-value]
@@ -169,4 +231,5 @@ def search_semantic(
             )
         )
 
-    return SearchResultsResponse(results=results, total=len(results), query=q)
+    total = count_rows[0]["total"] if count_rows else len(results)
+    return SearchResultsResponse(results=results, total=total, query=q)

--- a/src/api/routes/timeline.py
+++ b/src/api/routes/timeline.py
@@ -42,6 +42,19 @@ def get_timeline(
     """Return historical events with narrator counts per period for timeline visualization."""
     skip = (page - 1) * limit
 
+    # Total count of events matching the year filter, before SKIP/LIMIT
+    # pagination, so clients can paginate over the full result set.
+    count_rows = neo4j.execute_read(
+        """
+        MATCH (e:HistoricalEvent)
+        WHERE ($start_year IS NULL OR e.year_ah >= $start_year)
+          AND ($end_year IS NULL OR e.year_ah <= $end_year)
+        RETURN count(e) AS total
+        """,
+        {"start_year": start_year, "end_year": end_year},
+    )
+    total = count_rows[0]["total"] if count_rows else 0
+
     rows = neo4j.execute_read(
         """
         MATCH (e:HistoricalEvent)
@@ -77,4 +90,4 @@ def get_timeline(
         )
         for r in rows
     ]
-    return TimelineResponse(entries=entries, total=len(entries))
+    return TimelineResponse(entries=entries, total=total)

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -28,12 +28,19 @@ def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMo
                 "score": 1.8,
             }
         ],
+        # narrator count query
+        [{"total": 7}],
+        # hadith count query
+        [{"total": 12}],
     ]
     resp = client.get("/api/v1/search?q=test")
     assert resp.status_code == 200
     body = resp.json()
     assert body["query"] == "test"
-    assert body["total"] == 2
+    # total reflects the full match count (7 + 12), not the page-limited
+    # result list length (2)
+    assert body["total"] == 19
+    assert len(body["results"]) == 2
     assert body["results"][0]["type"] == "narrator"
     assert body["results"][0]["score"] == 2.5
     assert body["results"][1]["type"] == "hadith"
@@ -41,17 +48,47 @@ def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMo
     # Verify the full-text query was used (CALL db.index.fulltext)
     first_call_query = mock_neo4j.execute_read.call_args_list[0][0][0]
     assert "fulltext.queryNodes" in first_call_query
+    # Verify a dedicated count query was issued
+    count_query = mock_neo4j.execute_read.call_args_list[2][0][0]
+    assert "count(" in count_query
+
+
+def test_search_total_exceeds_limit(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """total reflects the true match count even when results are capped at limit."""
+    narrator_hits = [
+        {"id": f"nar-{i}", "name_ar": "اختبار", "name_en": f"n{i}", "score": 1.0} for i in range(2)
+    ]
+    hadith_hits = [
+        {"id": f"had-{i}", "matn_ar": "نص", "matn_en": f"h{i}", "score": 1.0} for i in range(2)
+    ]
+    mock_neo4j.execute_read.side_effect = [
+        narrator_hits,
+        hadith_hits,
+        [{"total": 50}],  # narrator count
+        [{"total": 130}],  # hadith count
+    ]
+    resp = client.get("/api/v1/search?q=test&limit=4")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["results"]) == 4
+    assert body["total"] == 180
 
 
 def test_search_falls_back_to_contains(client: TestClient, mock_neo4j: MagicMock) -> None:
     """When full-text index is unavailable, falls back to CONTAINS."""
-    # First call (fulltext) raises, second call (CONTAINS fallback) succeeds,
-    # third call (hadith fulltext) raises, fourth call (hadith fallback) succeeds
+    # narrator: fulltext raises, CONTAINS fallback succeeds
+    # hadith: fulltext raises, CONTAINS fallback succeeds
+    # narrator count: fulltext raises, CONTAINS count fallback succeeds
+    # hadith count: fulltext raises, CONTAINS count fallback succeeds
     mock_neo4j.execute_read.side_effect = [
         Exception("No such index 'narrator_search'"),
         [{"id": "nar-001", "name_ar": "اختبار", "name_en": "fallback", "score": 1.0}],
         Exception("No such index 'hadith_search'"),
         [],
+        Exception("No such index 'narrator_search'"),
+        [{"total": 1}],
+        Exception("No such index 'hadith_search'"),
+        [{"total": 0}],
     ]
     resp = client.get("/api/v1/search?q=test")
     assert resp.status_code == 200
@@ -103,13 +140,18 @@ def test_semantic_search_returns_503_when_pg_unavailable(client: TestClient, app
 def test_semantic_search_returns_results_when_pg_available(client: TestClient, app: object) -> None:
     """GET /api/v1/search/semantic returns results when pgvector is wired up."""
     mock_pg = MagicMock()
-    mock_pg.execute.return_value = [
-        {
-            "id": "had-001",
-            "matn_ar": "نص اختبار",
-            "matn_en": "test semantic hadith",
-            "score": 0.92,
-        },
+    mock_pg.execute.side_effect = [
+        # similarity-ranked data query (capped at limit)
+        [
+            {
+                "id": "had-001",
+                "matn_ar": "نص اختبار",
+                "matn_en": "test semantic hadith",
+                "score": 0.92,
+            },
+        ],
+        # dedicated count query over the full candidate set
+        [{"total": 84}],
     ]
     mock_pg.close.return_value = None
 
@@ -123,7 +165,9 @@ def test_semantic_search_returns_results_when_pg_available(client: TestClient, a
     resp = client.get("/api/v1/search/semantic?q=test")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["total"] == 1
+    # total reflects the full candidate set, not the page-limited result list
+    assert body["total"] == 84
+    assert len(body["results"]) == 1
     assert body["results"][0]["type"] == "hadith"
     assert body["results"][0]["score"] == 0.92
 

--- a/tests/test_api/test_timeline.py
+++ b/tests/test_api/test_timeline.py
@@ -1,0 +1,76 @@
+"""Tests for timeline endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+SAMPLE_EVENT = {
+    "id": "evt-001",
+    "name": "Battle of Badr",
+    "name_ar": "غزوة بدر",
+    "year_ah": 2,
+    "end_year_ah": None,
+    "event_type": "battle",
+    "description": "First major battle.",
+    "narrator_count": 3,
+}
+
+
+def test_timeline_empty(client: TestClient) -> None:
+    """GET /api/v1/timeline returns empty response when no data."""
+    resp = client.get("/api/v1/timeline")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["entries"] == []
+    assert body["total"] == 0
+
+
+def test_timeline_total_reflects_full_count(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """total comes from a dedicated COUNT query, not the page-limited entry list."""
+    mock_neo4j.execute_read.side_effect = [
+        # count query over the full filtered set
+        [{"total": 240}],
+        # page-limited data query
+        [SAMPLE_EVENT],
+    ]
+    resp = client.get("/api/v1/timeline?limit=1")
+    assert resp.status_code == 200
+    body = resp.json()
+    # total is the true count (240), not len(entries) which is capped at limit
+    assert body["total"] == 240
+    assert len(body["entries"]) == 1
+    assert body["entries"][0]["id"] == "evt-001"
+
+    # Verify the first query issued is a count query
+    count_query = mock_neo4j.execute_read.call_args_list[0][0][0]
+    assert "count(e)" in count_query
+
+
+def test_timeline_count_respects_year_filter(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """The COUNT query is passed the same start/end year filter as the data query."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 5}],
+        [SAMPLE_EVENT],
+    ]
+    resp = client.get("/api/v1/timeline?start_year=1&end_year=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 5
+
+    count_params = mock_neo4j.execute_read.call_args_list[0][0][1]
+    assert count_params["start_year"] == 1
+    assert count_params["end_year"] == 10
+
+
+def test_timeline_range(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /api/v1/timeline/range returns min/max year from events."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"min_year": 1, "max_year": 300}],
+    ]
+    resp = client.get("/api/v1/timeline/range")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["min_year_ah"] == 1
+    assert body["max_year_ah"] == 300


### PR DESCRIPTION
The /search, /search/semantic, and /timeline endpoints returned `total=len(results)` — the page-size-limited count — making client-side pagination impossible. This is a live API correctness bug on main.

Recovers the wave-10 fix (commit 21a0d4e, ig#792), hand-applied onto main's current route versions (which were identical to the wave-10 base for these files):

- `search.py`: add `_fulltext_narrator_count` / `_fulltext_hadith_count` helpers (fulltext index with CONTAINS fallback, mirroring the search queries) summed for the `/search` total; add a dedicated COUNT query over the embeddings join for `/search/semantic`.
- `timeline.py`: add a COUNT query with the same year filter as the data query, before SKIP/LIMIT pagination.
- tests: extend `test_search.py` count-query mocks and add `test_timeline.py` pinning `total` to the dedicated COUNT, not the page-limited entry list. These test updates are required to keep main green — main's existing tests asserted the old page-capped total and would fail under the corrected behavior.

**Local validation:** ruff / ruff-format / mypy clean. Backend pytest for these API routes cannot execute in the recovery sandbox — the FastAPI lifespan eagerly constructs a `Neo4jClient` against `bolt://localhost:7687`, which is unavailable here and hangs ALL api-route tests (including unmodified ones); this is an environment limit, not a code defect. Mock call-sequence counts were verified statically against the new query order.

Refs noorinalabs-main#520
Recovers ig#792 (stranded on deployments/phase-3/wave-10)
