### PR TITLE
feat(admin): 404 for authed non-admins + restrict admin route (#804)

### DIFF
--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,16 +1,23 @@
-import { Outlet } from 'react-router-dom'
+import { Navigate, Outlet } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
 export default function AdminRoute() {
-  const { hasRole } = useAuth()
+  const { hasRole, loading } = useAuth()
 
+  // Wait for the auth context to resolve before deciding — otherwise an admin
+  // who reloads on an /admin URL would be bounced to "/" during the brief
+  // window where `user` is still null (hasRole('admin') === false).
+  if (loading) {
+    return null
+  }
+
+  // Non-admins are silently redirected home rather than shown a 403. Pairing
+  // this with the API's 404 (see middleware.require_admin, ig#804), the admin
+  // area is not surfaced as a forbidden-but-existing destination — it simply
+  // does not exist for non-admins. The admin nav entry is likewise hidden in
+  // Sidebar via `{isAdmin && ...}`.
   if (!hasRole('admin')) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
-        <h1 className="text-4xl font-bold">403</h1>
-        <p className="text-muted-foreground">You do not have permission to access this page.</p>
-      </div>
-    )
+    return <Navigate to="/" replace />
   }
 
   return <Outlet />

--- a/frontend/src/components/__tests__/AdminRoute.test.tsx
+++ b/frontend/src/components/__tests__/AdminRoute.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import AdminRoute from "../AdminRoute"
+import type { UserRole } from "../../hooks/useAuth"
+
+const mockUseAuth = vi.fn()
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+// Stub matching the shape AdminRoute reads: `hasRole` + `loading`. `hasRole`
+// is derived from a granted role so the guard logic (not a hand-wired boolean)
+// is what's under test.
+function authStub(role: UserRole, loading = false) {
+  const RANK: Record<UserRole, number> = {
+    trial: 0,
+    reader: 1,
+    researcher: 2,
+    admin: 3,
+  }
+  return {
+    loading,
+    hasRole: (min: UserRole) => RANK[role] >= RANK[min],
+  }
+}
+
+function renderAdmin() {
+  return render(
+    <MemoryRouter initialEntries={["/admin"]}>
+      <Routes>
+        <Route path="/" element={<div>home page</div>} />
+        <Route element={<AdminRoute />}>
+          <Route path="/admin" element={<div>admin content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("AdminRoute", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+  })
+
+  it("renders the admin outlet for an admin user", () => {
+    mockUseAuth.mockReturnValue(authStub("admin"))
+
+    renderAdmin()
+    expect(screen.getByText("admin content")).toBeInTheDocument()
+  })
+
+  it("silently redirects a non-admin user to home (no 403 panel) — ig#804", () => {
+    mockUseAuth.mockReturnValue(authStub("researcher"))
+
+    renderAdmin()
+    expect(screen.getByText("home page")).toBeInTheDocument()
+    expect(screen.queryByText("admin content")).not.toBeInTheDocument()
+    // The old 403 forbidden panel must be gone — non-admins should not even
+    // learn the admin area exists.
+    expect(screen.queryByText("403")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing (no premature redirect) while auth is still loading", () => {
+    mockUseAuth.mockReturnValue(authStub("admin", /* loading */ true))
+
+    renderAdmin()
+    // Neither the admin content nor a redirect home — we wait for auth to settle
+    // so an admin reloading on /admin is not bounced during the null-user window.
+    expect(screen.queryByText("admin content")).not.toBeInTheDocument()
+    expect(screen.queryByText("home page")).not.toBeInTheDocument()
+  })
+})

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -284,13 +284,25 @@ def require_role(min_role: Role) -> Callable[..., object]:
 
 
 async def require_admin(request: Request) -> User:
-    """Require authenticated user with admin role. Return 403 if not admin."""
+    """Require an authenticated admin user, hiding the admin surface from others.
+
+    Returns **404 Not Found** (not 403) when an authenticated, non-admin user
+    hits an admin route, so the existence of the admin area is not disclosed to
+    anyone who could probe it with valid credentials (ig#804). The 404 detail
+    deliberately mirrors FastAPI's default ("Not Found") so the response is
+    indistinguishable from a genuinely missing route.
+
+    Anonymous / invalid-token requests still receive 401 from ``require_auth``:
+    that response is identical on every authenticated route, so it does not
+    single out the admin surface, whereas a 403-vs-404 authz differential would.
+    A 503 (auth backend unreachable) likewise propagates unchanged.
+    """
     user = await require_auth(request)
     user_role = Role(user.role) if user.role in {r.value for r in Role} else Role.VIEWER
     is_role_admin = ROLE_HIERARCHY.get(user_role, 0) >= ROLE_HIERARCHY[Role.ADMIN]
 
     if not is_role_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+        raise HTTPException(status_code=404, detail="Not Found")
     return user
 
 

--- a/tests/integration/test_cross_service_auth.py
+++ b/tests/integration/test_cross_service_auth.py
@@ -281,7 +281,8 @@ class TestRoleBasedAccessControl:
                 "/api/v1/admin/users",
                 headers={"Authorization": f"Bearer {token}"},
             )
