### PR TITLE
fix(#520): recover frontend auth fixes — fragment token parse + ProtectedRoute (ig#901/#831)

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -2,17 +2,22 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useSubscription } from '../hooks/useSubscription'
 
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}
+
 export default function ProtectedRoute() {
   const { user, loading } = useAuth()
   const { isExpired, isLoading: subLoading } = useSubscription()
   const location = useLocation()
 
-  if (loading || subLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
-      </div>
-    )
+  // Auth must resolve before we can decide whether to redirect or render.
+  if (loading) {
+    return <LoadingSpinner />
   }
 
   if (!user) {
@@ -27,5 +32,18 @@ export default function ProtectedRoute() {
     return <Navigate to="/check-email" replace />
   }
 
-  return <Outlet />
+  // Once authenticated, the child subtree mounts once and stays mounted.
+  // A `subLoading` toggle renders an overlay alongside <Outlet /> rather than
+  // swapping it out — otherwise React unmounts/remounts the whole subtree on
+  // every toggle, amplifying any re-mount-driven retry loop (see #831, #830).
+  return (
+    <>
+      <Outlet />
+      {subLoading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-sm">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      )}
+    </>
+  )
 }

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react"
+import { useEffect } from "react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import ProtectedRoute from "../ProtectedRoute"
+import type { AuthUser } from "../../hooks/useAuth"
+
+const mockUseAuth = vi.fn()
+const mockUseSubscription = vi.fn()
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}))
+vi.mock("../../hooks/useSubscription", () => ({
+  useSubscription: () => mockUseSubscription(),
+}))
+
+function makeUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: "6cf04f80-ede7-42e6-9756-43f8ce8f220d",
+    email: "jane@example.com",
+    display_name: "Jane Smith",
+    avatar_url: null,
+    email_verified: true,
+    is_active: true,
+    locale: null,
+    created_at: "2026-04-20T03:09:36.076621Z",
+    roles: [],
+    ...overrides,
+  }
+}
+
+let mountCount = 0
+function ChildPage() {
+  useEffect(() => {
+    mountCount += 1
+  }, [])
+  return <div>child page</div>
+}
+
+function renderProtected() {
+  return render(
+    <MemoryRouter initialEntries={["/app"]}>
+      <Routes>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/app" element={<ChildPage />} />
+        </Route>
+        <Route path="/login" element={<div>login page</div>} />
+        <Route path="/trial-expired" element={<div>trial expired page</div>} />
+        <Route path="/check-email" element={<div>check email page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ProtectedRoute", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+    mockUseSubscription.mockReset()
+    mountCount = 0
+  })
+
+  it("redirects to /login when unauthenticated", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("login page")).toBeInTheDocument()
+  })
+
+  it("redirects to /trial-expired when subscription is expired", () => {
+    mockUseAuth.mockReturnValue({ user: makeUser(), loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: true, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("trial expired page")).toBeInTheDocument()
+  })
+
+  it("redirects to /check-email when email is unverified", () => {
+    mockUseAuth.mockReturnValue({
+      user: makeUser({ email_verified: false }),
+      loading: false,
+    })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("check email page")).toBeInTheDocument()
+  })
+
+  it("renders children for an authenticated, verified, non-expired user", () => {
+    mockUseAuth.mockReturnValue({ user: makeUser(), loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    renderProtected()
+    expect(screen.getByText("child page")).toBeInTheDocument()
+  })
+
+  it("keeps children mounted across a subLoading toggle (regression for #831)", () => {
+    mockUseAuth.mockReturnValue({ user: makeUser(), loading: false })
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+
+    const { rerender } = renderProtected()
+    expect(screen.getByText("child page")).toBeInTheDocument()
+    expect(mountCount).toBe(1)
+
+    // subLoading toggles true — e.g. the subscription query refetches.
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: true })
+    rerender(
+      <MemoryRouter initialEntries={["/app"]}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/app" element={<ChildPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    // Child must NOT have unmounted/remounted — still mounted exactly once.
+    expect(screen.getByText("child page")).toBeInTheDocument()
+    expect(mountCount).toBe(1)
+
+    // subLoading toggles back to false.
+    mockUseSubscription.mockReturnValue({ isExpired: false, isLoading: false })
+    rerender(
+      <MemoryRouter initialEntries={["/app"]}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/app" element={<ChildPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+    expect(screen.getByText("child page")).toBeInTheDocument()
+    expect(mountCount).toBe(1)
+  })
+})

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -17,7 +17,13 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     const errorCode = searchParams.get('error')
-    const token = searchParams.get('token')
+    // The access token is read from the URL fragment first: user-service moves
+    // it out of the query string (#68) because query params leak into server
+    // logs, the Referer header, and browser history. The query-param read is a
+    // transition fallback so this works against both the pre-#68 user-service
+    // (token in query) and post-#68 (token in fragment) — and can land first.
+    const hashToken = new URLSearchParams(window.location.hash.slice(1)).get('token')
+    const token = hashToken ?? searchParams.get('token')
     const isNewUser = searchParams.get('is_new_user')
     const needsVerification = searchParams.get('needs_verification')
     const returnUrl = sessionStorage.getItem('oauth_return_url') || '/'


### PR DESCRIPTION
Recover two frontend auth fixes stranded on deployments/phase-3/wave-10, hand-applied onto main's current files (both identical to the wave-10 base — no conflict).

**ig#901** (commit 2a44fa1) — `AuthCallbackPage.tsx`: read the OAuth access token from the URL fragment (`#token=...`) FIRST, falling back to the `?token=` query param. This is the frontend half of user-service's token-in-fragment security fix (#68): query params leak into server logs, the Referer header, and browser history. The query fallback keeps it backward compatible against the pre-#68 user-service, so it lands safely and ahead of #68.

**ig#831** (commit 64e3149) — `ProtectedRoute.tsx`: stop remounting the whole authenticated subtree on every `subLoading` toggle. Auth `loading` still gates render, but once authenticated the child mounts once and stays mounted; `subLoading` now renders a fixed overlay alongside `<Outlet />` instead of swapping it out. Includes the regression vitest (`ProtectedRoute.test.tsx`, 5 tests) asserting the subtree mounts exactly once across subLoading transitions.

**SKIPPED:** the wave-10 e2e `auth.spec.ts` fragment-token test block did not apply — main's e2e auth suite diverged and lacks the "OAuth callback redirect contract" describe scaffolding the test depends on. It is a Playwright runtime test (not run by the CI `vitest run` job) and is not worth recovering blind; the production fix it covered is included here.

> **MERGE FIRST:** user-service's OAuth fragment PR (#68) is gated on this one — the frontend must read fragments before the backend sends them.

**Local CI parity (frontend job):** npm install, eslint (0 errors), gen:types + no drift, tsc --noEmit, vitest run — all green (97 tests).

Refs noorinalabs-main#520
Recovers ig#901, ig#831 (stranded on deployments/phase-3/wave-10)
