### PR TITLE
fix(config): accept DB/Redis component env vars, build DSN/URL with escaping (#956)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -135,7 +135,7 @@ def create_app() -> FastAPI:
         RateLimitMiddleware,
         requests_per_minute=settings.rate_limit.requests_per_minute,
         window_seconds=settings.rate_limit.window_seconds,
-        redis_url=settings.redis.url,
+        redis_url=settings.redis.effective_url,
     )
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -122,7 +122,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             try:
                 from src.config import get_settings
 
-                url = get_settings().redis.url
+                url = get_settings().redis.effective_url
             except Exception:  # noqa: BLE001
                 return None
         try:

--- a/src/api/routes/admin/health.py
+++ b/src/api/routes/admin/health.py
@@ -67,10 +67,10 @@ def readiness(
         from src.config import get_settings
 
         settings = get_settings()
-        if settings.postgres.dsn:
+        if settings.postgres.effective_dsn:
             import psycopg
 
-            conn = psycopg.connect(str(settings.postgres.dsn))
+            conn = psycopg.connect(str(settings.postgres.effective_dsn))
             conn.close()
             pg_ok = True
     except Exception as exc:
@@ -84,10 +84,10 @@ def readiness(
         from src.config import get_settings
 
         settings = get_settings()
-        if settings.redis.url:
+        if settings.redis.effective_url:
             import redis
 
-            r = redis.from_url(str(settings.redis.url))
+            r = redis.from_url(str(settings.redis.effective_url))
             r.ping()
             redis_ok = True
     except Exception as exc:

--- a/src/cli.py
+++ b/src/cli.py
@@ -44,8 +44,8 @@ def _cmd_info() -> None:
     print(f"  neo4j.uri      : {settings.neo4j.uri}")
     print(f"  neo4j.user     : {settings.neo4j.user}")
     print(f"  neo4j.password : {_mask_password(settings.neo4j.password)}")
-    print(f"  postgres.dsn   : {settings.postgres.dsn}")
-    print(f"  redis.url      : {settings.redis.url}")
+    print(f"  postgres.dsn   : {settings.postgres.effective_dsn}")
+    print(f"  redis.url      : {settings.redis.effective_url}")
     print(f"  log_level      : {settings.log_level}")
     print()
 
@@ -68,7 +68,7 @@ def _cmd_info() -> None:
     try:
         import psycopg
 
-        conn = psycopg.connect(settings.postgres.dsn)
+        conn = psycopg.connect(settings.postgres.effective_dsn)
         conn.close()
         print("  postgres : connected")
     except Exception:  # noqa: BLE001

--- a/src/config.py
+++ b/src/config.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from urllib.parse import quote
 
+from pydantic import computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,11 +20,51 @@ class Neo4jSettings(BaseSettings):
 
 
 class PostgresSettings(BaseSettings):
-    """PostgreSQL connection settings."""
+    """PostgreSQL connection settings.
+
+    The preferred config path is the separate component vars below
+    (PG_HOST/PORT/USER/PASSWORD/DB). When PG_HOST is set, the DSN is built
+    in-app with the user and password percent-encoded via ``urllib.parse.quote``
+    — so a password containing URL-reserved characters (`/`, `+`, `=`, `@`, `:`,
+    `#`, ...) can never corrupt the URL authority and break ``urlparse`` at
+    startup (#956, sibling of user-service #65). PG_DSN is retained as a
+    backward-compatible fallback and as the local-dev default; it is used
+    verbatim only when PG_HOST is unset. Consumers should read
+    :attr:`effective_dsn`, never ``dsn`` directly.
+    """
 
     dsn: str = "postgresql://isnad:isnad_dev@localhost:5432/isnad_graph"
+    host: str | None = None
+    port: int = 5432
+    user: str | None = None
+    password: str | None = None
+    db: str | None = None
+    # Scheme used when building the DSN from components.
+    driver: str = "postgresql"
 
     model_config = SettingsConfigDict(env_prefix="PG_")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_dsn(self) -> str:
+        """The Postgres DSN the app should actually connect with.
+
+        When ``host`` is set, build the DSN from the component vars with the
+        user and password percent-encoded (``safe=""`` so every URL-reserved
+        character is escaped), so a password with URL-unsafe characters can
+        never corrupt the URL. Otherwise fall back to ``dsn`` verbatim
+        (backward compat / local-dev default).
+        """
+        if self.host is None:
+            return self.dsn
+        auth = ""
+        if self.user is not None:
+            auth = quote(self.user, safe="")
+            if self.password is not None:
+                auth += f":{quote(self.password, safe='')}"
+            auth += "@"
+        path = f"/{self.db}" if self.db is not None else ""
+        return f"{self.driver}://{auth}{self.host}:{self.port}{path}"
 
 
 class RateLimitSettings(BaseSettings):
@@ -35,11 +77,45 @@ class RateLimitSettings(BaseSettings):
 
 
 class RedisSettings(BaseSettings):
-    """Redis cache connection settings."""
+    """Redis cache connection settings.
+
+    The preferred config path is the separate component vars below
+    (REDIS_HOST/PORT/PASSWORD/DB, + REDIS_TLS). When REDIS_HOST is set, the URL
+    is built in-app with the password percent-encoded via ``urllib.parse.quote``
+    — so a base64 password containing `/` no longer terminates the URL authority
+    and crashes ``urlparse`` at startup (#956, sibling of user-service #65).
+    REDIS_URL is the backward-compatible fallback / local-dev default, used
+    verbatim only when REDIS_HOST is unset. Consumers should read
+    :attr:`effective_url`, never ``url`` directly.
+    """
 
     url: str = "redis://localhost:6379/0"
+    host: str | None = None
+    port: int = 6379
+    password: str | None = None
+    db: int = 0
+    # Set true to use rediss:// (TLS) when building the URL from components.
+    tls: bool = False
 
     model_config = SettingsConfigDict(env_prefix="REDIS_")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_url(self) -> str:
+        """The Redis connection URL the app should actually connect with.
+
+        When ``host`` is set, build ``redis(s)://[:<encoded-password>@]host:port/db``
+        with the password percent-encoded via ``urllib.parse.quote`` (``safe=""``
+        so `/`, `@`, `:`, `#`, etc. survive ``urlparse``). Otherwise fall back to
+        ``url`` verbatim (backward compat / local-dev default).
+        """
+        if self.host is None:
+            return self.url
+        scheme = "rediss" if self.tls else "redis"
+        auth = ""
+        if self.password:
+            auth = f":{quote(self.password, safe='')}@"
+        return f"{scheme}://{auth}{self.host}:{self.port}/{self.db}"
 
 
 class AuthSettings(BaseSettings):

--- a/src/utils/pg_client.py
+++ b/src/utils/pg_client.py
@@ -23,7 +23,7 @@ class PgClient:
 
     def __init__(self, dsn: str | None = None) -> None:
         settings = get_settings()
-        self._dsn = dsn or settings.postgres.dsn
+        self._dsn = dsn or settings.postgres.effective_dsn
         try:
             self._conn: psycopg.Connection[dict[str, Any]] = psycopg.connect(
                 self._dsn, row_factory=dict_row

--- a/src/utils/redis_client.py
+++ b/src/utils/redis_client.py
@@ -20,7 +20,7 @@ def get_redis_client() -> Any | None:
         import redis
 
         settings = get_settings().redis
-        client = redis.Redis.from_url(settings.url, decode_responses=True)
+        client = redis.Redis.from_url(settings.effective_url, decode_responses=True)
         client.ping()
         return client
     except Exception:  # noqa: BLE001

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,29 @@
 
 from __future__ import annotations
 
+from urllib.parse import unquote, urlparse
+
 import pytest
 
-from src.config import Neo4jSettings, Settings, get_settings
+from src.config import (
+    Neo4jSettings,
+    PostgresSettings,
+    RedisSettings,
+    Settings,
+    get_settings,
+)
+
+# Passwords exercising every URL-reserved character that breaks naive
+# string-interpolation + urlparse — the bug class behind #956 / user-service #65.
+# The base64-style `tW/3+x=` value is the real us#65 prod-crash repro shape.
+URL_HOSTILE_PASSWORDS = [
+    "tW/3+x=",  # the us#65 repro: leading `/` terminates the URL authority
+    "p@ss/w+rd=",
+    "a:b@c/d",
+    "with#hash?q",
+    "100%done",
+    "sl/ash",
+]
 
 
 class TestSettingsDefaults:
@@ -38,6 +58,123 @@ class TestSettingsEnvOverride:
         # Neo4jSettings reads NEO4J_PASSWORD via its own env_prefix
         neo4j = Neo4jSettings()
         assert neo4j.password == "supersecret"
+
+    def test_postgres_component_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # PG_HOST/USER/PASSWORD/DB are read via the PG_ env_prefix and build the DSN.
+        monkeypatch.setenv("PG_HOST", "pg.internal")
+        monkeypatch.setenv("PG_USER", "isnad")
+        monkeypatch.setenv("PG_PASSWORD", "tW/3+x=")  # URL-hostile
+        monkeypatch.setenv("PG_DB", "isnad_graph")
+        pg = PostgresSettings()
+        parsed = urlparse(pg.effective_dsn)
+        assert parsed.hostname == "pg.internal"
+        assert parsed.password is not None
+        assert unquote(parsed.password) == "tW/3+x="
+
+    def test_redis_component_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("REDIS_HOST", "redis.internal")
+        monkeypatch.setenv("REDIS_PASSWORD", "tW/3+x=")  # URL-hostile
+        monkeypatch.setenv("REDIS_DB", "2")
+        r = RedisSettings()
+        parsed = urlparse(r.effective_url)
+        assert parsed.hostname == "redis.internal"
+        assert parsed.path == "/2"
+        assert parsed.password is not None
+        assert unquote(parsed.password) == "tW/3+x="
+
+
+class TestPostgresEffectiveDsn:
+    """PostgresSettings.effective_dsn — component build vs. pre-built fallback (#956)."""
+
+    def test_falls_back_to_dsn_when_host_unset(self) -> None:
+        pg = PostgresSettings(dsn="postgresql://test:test@localhost:5432/test")
+        assert pg.effective_dsn == "postgresql://test:test@localhost:5432/test"
+
+    def test_component_form_takes_precedence_over_prebuilt_dsn(self) -> None:
+        pg = PostgresSettings(
+            dsn="postgresql://ignored:ignored@ignored:9999/ignored",
+            host="pg.internal",
+            port=5432,
+            user="isnad",
+            password="isnad_dev",
+            db="isnad_graph",
+        )
+        assert pg.effective_dsn == "postgresql://isnad:isnad_dev@pg.internal:5432/isnad_graph"
+
+    def test_custom_driver_scheme(self) -> None:
+        pg = PostgresSettings(
+            host="pg.internal", user="u", password="p", db="d", driver="postgresql+psycopg"
+        )
+        assert pg.effective_dsn.startswith("postgresql+psycopg://")
+
+    def test_host_only_no_credentials(self) -> None:
+        pg = PostgresSettings(host="pg.internal", port=5432, db="isnad_graph")
+        assert pg.effective_dsn == "postgresql://pg.internal:5432/isnad_graph"
+
+    @pytest.mark.parametrize("password", URL_HOSTILE_PASSWORDS)
+    def test_special_char_password_round_trips(self, password: str) -> None:
+        pg = PostgresSettings(
+            host="pg.internal",
+            port=5432,
+            user="isnad",
+            password=password,
+            db="isnad_graph",
+        )
+        parsed = urlparse(pg.effective_dsn)
+        # The special chars must NOT corrupt the authority — host/port parse cleanly.
+        assert parsed.hostname == "pg.internal"
+        assert parsed.port == 5432
+        assert parsed.path == "/isnad_graph"
+        assert parsed.username == "isnad"
+        # The raw password survives a round-trip back out of the URL.
+        assert parsed.password is not None
+        assert unquote(parsed.password) == password
+
+    @pytest.mark.parametrize("user", ["us+er", "a/b", "u@h"])
+    def test_special_char_username_round_trips(self, user: str) -> None:
+        pg = PostgresSettings(host="pg.internal", user=user, password="p", db="d")
+        parsed = urlparse(pg.effective_dsn)
+        assert parsed.hostname == "pg.internal"
+        assert parsed.username is not None
+        assert unquote(parsed.username) == user
+
+
+class TestRedisEffectiveUrl:
+    """RedisSettings.effective_url — component build vs. pre-built fallback (#956)."""
+
+    def test_falls_back_to_url_when_host_unset(self) -> None:
+        r = RedisSettings(url="redis://localhost:6379/0")
+        assert r.effective_url == "redis://localhost:6379/0"
+
+    def test_component_form_takes_precedence_over_prebuilt_url(self) -> None:
+        r = RedisSettings(
+            url="redis://ignored:1111/9",
+            host="redis.internal",
+            port=6379,
+            password="cachepw",
+            db=2,
+        )
+        assert r.effective_url == "redis://:cachepw@redis.internal:6379/2"
+
+    def test_no_password_omits_auth(self) -> None:
+        r = RedisSettings(host="redis.internal", port=6379, db=0)
+        assert r.effective_url == "redis://redis.internal:6379/0"
+
+    def test_tls_uses_rediss_scheme(self) -> None:
+        r = RedisSettings(host="redis.internal", tls=True)
+        assert r.effective_url.startswith("rediss://")
+
+    @pytest.mark.parametrize("password", URL_HOSTILE_PASSWORDS)
+    def test_special_char_password_round_trips(self, password: str) -> None:
+        r = RedisSettings(host="redis.internal", port=6379, password=password, db=0)
+        parsed = urlparse(r.effective_url)
+        # The first `/` in a base64 password used to terminate the authority and
+        # make urlparse read the next chars as host:port and crash (#65/#956).
+        assert parsed.hostname == "redis.internal"
+        assert parsed.port == 6379
+        assert parsed.path == "/0"
+        assert parsed.password is not None
+        assert unquote(parsed.password) == password
 
 
 class TestGetSettings:


### PR DESCRIPTION
## Summary

Closes #956 (Tier 5 tech-debt; sibling of user-service #65).

The isnad-graph API consumes pre-built `PG_DSN` and `REDIS_URL` env values
(`src/config.py` `PostgresSettings.dsn`, `RedisSettings.url`). Whoever composes
those values (deploy compose) string-interpolates the password — a password
containing URL-reserved characters (`/`, `+`, `=`, `@`, `:`, `#`) corrupts the URL
authority and crashes `urlparse` at startup, exactly the user-service #65 prod
crash. Latent here only because the current passwords happen to be URL-safe.

## Change

Accept separate connection-**component** env vars as the preferred config path and
build the connection string in-app with credentials percent-encoded, so a
special-char password can never break parsing:

- **Postgres** — `PG_HOST` / `PG_PORT` / `PG_USER` / `PG_PASSWORD` / `PG_DB`
  (+ `PG_DRIVER`). New computed `PostgresSettings.effective_dsn` builds the DSN
  with user + password URL-encoded via `urllib.parse.quote(safe="")`.
- **Redis** — `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD` / `REDIS_DB`
  (+ `REDIS_TLS`). New computed `RedisSettings.effective_url` builds
  `redis(s)://[:<encoded-pw>@]host:port/db` with the password percent-encoded.

Both `effective_*` properties fall back to the pre-built `PG_DSN` / `REDIS_URL`
**verbatim** when the host var is unset — backward-compatible and the local-dev
default. The component form takes precedence when present.

All runtime consumers now read `effective_dsn` / `effective_url` instead of the
raw `dsn` / `url`: `PgClient`, `get_redis_client`, `RateLimitMiddleware`
(`app.py` + `middleware.py` fallback), admin `/health` probes, and `cli info`.

## Approach parity with us#65

Mirrors `ae4d08d` in user-service. isnad-graph has **no SQLAlchemy** dependency
(it uses `psycopg` directly), so the Postgres DSN is built directly with
`urllib.parse.quote` escaping rather than `sqlalchemy.URL.create`.

## Tests

`tests/test_config.py` adds:
- Parametrized round-trip tests for passwords containing `/ + = @ : # %`,
  including the us#65 repro shape `tW/3+x=` — asserting host/port parse cleanly
  and the raw password decodes back out of both the DSN and the Redis URL.
- Special-char **username** round-trip (Postgres).
- Component-env-var path tests (`PG_HOST`/`REDIS_HOST` etc. read via the env
  prefix and build the connection string).
- Fallback-to-prebuilt and component-takes-precedence assertions.

## Follow-up (not this PR)

noorinalabs-deploy: rewrite the compose env list to pass the component vars
instead of the pre-composed `PG_DSN` / `REDIS_URL`. Until then this PR is fully
backward-compatible — the verbatim-fallback path is unchanged.

## Reviewers

@AnyaKowalczyk @ArjunRaghavan — 2 Approved required.
