### PR TITLE
fix(search): narrator fulltext index on deploy + graceful CONTAINS fallback

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -17,6 +18,8 @@ from src.api.middleware import (
     require_auth,
 )
 
+log = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -30,6 +33,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         user=settings.neo4j.user,
         password=settings.neo4j.password,
     )
+    # Ensure the search full-text indexes exist on the deployed graph. The
+    # statements are idempotent (``IF NOT EXISTS``); this is the one path
+    # guaranteed to run on every deploy, since data may be loaded out-of-band
+    # (e.g. via cypher-shell) without going through the loader. Best-effort: a
+    # transiently unavailable Neo4j must not block API startup — search degrades
+    # gracefully to CONTAINS until the index is present.
+    try:
+        app.state.neo4j.ensure_fulltext_indexes()
+    except Exception:  # noqa: BLE001 — startup must not fail on index setup
+        log.warning("ensure_fulltext_indexes failed at startup", exc_info=True)
     yield
     app.state.neo4j.close()
 

--- a/src/api/routes/narrators.py
+++ b/src/api/routes/narrators.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
@@ -9,6 +12,49 @@ from src.api.models import NarratorResponse, PaginatedResponse
 from src.utils.neo4j_client import Neo4jClient
 
 router = APIRouter()
+
+log = logging.getLogger(__name__)
+
+
+def _search_narrators(
+    neo4j: Neo4jClient, q: str, skip: int, limit: int
+) -> tuple[int, list[dict[str, Any]]]:
+    """Search narrators by ``q``, returning ``(total, rows)``.
+
+    Prefers the ``narrator_search`` full-text index (ranked by relevance) and
+    falls back to a parameterized ``CONTAINS`` match when the index is absent
+    (e.g. not yet created on a freshly provisioned graph). Both branches issue a
+    single query that returns the full match count via ``size()`` plus the
+    requested page slice, so the endpoint never 500s on a missing index.
+    """
+    try:
+        # Quote the term so the Lucene parser treats it as a phrase and special
+        # characters in user input don't break query parsing.
+        escaped = q.replace("\\", "\\\\").replace('"', '\\"')
+        search_term = f'"{escaped}"'
+        result = neo4j.execute_read(
+            "CALL db.index.fulltext.queryNodes('narrator_search', $term) "
+            "YIELD node, score "
+            "WITH node, score ORDER BY score DESC "
+            "WITH collect({props: properties(node)}) AS all_rows "
+            "RETURN size(all_rows) AS total, "
+            "all_rows[$skip .. $skip + $limit] AS rows",
+            {"term": search_term, "skip": skip, "limit": limit},
+        )
+    except Exception:  # noqa: BLE001 — degrade on any index/query failure
+        log.debug("fulltext narrator_search unavailable, falling back to CONTAINS")
+        result = neo4j.execute_read(
+            "MATCH (n:Narrator) "
+            "WHERE n.name_ar CONTAINS $q OR n.name_en CONTAINS $q "
+            "WITH n ORDER BY n.id "
+            "WITH collect({props: properties(n)}) AS all_rows "
+            "RETURN size(all_rows) AS total, "
+            "all_rows[$skip .. $skip + $limit] AS rows",
+            {"q": q, "skip": skip, "limit": limit},
+        )
+    total = result[0]["total"] if result else 0
+    rows = result[0]["rows"] if result else []
+    return total, rows
 
 
 @router.get("/narrators", response_model=PaginatedResponse[NarratorResponse])