-        assert resp.status_code == 403
+        # Non-admins get 404 — the admin surface is hidden (ig#804).
+        assert resp.status_code == 404
 
     def test_moderator_blocked_from_admin_endpoints(self, client: TestClient) -> None:
         token = _make_token(roles=["moderator"])
@@ -290,7 +291,8 @@ class TestRoleBasedAccessControl:
                 "/api/v1/admin/users",
                 headers={"Authorization": f"Bearer {token}"},
             )
-        assert resp.status_code == 403
+        # Non-admins get 404 — the admin surface is hidden (ig#804).
+        assert resp.status_code == 404
 
     def test_researcher_maps_to_editor_role(
         self, client: TestClient, mock_neo4j: MagicMock

--- a/tests/test_api/test_admin.py
+++ b/tests/test_api/test_admin.py
@@ -113,10 +113,11 @@ def regular_app(mock_neo4j: MagicMock) -> FastAPI:
 
     from fastapi import HTTPException
 
-    def _raise_forbidden() -> User:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    def _raise_not_found() -> User:
+        # Mirrors require_admin's hide-existence 404 for non-admins (ig#804).
+        raise HTTPException(status_code=404, detail="Not Found")
 
-    app.dependency_overrides[require_admin] = _raise_forbidden
+    app.dependency_overrides[require_admin] = _raise_not_found
     return app
 
 
@@ -452,6 +453,6 @@ class TestAdminAuthEnforcement:
         resp = noauth_client.get("/api/v1/admin/stats")
         assert resp.status_code == 401
 
-    def test_non_admin_returns_403(self, regular_client: TestClient) -> None:
+    def test_non_admin_returns_404(self, regular_client: TestClient) -> None:
         resp = regular_client.get("/api/v1/admin/stats")
-        assert resp.status_code == 403
+        assert resp.status_code == 404

--- a/tests/test_api/test_admin_auth.py
+++ b/tests/test_api/test_admin_auth.py
@@ -50,16 +50,17 @@ def noauth_client(noauth_app: FastAPI) -> TestClient:
 
 @pytest.fixture
 def regular_app(mock_neo4j: MagicMock) -> FastAPI:
-    """App with non-admin user — all admin endpoints should return 403."""
+    """App with non-admin user — all admin endpoints should return 404 (ig#804)."""
     from src.api.app import create_app
 
     app = create_app()
     app.state.neo4j = mock_neo4j
 
-    def _raise_forbidden() -> User:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    def _raise_not_found() -> User:
+        # Mirrors require_admin's hide-existence 404 for non-admins (ig#804).
+        raise HTTPException(status_code=404, detail="Not Found")
 
-    app.dependency_overrides[require_admin] = _raise_forbidden
+    app.dependency_overrides[require_admin] = _raise_not_found
     return app
 
 
@@ -110,29 +111,100 @@ class TestAllEndpoints401:
         assert resp.status_code == 401
 
 
-class TestAllEndpoints403:
-    """Verify every admin endpoint returns 403 for non-admin users."""
+class TestAllEndpoints404:
+    """Verify every admin endpoint returns 404 (not 403) for non-admin users.
+
+    A 404 hides the existence of the admin surface from authenticated non-admins
+    who could otherwise distinguish a forbidden-but-real route from a missing one
+    (ig#804). See ``test_require_admin_guard`` below for the unit-level proof.
+    """
 
     @pytest.mark.parametrize("endpoint", ADMIN_GET_ENDPOINTS)
-    def test_get_endpoints_403(self, regular_client: TestClient, endpoint: str) -> None:
+    def test_get_endpoints_404(self, regular_client: TestClient, endpoint: str) -> None:
         resp = regular_client.get(endpoint)
-        assert resp.status_code == 403, f"{endpoint} returned {resp.status_code}"
+        assert resp.status_code == 404, f"{endpoint} returned {resp.status_code}"
 
-    def test_patch_moderation_403(self, regular_client: TestClient) -> None:
+    def test_patch_moderation_404(self, regular_client: TestClient) -> None:
         resp = regular_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
-    def test_post_flag_403(self, regular_client: TestClient) -> None:
+    def test_post_flag_404(self, regular_client: TestClient) -> None:
         resp = regular_client.post(
             "/api/v1/admin/moderation/flag",
             json={"entity_type": "hadith", "entity_id": "h1", "reason": "test"},
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
-    def test_patch_config_403(self, regular_client: TestClient) -> None:
+    def test_patch_config_404(self, regular_client: TestClient) -> None:
         resp = regular_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
-    def test_patch_user_403(self, regular_client: TestClient) -> None:
+    def test_patch_user_404(self, regular_client: TestClient) -> None:
         resp = regular_client.patch("/api/v1/admin/users/u1", json={"is_admin": True})
-        assert resp.status_code == 403
+        assert resp.status_code == 404
+
+
+class TestRequireAdminGuard:
+    """Unit-level proof of the ``require_admin`` guard contract (ig#804).
+
+    Exercises the guard function directly — admin / non-admin / anonymous /
+    auth-backend-down — by stubbing ``require_auth``, so the status-code mapping
+    is pinned independently of router wiring. The request object is never read by
+    the guard once ``require_auth`` is stubbed, so a bare ``MagicMock`` suffices.
+    """
+
+    @staticmethod
+    def _user(role: str) -> User:
+        return User(id="u1", email="u@example.com", name="u", role=role)
+
+    @pytest.mark.asyncio
+    async def test_admin_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.api.middleware as mw
+
+        async def _auth(_request: object) -> User:
+            return self._user("admin")
+
+        monkeypatch.setattr(mw, "require_auth", _auth)
+        user = await mw.require_admin(MagicMock())
+        assert user.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_non_admin_raises_404(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.api.middleware as mw
+
+        async def _auth(_request: object) -> User:
+            return self._user("viewer")
+
+        monkeypatch.setattr(mw, "require_auth", _auth)
+        with pytest.raises(HTTPException) as exc:
+            await mw.require_admin(MagicMock())
+        # 404 (not 403) + the default detail so it is indistinguishable from a
+        # genuinely missing route.
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Not Found"
+
+    @pytest.mark.asyncio
+    async def test_anonymous_propagates_401(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.api.middleware as mw
+
+        async def _auth(_request: object) -> User:
+            raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+
+        monkeypatch.setattr(mw, "require_auth", _auth)
+        with pytest.raises(HTTPException) as exc:
+            await mw.require_admin(MagicMock())
+        # Anonymous stays 401 — uniform across every authed route, so it does not
+        # single out the admin surface the way a 403-vs-404 differential would.
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_auth_backend_down_propagates_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import src.api.middleware as mw
+
+        async def _auth(_request: object) -> User:
+            raise HTTPException(status_code=503, detail="Authentication service unavailable")
+
+        monkeypatch.setattr(mw, "require_auth", _auth)
+        with pytest.raises(HTTPException) as exc:
+            await mw.require_admin(MagicMock())
+        assert exc.value.status_code == 503

--- a/tests/test_api/test_admin_config.py
+++ b/tests/test_api/test_admin_config.py
@@ -225,10 +225,11 @@ class TestConfigAuthEnforcement:
         app = create_app()
         app.state.neo4j = mock_neo4j
 
-        def _raise_forbidden() -> User:
-            raise HTTPException(status_code=403, detail="Admin access required")
+        def _raise_not_found() -> User:
+            # Mirrors require_admin's hide-existence 404 for non-admins (ig#804).
+            raise HTTPException(status_code=404, detail="Not Found")
 
-        app.dependency_overrides[require_admin] = _raise_forbidden
+        app.dependency_overrides[require_admin] = _raise_not_found
         return app
 
     @pytest.fixture
@@ -239,22 +240,22 @@ class TestConfigAuthEnforcement:
         resp = noauth_client.get("/api/v1/admin/config")
         assert resp.status_code == 401
 
-    def test_get_config_403(self, regular_client: TestClient) -> None:
+    def test_get_config_404(self, regular_client: TestClient) -> None:
         resp = regular_client.get("/api/v1/admin/config")
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     def test_patch_config_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
         assert resp.status_code == 401
 
-    def test_patch_config_403(self, regular_client: TestClient) -> None:
+    def test_patch_config_404(self, regular_client: TestClient) -> None:
         resp = regular_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 10})
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     def test_audit_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.get("/api/v1/admin/config/audit")
         assert resp.status_code == 401
 
-    def test_audit_403(self, regular_client: TestClient) -> None:
+    def test_audit_404(self, regular_client: TestClient) -> None:
         resp = regular_client.get("/api/v1/admin/config/audit")
-        assert resp.status_code == 403
+        assert resp.status_code == 404

--- a/tests/test_api/test_admin_moderation.py
+++ b/tests/test_api/test_admin_moderation.py
@@ -253,10 +253,11 @@ class TestModerationAuthEnforcement:
         app = create_app()
         app.state.neo4j = mock_neo4j
 
-        def _raise_forbidden() -> User:
-            raise HTTPException(status_code=403, detail="Admin access required")
+        def _raise_not_found() -> User:
+            # Mirrors require_admin's hide-existence 404 for non-admins (ig#804).
+            raise HTTPException(status_code=404, detail="Not Found")
 
-        app.dependency_overrides[require_admin] = _raise_forbidden
+        app.dependency_overrides[require_admin] = _raise_not_found
         return app
 
     @pytest.fixture
@@ -267,17 +268,17 @@ class TestModerationAuthEnforcement:
         resp = noauth_client.get("/api/v1/admin/moderation")
         assert resp.status_code == 401
 
-    def test_list_403(self, regular_client: TestClient) -> None:
+    def test_list_404(self, regular_client: TestClient) -> None:
         resp = regular_client.get("/api/v1/admin/moderation")
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     def test_patch_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
         assert resp.status_code == 401
 
-    def test_patch_403(self, regular_client: TestClient) -> None:
+    def test_patch_404(self, regular_client: TestClient) -> None:
         resp = regular_client.patch("/api/v1/admin/moderation/some-id", json={"status": "approved"})
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     def test_flag_401(self, noauth_client: TestClient) -> None:
         resp = noauth_client.post(
@@ -286,9 +287,9 @@ class TestModerationAuthEnforcement:
         )
         assert resp.status_code == 401
 
-    def test_flag_403(self, regular_client: TestClient) -> None:
+    def test_flag_404(self, regular_client: TestClient) -> None:
         resp = regular_client.post(
             "/api/v1/admin/moderation/flag",
             json={"entity_type": "hadith", "entity_id": "h1", "reason": "test"},
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 404

--- a/tests/test_api/test_admin_reports.py
+++ b/tests/test_api/test_admin_reports.py
@@ -138,10 +138,11 @@ class TestReportsAuthEnforcement:
         app = create_app()
         app.state.neo4j = mock_neo4j
 
-        def _raise_forbidden() -> User:
-            raise HTTPException(status_code=403, detail="Admin access required")
+        def _raise_not_found() -> User:
+            # Mirrors require_admin's hide-existence 404 for non-admins (ig#804).
+            raise HTTPException(status_code=404, detail="Not Found")
 
-        app.dependency_overrides[require_admin] = _raise_forbidden
+        app.dependency_overrides[require_admin] = _raise_not_found
         return app
 
     @pytest.fixture
@@ -152,6 +153,6 @@ class TestReportsAuthEnforcement:
         resp = noauth_client.get("/api/v1/admin/reports")
         assert resp.status_code == 401
 
-    def test_reports_403(self, regular_client: TestClient) -> None:
+    def test_reports_404(self, regular_client: TestClient) -> None:
         resp = regular_client.get("/api/v1/admin/reports")
-        assert resp.status_code == 403
+        assert resp.status_code == 404

--- a/tests/test_auth/test_jwt_validation.py
+++ b/tests/test_auth/test_jwt_validation.py
@@ -261,7 +261,8 @@ class TestRoleBasedAccess:
                 "/api/v1/admin/users",
                 headers={"Authorization": "Bearer viewer-token"},
             )
-        assert resp.status_code == 403
+        # Non-admins get 404, not 403 — the admin surface is hidden (ig#804).
+        assert resp.status_code == 404
 
     def test_researcher_maps_to_editor(self) -> None:
         from src.api.auth import Role

--- a/tests/test_security/test_idor.py
+++ b/tests/test_security/test_idor.py
@@ -14,12 +14,16 @@ class TestIDORUserEndpoints:
     """Non-admin user must not be able to view or modify other users via admin routes."""
 
     def test_cannot_view_other_user_via_admin(self, client: TestClient, valid_token: str) -> None:
-        """Regular user cannot GET another user's details from admin endpoint."""
+        """Regular user cannot GET another user's details from admin endpoint.
+
+        The admin surface 404s for non-admins (ig#804), so the attempt is
+        indistinguishable from a missing route rather than a forbidden one.
+        """
         response = client.get(
             "/api/v1/admin/users/admin-user-001",
             headers={"Authorization": f"Bearer {valid_token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     def test_cannot_modify_other_user_via_admin(self, client: TestClient, valid_token: str) -> None:
         """Regular user cannot PATCH another user's record."""
@@ -28,7 +32,7 @@ class TestIDORUserEndpoints:
             json={"role": "viewer"},
             headers={"Authorization": f"Bearer {valid_token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
 
 
 class TestIDEnumeration:

--- a/tests/test_security/test_privilege_escalation.py
+++ b/tests/test_security/test_privilege_escalation.py
@@ -19,15 +19,19 @@ ADMIN_ENDPOINTS: list[tuple[str, str]] = [
 
 
 class TestNonAdminCannotAccessAdminRoutes:
-    """A valid token for a non-admin user must return 403 on admin endpoints."""
+    """A valid token for a non-admin user must return 404 on admin endpoints.
+
+    404 (not 403) hides the existence of the admin surface from authenticated
+    non-admins (ig#804).
+    """
 
     @pytest.mark.parametrize("method,path", ADMIN_ENDPOINTS)
-    def test_regular_user_gets_403(
+    def test_regular_user_gets_404(
         self, client: TestClient, valid_token: str, method: str, path: str
     ) -> None:
         response = client.request(method, path, headers={"Authorization": f"Bearer {valid_token}"})
-        assert response.status_code == 403, (
-            f"Non-admin user should get 403 on {method} {path}, got {response.status_code}"
+        assert response.status_code == 404, (
+            f"Non-admin user should get 404 on {method} {path}, got {response.status_code}"
         )
 
     @pytest.mark.parametrize("method,path", ADMIN_ENDPOINTS)
@@ -51,7 +55,7 @@ class TestAdminUserUpdate:
             json={"is_admin": True},
             headers={"Authorization": f"Bearer {valid_token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     def test_non_admin_cannot_suspend_user(self, client: TestClient, valid_token: str) -> None:
         response = client.patch(
@@ -59,7 +63,7 @@ class TestAdminUserUpdate:
             json={"is_suspended": True},
             headers={"Authorization": f"Bearer {valid_token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
 
     def test_non_admin_cannot_change_role(self, client: TestClient, valid_token: str) -> None:
         response = client.patch(
@@ -67,7 +71,7 @@ class TestAdminUserUpdate:
             json={"role": "admin"},
             headers={"Authorization": f"Bearer {valid_token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
 
 
 class TestRoleManipulationInJWT:
@@ -92,7 +96,7 @@ class TestRoleManipulationInJWT:
             "/api/v1/admin/users",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 403, (
+        assert response.status_code == 404, (
             "Spoofed admin role in JWT should not grant admin access"
         )
 
@@ -105,4 +109,4 @@ class TestRoleManipulationInJWT:
             "/api/v1/admin/users",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 404


### PR DESCRIPTION
Closes #804

## What
Hide the admin surface from non-admins instead of returning a discoverable 403.

### Backend (`src/api/middleware.py`)
- `require_admin` now raises **404 Not Found** (was 403) for an authenticated, non-admin user, with the default `"Not Found"` detail so the response is indistinguishable from a genuinely missing route.
- **Anonymous / invalid-token** requests still get **401** from `require_auth` — identical on *every* authenticated route, so it does not single out the admin surface the way a 403-vs-404 authz differential does. **503** (JWKS/auth-backend down) still propagates unchanged. Rationale is in the docstring.

### Frontend (`frontend/src/components/AdminRoute.tsx`)
- Non-admins are **silently redirected** (`<Navigate to="/" replace />`) instead of seeing a 403 panel.
- Added a `loading` guard so an admin reloading on an `/admin` URL is not bounced to `/` during the null-user window.
- The admin nav entry was already hidden for non-admins in `Sidebar.tsx` (`{isAdmin && ...}`).

## Decision: 404 for authed non-admins, 401 for anonymous
The leak this closes is the **authz differential**: an authenticated non-admin probing `/api/v1/admin/*` and getting 403 learns the admin area exists. 404 makes it indistinguishable from a missing route for anyone who can probe with valid credentials. Anonymous callers get 401 on *all* protected routes, so 401 on admin reveals nothing admin-specific. Matches the issue's "404 … for non-admin requests" and the standard hide-existence pattern.

## "Restrict to parametrization"
Admin is carried by the user-service JWT `roles` claim, so this guard restricts the surface to the **admin role**. The "only parametrization is admin" *seeding* is a **user-service** concern (JWT role assignment), not isnad-graph — flagged to fold into the user-service admin rewire (ig#805) so it is tracked, not dropped.

## Tests
- **New** `TestRequireAdminGuard` (unit) exercises the guard directly: admin -> pass, non-admin -> 404 (+ "Not Found" detail), anonymous -> 401 propagated, auth-backend-down -> 503 propagated.
- **New** `frontend/src/components/__tests__/AdminRoute.test.tsx` (3 tests): admin renders outlet, non-admin silently redirects home (no 403), loading renders nothing. Green locally (3/3).
- Flipped the existing `403 -> 404` admin assertions across `test_admin_auth`, `test_admin`, `test_admin_config`, `test_admin_moderation`, `test_admin_reports`, the security suites (`test_privilege_escalation`, `test_idor`), `test_jwt_validation`, and `test_cross_service_auth`. Anonymous/401 and other-role (`require_role`) assertions unchanged.

### Test-run note
Frontend (vitest) and `ruff format --check` + `ruff check` pass locally. The backend pytest process could not be run to completion **in this sandbox** (process killed with no output — an environment limitation, not a code failure). The assertion flips are mechanical and mirror the single 403->404 change in `require_admin`; **CI is the authoritative gate** — reviewers please confirm the backend job is green before merge.

## Reviewers
@Anya Kowalczyk (primary), @Mateo Salazar (secondary)
