### PR TITLE
security(auth): remove ?token= query fallback from AuthCallbackPage (#955)

### DIFF
--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -17,13 +17,14 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     const errorCode = searchParams.get('error')
-    // The access token is read from the URL fragment first: user-service moves
-    // it out of the query string (#68) because query params leak into server
-    // logs, the Referer header, and browser history. The query-param read is a
-    // transition fallback so this works against both the pre-#68 user-service
-    // (token in query) and post-#68 (token in fragment) — and can land first.
-    const hashToken = new URLSearchParams(window.location.hash.slice(1)).get('token')
-    const token = hashToken ?? searchParams.get('token')
+    // The access token is read ONLY from the URL fragment. user-service delivers
+    // it in the fragment (#68) because query params leak into server logs, the
+    // Referer header, and browser history. The `?token=` query fallback that PR
+    // #952 kept for the pre-#68 transition is now removed (#955): us#147 is
+    // deployed, so the backend always sends the token in the fragment. Keeping a
+    // query read alive would re-open the very Referer-leak path #68 closed — a
+    // token arriving on the query string is now treated as untrusted and ignored.
+    const token = new URLSearchParams(window.location.hash.slice(1)).get('token')
     const isNewUser = searchParams.get('is_new_user')
     const needsVerification = searchParams.get('needs_verification')
     const returnUrl = sessionStorage.getItem('oauth_return_url') || '/'

--- a/frontend/src/pages/__tests__/AuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/AuthCallbackPage.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+
+import AuthCallbackPage from "../AuthCallbackPage"
+
+// AuthCallbackPage reads the access token from window.location.hash (the URL
+// fragment) and reads the error/flag params via react-router's useSearchParams
+// (the query string). MemoryRouter controls the query string via initialEntries;
+// window.location.hash is set directly on the jsdom window since the component
+// reads it off window, not the router.
+function renderCallback(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/callback/google${search}`]}>
+      <Routes>
+        <Route path="/auth/callback/:provider" element={<AuthCallbackPage />} />
+        <Route path="/" element={<div>home page</div>} />
+        <Route path="/check-email" element={<div>check email page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function setHash(hash: string) {
+  // jsdom lets us assign location.hash; the component reads window.location.hash.
+  window.location.hash = hash
+}
+
+describe("AuthCallbackPage — token source (#955: fragment-only, query ignored)", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    setHash("")
+  })
+
+  afterEach(() => {
+    setHash("")
+  })
+
+  it("stores the access token when it arrives in the URL fragment", async () => {
+    setHash("#token=frag-token-abc")
+    renderCallback("")
+
+    await waitFor(() => {
+      expect(screen.getByText("home page")).toBeInTheDocument()
+    })
+    expect(localStorage.getItem("access_token")).toBe("frag-token-abc")
+  })
+
+  it("IGNORES a token in the query string (the removed ?token= fallback, #955)", async () => {
+    // Pre-#955 this query token would have been stored via the `?? searchParams`
+    // fallback. Post-#955 the query string is untrusted for tokens — a token
+    // here must NOT be persisted (re-opening the Referer-leak path #68 closed).
+    setHash("")
+    renderCallback("?token=query-token-should-be-ignored")
+
+    await waitFor(() => {
+      expect(screen.getByText("home page")).toBeInTheDocument()
+    })
+    expect(localStorage.getItem("access_token")).toBeNull()
+  })
+
+  it("uses the fragment token even when a query token is also present", async () => {
+    // Belt-and-suspenders: if both are present, the fragment wins and the query
+    // value is never read.
+    setHash("#token=frag-wins")
+    renderCallback("?token=query-loses")
+
+    await waitFor(() => {
+      expect(screen.getByText("home page")).toBeInTheDocument()
+    })
+    expect(localStorage.getItem("access_token")).toBe("frag-wins")
+  })
+
+  it("routes a new user needing verification to /check-email and stores the fragment token", async () => {
+    setHash("#token=frag-token-new")
+    renderCallback("?is_new_user=1&needs_verification=1")
+
+    await waitFor(() => {
+      expect(screen.getByText("check email page")).toBeInTheDocument()
+    })
+    expect(localStorage.getItem("access_token")).toBe("frag-token-new")
+    expect(sessionStorage.getItem("is_new_user")).toBe("1")
+  })
+
+  it("renders the error UI for an error query param without storing any token", async () => {
+    setHash("#token=should-not-be-read-on-error")
+    renderCallback("?error=oauth_exchange_failed")
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign-in failed")).toBeInTheDocument()
+    })
+    // On the error path the component returns before persisting the token.
+    expect(localStorage.getItem("access_token")).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #955

## Summary

Removes the `?token=` query-string fallback from `AuthCallbackPage.tsx`, making OAuth token parsing **fragment-only**. PR #952 (recovery of ig#901) kept a query fallback for the pre-#68 transition window; now that the backend (us#147) is deployed and always sends the token in the URL fragment, the query read is dead code that keeps the legacy **Referer-leak path alive** — a token on the query string leaks into server logs, the `Referer` header, and browser history, the exact exposure #68 closed.

- `AuthCallbackPage` now reads the access token **only** from `window.location.hash`. A token arriving on the query string is untrusted and ignored.
- Error / flag params (`error`, `is_new_user`, `needs_verification`) still come from the query string — non-secret, unchanged.

## Gate evidence (us#147 deployed — live-trace, per the org requirement)

The gate for this issue is "us#147 (backend sends token in fragment) deployed to staging." Verified directly:

**Image provenance (decisive):** the staging `stg-latest` user-service image resolves to digest `sha256:96c76739109a20251f5b3404d8ff3e71444d0dfa9fa7215c148ee754dfddf746`, which carries the tags `stg-d87643c` / `sha-d87643c` / `stg-latest`. The `sha-d87643c` provenance tag = build commit **`d87643c`** = the **us#147 merge commit** ("Merge pull request #147"). That commit's `src/app/routers/auth.py` callback emits the token via `fragment_params={"token": access_token}` (`#token=…`), with only non-secret flags on the query string. So the fragment behavior is in the deployed code by construction. Deployed via deploy run 26855753410 (deploy job: success) after deploy#407 was fixed (PR #411).

**Live probes (staging):**
- `GET https://users.stg.noorinalabs.com/health` → `200`
- `GET https://users.stg.noorinalabs.com/auth/oauth/google/login` → JSON with a valid `authorization_url` (PKCE wired, `redirect_uri` = staging callback) — proves OAuth is live on the new image
- `GET https://users.stg.noorinalabs.com/.well-known/jwks.json` → populated RSA signing keys

(The deploy#414 "Verify Deployment" smoke red is an unrelated pre-carve-out routing probe bug, not user-service health — confirmed by the direct probes above.)

## Test Plan

New `frontend/src/pages/__tests__/AuthCallbackPage.test.tsx` (Vitest + Testing Library):
- fragment token → stored in `localStorage`
- **query-string token → IGNORED** (asserts `localStorage` stays null — the removed fallback)
- both present → fragment wins
- new user + `needs_verification` → routes to `/check-email`, fragment token stored
- `error` param → renders error UI, no token stored

Verified in the worktree (frontend/):
- `npx vitest run` → **102 passed** (18 files; 5 new)
- `npm run lint` → exit 0 (0 errors; the 11 `set-state-in-effect` warnings are all pre-existing and not failing — `lint` has no `--max-warnings`)
- `npx tsc --noEmit` → exit 0

## Background

Flagged by my security review of PR #952 (issuecomment-4598414093). Refs noorinalabs-main#520.

Co-Authored-By: Idris Yusuf <parametrization+Idris.Yusuf@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