@@ -22,27 +68,14 @@ def list_narrators(
 
     When the ``q`` parameter is provided the endpoint queries the
     ``narrator_search`` full-text index (covers ``name_ar`` and ``name_en``)
-    and returns results ranked by relevance score.
+    and returns results ranked by relevance score. If that index is not present
+    on the graph the endpoint degrades to a ``CONTAINS`` substring match rather
+    than returning a 500.
     """
     skip = (page - 1) * limit
 
     if q:
-        # Single fulltext query: collect all matches, return total via size()
-        # and paginated slice to avoid executing the fulltext index twice.
-        escaped = q.replace("\\", "\\\\").replace('"', '\\"')
-        search_term = f'"{escaped}"'
-
-        result = neo4j.execute_read(
-            "CALL db.index.fulltext.queryNodes('narrator_search', $term) "
-            "YIELD node, score "
-            "WITH node, score ORDER BY score DESC "
-            "WITH collect({props: properties(node)}) AS all_rows "
-            "RETURN size(all_rows) AS total, "
-            "all_rows[$skip .. $skip + $limit] AS rows",
-            {"term": search_term, "skip": skip, "limit": limit},
-        )
-        total = result[0]["total"] if result else 0
-        rows = result[0]["rows"] if result else []
+        total, rows = _search_narrators(neo4j, q, skip, limit)
     else:
         count_result = neo4j.execute_read(
             "MATCH (n:Narrator) RETURN count(n) AS total",

--- a/tests/test_api/test_app_lifespan.py
+++ b/tests/test_api/test_app_lifespan.py
@@ -1,0 +1,71 @@
+"""Tests for the FastAPI app lifespan — Neo4j wiring and index bootstrap."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+@asynccontextmanager
+async def _no_settings_cache():  # type: ignore[no-untyped-def]
+    """Keep ``get_settings`` cache from leaking real config between tests."""
+    from src.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        yield
+    finally:
+        get_settings.cache_clear()
+
+
+def _patch_neo4j(monkeypatch: pytest.MonkeyPatch, client: MagicMock) -> None:
+    """Make the lifespan construct ``client`` instead of a real Neo4jClient."""
+    import src.utils.neo4j_client as neo4j_module
+
+    monkeypatch.setattr(neo4j_module, "Neo4jClient", lambda **_: client)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_ensures_fulltext_indexes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup creates the search full-text indexes (idempotent bootstrap)."""
+    from src.api.app import lifespan
+
+    fake_client = MagicMock()
+    _patch_neo4j(monkeypatch, fake_client)
+
+    app: FastAPI = MagicMock()
+    async with _no_settings_cache():
+        async with lifespan(app):
+            pass
+
+    fake_client.ensure_fulltext_indexes.assert_called_once()
+    fake_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_survives_index_bootstrap_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transiently-unavailable Neo4j must not block API startup."""
+    from src.api.app import lifespan
+
+    fake_client = MagicMock()
+    fake_client.ensure_fulltext_indexes.side_effect = Exception("Neo4j unavailable")
+    _patch_neo4j(monkeypatch, fake_client)
+
+    app: FastAPI = MagicMock()
+    async with _no_settings_cache():
+        # Must not raise despite the index bootstrap failing.
+        async with lifespan(app):
+            pass
+
+    fake_client.ensure_fulltext_indexes.assert_called_once()
+    fake_client.close.assert_called_once()

--- a/tests/test_api/test_narrators.py
+++ b/tests/test_api/test_narrators.py
@@ -102,6 +102,47 @@ def test_list_narrators_fulltext_search_pagination(
     assert params["limit"] == 10
 
 
+def test_list_narrators_search_falls_back_to_contains(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """When ``narrator_search`` is absent, search degrades to CONTAINS (no 500)."""
+    # First call (fulltext) raises as Neo4j does for a missing index;
+    # second call (CONTAINS fallback) succeeds.
+    mock_neo4j.execute_read.side_effect = [
+        Exception("There is no such fulltext schema index: narrator_search"),
+        [{"total": 1, "rows": [{"props": SAMPLE_NARRATOR}]}],
+    ]
+    resp = client.get("/api/v1/narrators?q=Abu")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["name_en"] == "Abu Hurayra"
+
+    # Fulltext attempted first, then the CONTAINS fallback.
+    assert mock_neo4j.execute_read.call_count == 2
+    fallback_query = mock_neo4j.execute_read.call_args_list[1][0][0]
+    assert "CONTAINS" in fallback_query
+    assert "fulltext.queryNodes" not in fallback_query
+    # Fallback matches on the raw query, not the Lucene-quoted phrase.
+    assert mock_neo4j.execute_read.call_args_list[1][0][1]["q"] == "Abu"
+
+
+def test_list_narrators_search_fallback_empty_not_500(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Missing index + no CONTAINS matches yields an empty 200, never a 500."""
+    mock_neo4j.execute_read.side_effect = [
+        Exception("There is no such fulltext schema index: narrator_search"),
+        [{"total": 0, "rows": []}],
+    ]
+    resp = client.get("/api/v1/narrators?q=Nobody")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
 def test_get_narrator_found(client: TestClient, mock_neo4j: MagicMock) -> None:
     """GET /api/v1/narrators/{id} returns narrator when found."""
     mock_neo4j.execute_read.return_value = [{"props": SAMPLE_NARRATOR}]


### PR DESCRIPTION
## What

Fixes the stg narrator-search **HTTP 500** (`There is no such fulltext schema index: narrator_search`) from #963, in two parts:

### 1. Create the fulltext indexes on every deploy
`Neo4jClient.ensure_fulltext_indexes()` already existed (`CREATE FULLTEXT INDEX narrator_search / hadith_search IF NOT EXISTS`) but was only reachable via the loader path — which da#73's direct-cypher first-light load bypassed, so the index was never created on stg. This wires it into the **API lifespan startup**, so it runs idempotently on every deploy regardless of how data was loaded. It is **best-effort**: a transiently unavailable Neo4j logs a warning rather than blocking startup (search degrades gracefully until the index exists).

### 2. Graceful fallback in `/narrators`
The `q`-search path called `db.index.fulltext.queryNodes('narrator_search', …)` with no guard → a missing index threw → 500. Factored into `_search_narrators()`, which tries the fulltext index and, on any failure, degrades to a parameterized `CONTAINS` match on `name_ar`/`name_en` — the same pattern `/search` already uses. The endpoint **never 500s on a missing index**; ranked results when present, substring matches otherwise. Both branches preserve the single-query `total` + page-slice semantics.

## Coordination
- Touches only `/narrators` (the index/500 path). Jun-Seo's #966 owns the `/search` empty-`q` 422 validation path — no overlap.

## Testing
- **`tests/test_api/test_narrators.py`** — added: fallback-to-CONTAINS on a missing index (asserts 2nd query uses `CONTAINS`, raw `q` param, no 500); empty-fallback returns 200 not 500. Existing single-fulltext-query tests unchanged.
- **`tests/test_api/test_app_lifespan.py`** (new) — startup invokes `ensure_fulltext_indexes()`; a bootstrap failure does **not** block startup.

### Verified locally
- `ruff check` + `ruff format --check` clean; `mypy` clean.
- `test_app_lifespan.py` — **2/2 pass**.
- `_search_narrators` fulltext / fallback / empty paths — pass via direct unit invocation.
- The full TestClient narrator suite could not be run to completion locally (no local Docker/Redis + a contended box; the ASGI TestClient stalls after the first test). **CI is authoritative for that suite** — consistent with the repo's no-local-Docker policy.

### Deferred (post-merge, needs stg)
- Run `ensure_fulltext_indexes()` against **stg Neo4j** and confirm `GET /api/v1/narrators?q=…` returns 200 (immediate stg mitigation called out in the issue).
- Loading **Narrator** data (resolve/NER stage) so the explorer is populated is a separate, larger W3 item.

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)
