### PR TITLE
tech-debt(#520): recover frontend/backend cleanups (ig#791/#793/#803)

### DIFF
--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -7,13 +7,9 @@ import type {
 } from '../types/admin'
 import type { PaginatedResponse } from '../types/api'
 import { emitSessionExpired } from '../hooks/useAuth'
+import { getAuthHeaders } from './auth-headers'
 
 const API_BASE = '/api/v1/admin'
-
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
 
 async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {

--- a/frontend/src/api/auth-headers.ts
+++ b/frontend/src/api/auth-headers.ts
@@ -1,0 +1,4 @@
+export function getAuthHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,13 +17,9 @@ import type {
 } from '../types/api'
 
 import { emitSessionExpired } from '../hooks/useAuth'
+import { getAuthHeaders } from './auth-headers'
 
 const API_BASE = '/api/v1'
-
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -1,4 +1,5 @@
 import { emitSessionExpired } from '../hooks/useAuth'
+import { getAuthHeaders } from './auth-headers'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
 // useAuth.ts for the full BASE-constant set and the runtime-vs-build-time
@@ -9,11 +10,6 @@ const USER_SERVICE_ORIGIN =
   import.meta.env.VITE_USER_SERVICE_ORIGIN ||
   ''
 const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
-
-function getAuthHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
 
 async function fetchProfileJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -257,14 +257,7 @@ export default function LoginPage() {
               <button
                 onClick={() => handleOAuth('google')}
                 disabled={isLoading}
-                className="flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
-                style={{
-                  border: `1px solid var(--color-oauth-google-border)`,
-                  backgroundColor: 'var(--color-oauth-google-bg)',
-                  color: 'var(--color-oauth-google-text)',
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-google-bg-hover)')}
-                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-google-bg)')}
+                className="oauth-button-google flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
               >
                 <GoogleIcon />
                 {oauthLoading === 'google' ? 'Redirecting...' : 'Sign in with Google'}
@@ -275,13 +268,7 @@ export default function LoginPage() {
               <button
                 onClick={() => handleOAuth('github')}
                 disabled={isLoading}
-                className="flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
-                style={{
-                  backgroundColor: 'var(--color-oauth-github-bg)',
-                  color: 'var(--color-oauth-github-text)',
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-github-bg-hover)')}
-                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-oauth-github-bg)')}
+                className="oauth-button-github flex w-full items-center justify-center gap-3 rounded-md px-4 py-2.5 text-sm font-medium shadow-sm transition-colors disabled:opacity-50"
               >
                 <GitHubIcon />
                 {oauthLoading === 'github' ? 'Redirecting...' : 'Sign in with GitHub'}

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -1088,3 +1088,24 @@
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-muted-foreground);
 }
+
+/* OAuth sign-in buttons — per-provider colors with CSS :hover
+   (replaces inline onMouseEnter/onMouseLeave handlers) */
+.oauth-button-google {
+  border: var(--border-width-thin) solid var(--color-oauth-google-border);
+  background-color: var(--color-oauth-google-bg);
+  color: var(--color-oauth-google-text);
+}
+
+.oauth-button-google:hover {
+  background-color: var(--color-oauth-google-bg-hover);
+}
+
+.oauth-button-github {
+  background-color: var(--color-oauth-github-bg);
+  color: var(--color-oauth-github-text);
+}
+
+.oauth-button-github:hover {
+  background-color: var(--color-oauth-github-bg-hover);
+}

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import time
 
-import psycopg
-import redis as redis_lib
 from fastapi import APIRouter, Depends, Response
 
 from src.api.deps import get_neo4j
 from src.api.models import HealthResponse, ServiceStatus, StatusResponse
-from src.config import get_settings
 from src.utils.neo4j_client import Neo4jClient
+from src.utils.pg_client import PgClient
+from src.utils.redis_client import get_redis_client
 
 router = APIRouter()
 
@@ -32,19 +31,18 @@ def _check_neo4j(neo4j: Neo4jClient) -> ServiceStatus:
 
 
 def _check_postgres() -> ServiceStatus:
-    """Check PostgreSQL connectivity and return status."""
+    """Check PostgreSQL connectivity and return status.
+
+    Uses the application's ``PgClient`` wrapper — the same accessor used for
+    real traffic — instead of hand-rolling a raw ``psycopg.connect`` call.
+    """
     start = time.monotonic()
     try:
-        settings = get_settings()
-        conn = psycopg.connect(settings.postgres.dsn)
-        try:
-            with conn.cursor() as cur:
-                cur.execute("SELECT version()")
-                row = cur.fetchone()
-                version = str(row[0]).split(",")[0] if row else None
-        finally:
-            conn.close()
+        with PgClient() as pg:
+            rows = pg.execute("SELECT version() AS version")
         latency = (time.monotonic() - start) * 1000
+        raw = rows[0]["version"] if rows else None
+        version = str(raw).split(",")[0] if raw else None
         return ServiceStatus(status="up", latency_ms=round(latency, 1), version=version)
     except Exception as exc:
         latency = (time.monotonic() - start) * 1000
@@ -52,15 +50,21 @@ def _check_postgres() -> ServiceStatus:
 
 
 def _check_redis() -> ServiceStatus:
-    """Check Redis connectivity and return status."""
+    """Check Redis connectivity and return status.
+
+    Uses the shared ``get_redis_client`` helper — the same accessor used for
+    real traffic — instead of hand-rolling a raw ``redis.from_url`` call.
+    """
     start = time.monotonic()
     try:
-        settings = get_settings()
-        r = redis_lib.from_url(str(settings.redis.url))
-        r.ping()
-        info: dict[str, object] = r.info("server")  # type: ignore[assignment]
+        client = get_redis_client()
+        if client is None:
+            latency = (time.monotonic() - start) * 1000
+            return ServiceStatus(
+                status="down", latency_ms=round(latency, 1), error="redis unavailable"
+            )
+        info: dict[str, object] = client.info("server")
         version = str(info.get("redis_version", "")) or None
-        r.close()
         latency = (time.monotonic() - start) * 1000
         return ServiceStatus(status="up", latency_ms=round(latency, 1), version=version)
     except Exception as exc:

--- a/tests/test_api/test_health.py
+++ b/tests/test_api/test_health.py
@@ -8,29 +8,33 @@ from fastapi.testclient import TestClient
 
 
 def _patch_pg_and_redis():
-    """Return context managers that mock PostgreSQL and Redis in the health module."""
-    mock_conn = MagicMock()
-    mock_cur = MagicMock()
-    mock_cur.fetchone.return_value = ("PostgreSQL 16.2",)
-    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cur
-    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    """Return context managers that mock PostgreSQL and Redis for the health checks.
+
+    Both are mocked at the names imported into the health module — the
+    ``PgClient`` wrapper and the ``get_redis_client`` helper — so the route
+    exercises the same accessors the application uses for real traffic.
+    ``PgClient`` is used as a context manager, so the mock's ``__enter__``
+    returns the connection mock.
+    """
+    mock_pg = MagicMock()
+    mock_pg.execute.return_value = [{"version": "PostgreSQL 16.2"}]
+    mock_pg_cls = MagicMock()
+    mock_pg_cls.return_value.__enter__.return_value = mock_pg
 
     mock_r = MagicMock()
     mock_r.ping.return_value = True
     mock_r.info.return_value = {"redis_version": "7.2.4"}
 
-    pg_patch = patch("src.api.routes.health.psycopg")
-    redis_patch = patch("src.api.routes.health.redis_lib")
-    return pg_patch, redis_patch, mock_conn, mock_r
+    pg_patch = patch("src.api.routes.health.PgClient", mock_pg_cls)
+    redis_patch = patch("src.api.routes.health.get_redis_client", return_value=mock_r)
+    return pg_patch, redis_patch, mock_pg, mock_r
 
 
 def test_health_check_all_up(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /health returns 200 with healthy status when all services are up."""
     mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/health")
     assert resp.status_code == 200
     body = resp.json()
@@ -43,10 +47,8 @@ def test_health_check_all_up(client: TestClient, mock_neo4j: MagicMock) -> None:
 def test_health_check_neo4j_down(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /health returns 503 when Neo4j is down."""
     mock_neo4j.execute_read.side_effect = RuntimeError("connection refused")
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/health")
     assert resp.status_code == 503
     body = resp.json()
@@ -55,13 +57,38 @@ def test_health_check_neo4j_down(client: TestClient, mock_neo4j: MagicMock) -> N
     assert body["services"]["neo4j"]["error"] is not None
 
 
+def test_health_check_postgres_down(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /health returns 503 when PostgreSQL is unreachable via get_pg."""
+    mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
+    pg_patch, redis_patch, mock_pg, _mock_r = _patch_pg_and_redis()
+    mock_pg.execute.side_effect = RuntimeError("connection refused")
+    with pg_patch, redis_patch:
+        resp = client.get("/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["services"]["postgres"]["status"] == "down"
+    assert body["services"]["postgres"]["error"] is not None
+
+
+def test_health_check_redis_unavailable(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /health returns 503 when get_redis_client yields None."""
+    mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
+    pg_patch, _redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    redis_none = patch("src.api.routes.health.get_redis_client", return_value=None)
+    with pg_patch, redis_none:
+        resp = client.get("/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["services"]["redis"]["status"] == "down"
+
+
 def test_root_serves_health(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET / serves the same health check as /health."""
     mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/")
     assert resp.status_code == 200
     body = resp.json()
@@ -71,10 +98,8 @@ def test_root_serves_health(client: TestClient, mock_neo4j: MagicMock) -> None:
 def test_status_all_operational(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /status returns operational when all services are up."""
     mock_neo4j.execute_read.return_value = [{"version": "5.26.0"}]
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/status")
     assert resp.status_code == 200
     body = resp.json()
@@ -85,10 +110,8 @@ def test_status_all_operational(client: TestClient, mock_neo4j: MagicMock) -> No
 def test_status_degraded(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /status returns degraded when a service is down."""
     mock_neo4j.execute_read.side_effect = RuntimeError("connection refused")
-    pg_patch, redis_patch, mock_conn, mock_r = _patch_pg_and_redis()
-    with pg_patch as mock_psycopg, redis_patch as mock_redis:
-        mock_psycopg.connect.return_value = mock_conn
-        mock_redis.from_url.return_value = mock_r
+    pg_patch, redis_patch, _mock_pg, _mock_r = _patch_pg_and_redis()
+    with pg_patch, redis_patch:
         resp = client.get("/status")
     assert resp.status_code == 200
     body = resp.json()


### PR DESCRIPTION
Recover tech-debt cleanups stranded on deployments/phase-3/wave-10, hand-applied onto main's current code (owner approved recovering the TD tier).

**ig#791** (commit 3cdc978) — dedup `getAuthHeaders` into a shared `frontend/src/api/auth-headers.ts` and import it from `client.ts`, `admin-client.ts`, and `profile-client.ts` (removing 3 inline copies). The dedup pattern was hand-applied: `profile-client.ts` had evolved on main (`window.RUNTIME_CONFIG` / `VITE_USER_SERVICE_ORIGIN` resolution, `/users/me` base) so its surrounding code is preserved — only the inline `getAuthHeaders` is removed and the import added.

**ig#793** (commit 5c391a5) — route the per-service DB checks in `src/api/routes/health.py` through the application accessors (`PgClient` context manager, `get_redis_client` helper) instead of hand-rolled `psycopg.connect` / `redis.from_url`. `test_health.py` updated to patch the new accessors and adds postgres-down / redis-unavailable degraded-path coverage. **NOTE:** the wave-10 source commit also touched `src/api/routes/admin/health.py` + `test_admin.py` — those are deliberately NOT recovered (`admin/health.py` is on the DO-NOT-TOUCH list; main is newer there).

**ig#803** (commit ddc268a) — move LoginPage OAuth-button hover from inline `onMouseEnter`/`onMouseLeave` JS handlers to CSS `:hover` classes (`.oauth-button-google` / `.oauth-button-github` in `common.css`). Verified main's current LoginPage still had the inline handlers before applying.

**SKIPPED:**
- **ig#794** (remove unused `layoutMode` from GraphExplorerPage) and **ig#802** (remove `--color-primary` oklch fallbacks in the same file). Main went a DIFFERENT way: `layoutMode` is now a live, tested feature on main (a "switches layout mode when a layout button is clicked" vitest added post-wave-10, absent on the wave-10 branch). Recovering #794 would regress main's newer decision and delete its test; #802's second hunk targets the now-divergent layoutMode block. Left GraphExplorerPage at main's version — the cosmetic oklch-fallback debt is not worth coupling to a file main maintains differently.
- **ig#889** (AuthCallbackPage width) — needs runtime verification, per brief.

**Local CI parity:** backend ruff / ruff-format / mypy clean; frontend eslint (0 errors), gen:types + no drift, tsc --noEmit, vitest run (92 tests) — all green. Backend pytest for the health route cannot run in the sandbox (FastAPI lifespan eagerly constructs a `Neo4jClient` against an unavailable `bolt://localhost:7687`, hanging ALL api tests incl. unmodified ones — environment limit, not a code defect); the health test mocks were verified statically against the new accessor names.

Refs noorinalabs-main#520
Recovers ig#791, ig#793, ig#803 (stranded on deployments/phase-3/wave-10)
