### PR TITLE
feat(admin): rewire user-management panel to user-service admin API (#805)

### DIFF
--- a/frontend/src/api/__tests__/admin-client.test.ts
+++ b/frontend/src/api/__tests__/admin-client.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  fetchAdminUsers,
+  fetchAdminUser,
+  fetchRoles,
+  assignUserRole,
+  removeUserRole,
+  deactivateUser,
+  setUserRole,
+  type Role,
+} from '../admin-client'
+import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
+
+// Origin resolution falls back to '' (same-origin) in the test env (no
+// window.RUNTIME_CONFIG, no VITE_USER_SERVICE_ORIGIN), so every user-service
+// call targets a bare `/api/v1/...` path.
+const USERS = '/api/v1/users'
+const ROLES = '/api/v1/roles'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+  } as Response
+}
+
+function noContent(): Response {
+  return { ok: true, status: 204, statusText: 'No Content', json: async () => undefined } as Response
+}
+
+const fetchMock = vi.fn()
+
+// Safe accessor — tsconfig enables noUncheckedIndexedAccess, so a bare
+// `fetchMock.mock.calls[i][0]` is typed as possibly-undefined.
+function nthCall(i: number): { url: string; init: RequestInit | undefined } {
+  const c = fetchMock.mock.calls[i]
+  if (!c) throw new Error(`no fetch call at index ${i}`)
+  return { url: c[0] as string, init: c[1] as RequestInit | undefined }
+}
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'admin-jwt')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('admin-client user-service calls', () => {
+  it('fetchAdminUsers targets the user-service list with limit and cursor', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [], next_cursor: null }))
+    await fetchAdminUsers('cur-123', 20)
+    const { url } = nthCall(0)
+    expect(url).toContain(USERS)
+    expect(url).toContain('limit=20')
+    expect(url).toContain('cursor=cur-123')
+  })
+
+  it('fetchAdminUsers omits the cursor param on the first page', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [], next_cursor: null }))
+    await fetchAdminUsers(null, 20)
+    expect(nthCall(0).url).not.toContain('cursor=')
+  })
+
+  it('sends the admin Bearer JWT and does NOT set credentials:include', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [], next_cursor: null }))
+    await fetchAdminUsers(null, 20)
+    const { init } = nthCall(0)
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer admin-jwt')
+    expect(init?.credentials).toBeUndefined()
+  })
+
+  it('fetchAdminUser targets the by-id endpoint', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'u1', email: 'a@b.c' }))
+    await fetchAdminUser('u1')
+    expect(nthCall(0).url).toBe(`${USERS}/u1`)
+  })
+
+  it('fetchRoles reads the role catalog', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    await fetchRoles()
+    expect(nthCall(0).url).toBe(ROLES)
+  })
+
+  it('assignUserRole POSTs the role_id', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'r1', name: 'admin' }))
+    await assignUserRole('u1', 'r1')
+    const { url, init } = nthCall(0)
+    expect(url).toBe(`${USERS}/u1/roles`)
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual({ role_id: 'r1' })
+  })
+
+  it('removeUserRole DELETEs the assignment and resolves on 204', async () => {
+    fetchMock.mockResolvedValue(noContent())
+    await expect(removeUserRole('u1', 'r1')).resolves.toBeUndefined()
+    const { url, init } = nthCall(0)
+    expect(url).toBe(`${USERS}/u1/roles/r1`)
+    expect(init?.method).toBe('DELETE')
+  })
+
+  it('deactivateUser soft-deletes via DELETE on the user', async () => {
+    fetchMock.mockResolvedValue(noContent())
+    await deactivateUser('u1')
+    const { url, init } = nthCall(0)
+    expect(url).toBe(`${USERS}/u1`)
+    expect(init?.method).toBe('DELETE')
+  })
+
+  it('throws an admin-access error on 403', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'forbidden' }, 403))
+    await expect(fetchAdminUsers(null, 20)).rejects.toThrow(/admin access required/)
+  })
+
+  it('emits the session-expired event on 401', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+    const onExpired = vi.fn()
+    window.addEventListener(SESSION_EXPIRED_EVENT, onExpired)
+    await expect(fetchAdminUser('u1')).rejects.toThrow(/admin access required/)
+    expect(onExpired).toHaveBeenCalledOnce()
+    window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired)
+  })
+})
+
+describe('setUserRole (single-role switch over the additive role API)', () => {
+  const catalog: Role[] = [
+    { id: 'r-trial', name: 'trial', description: null, created_at: '2026-01-01T00:00:00Z' },
+    { id: 'r-reader', name: 'reader', description: null, created_at: '2026-01-01T00:00:00Z' },
+    { id: 'r-admin', name: 'admin', description: null, created_at: '2026-01-01T00:00:00Z' },
+  ]
+
+  it('assigns the target and removes every other held role', async () => {
+    fetchMock.mockResolvedValue(noContent())
+    // user currently holds 'reader'; switch to 'admin'
+    await setUserRole('u1', 'admin', ['reader'], catalog)
+
+    // POST assign admin, then DELETE remove reader (NOT trial — user lacks it)
+    expect(fetchMock.mock.calls).toHaveLength(2)
+    const assign = nthCall(0)
+    expect(assign.url).toBe(`${USERS}/u1/roles`)
+    expect(assign.init?.method).toBe('POST')
+    expect(JSON.parse(assign.init?.body as string)).toEqual({ role_id: 'r-admin' })
+    const remove = nthCall(1)
+    expect(remove.url).toBe(`${USERS}/u1/roles/r-reader`)
+    expect(remove.init?.method).toBe('DELETE')
+  })
+
+  it('does not re-assign a role the user already holds', async () => {
+    fetchMock.mockResolvedValue(noContent())
+    // user already 'admin' and also 'reader'; re-selecting 'admin' just strips reader
+    await setUserRole('u1', 'admin', ['admin', 'reader'], catalog)
+    expect(fetchMock.mock.calls).toHaveLength(1)
+    const remove = nthCall(0)
+    expect(remove.url).toBe(`${USERS}/u1/roles/r-reader`)
+    expect(remove.init?.method).toBe('DELETE')
+  })
+
+  it('throws when the target role is not in the catalog', async () => {
+    await expect(setUserRole('u1', 'wizard', ['reader'], catalog)).rejects.toThrow(/Unknown role/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -1,15 +1,34 @@
-import type {
-  AdminUser,
-  UserUpdateRequest,
-  SystemHealth,
-  ContentStats,
-  UsageAnalytics,
-} from '../types/admin'
+import type { components } from '../types/user-service'
+import type { SystemHealth, ContentStats, UsageAnalytics } from '../types/admin'
 import type { PaginatedResponse } from '../types/api'
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
 
+// --- isnad-graph admin API (system / content / analytics panels — #806) ---
 const API_BASE = '/api/v1/admin'
+
+// --- user-service admin API (user + role management — #805) ---
+// User CRUD and roles live in the user-service (the JWT issuer / RBAC service);
+// the isnad-graph `/api/v1/admin/users` routes are now 501 stubs. These calls
+// target the user-service vhost (`users.{base}`) directly with the same admin
+// Bearer JWT. The origin is resolved at runtime from `window.RUNTIME_CONFIG`
+// (injected by the container entrypoint via /runtime-config.js) so a single
+// image digest serves env-specific origins; it falls back to the build-time
+// `VITE_USER_SERVICE_ORIGIN` for local `npm run dev`, then '' (same-origin).
+// Mirrors the resolution in useAuth.ts / profile-client.ts (isnad-graph#932).
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
+const US_USERS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users`
+const US_ROLES_BASE = `${USER_SERVICE_ORIGIN}/api/v1/roles`
+
+// Canonical user/role shapes are sourced from the committed user-service
+// OpenAPI snapshot (`frontend/src/types/user-service.d.ts`); drift is enforced
+// by the `frontend-typegen-drift` CI job, the same as in useAuth.ts.
+export type AdminUser = components['schemas']['UserRead']
+export type AdminUserList = components['schemas']['UserListResponse']
+export type Role = components['schemas']['RoleRead']
 
 async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {
@@ -30,31 +49,115 @@ async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>
 }
 
+// user-service calls authorize purely via the admin Bearer JWT (no cookies), so
+// — unlike the same-origin isnad-graph admin API — they do NOT set
+// `credentials: 'include'` (matches profile-client.ts, avoids a cross-origin
+// credentialed-CORS requirement on the user-service vhost).
+async function fetchUserServiceJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...init?.headers },
+  })
+  if (res.status === 401) {
+    emitSessionExpired()
+    throw new Error('Unauthorized: admin access required')
+  }
+  if (res.status === 403) {
+    throw new Error('Unauthorized: admin access required')
+  }
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status} ${res.statusText}`)
+  }
+  return res.json() as Promise<T>
+}
+
+// 204 No Content variant (role removal, soft-delete) — same auth/error handling
+// as fetchUserServiceJson but no body to parse.
+async function sendUserServiceRequest(url: string, init: RequestInit): Promise<void> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...init.headers },
+  })
+  if (res.status === 401) {
+    emitSessionExpired()
+    throw new Error('Unauthorized: admin access required')
+  }
+  if (res.status === 403) {
+    throw new Error('Unauthorized: admin access required')
+  }
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status} ${res.statusText}`)
+  }
+}
+
+// List users (admin). The user-service paginates by opaque cursor, NOT page
+// number — pass the previous response's `next_cursor` to advance.
 export async function fetchAdminUsers(
-  page = 1,
+  cursor?: string | null,
   limit = 20,
-  search?: string,
-  role?: string,
-): Promise<PaginatedResponse<AdminUser>> {
-  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
-  if (search) params.set('search', search)
-  if (role) params.set('role', role)
-  return fetchAdminJson(`${API_BASE}/users?${params}`)
+): Promise<AdminUserList> {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (cursor) params.set('cursor', cursor)
+  return fetchUserServiceJson(`${US_USERS_BASE}?${params}`)
 }
 
 export async function fetchAdminUser(userId: string): Promise<AdminUser> {
-  return fetchAdminJson(`${API_BASE}/users/${encodeURIComponent(userId)}`)
+  return fetchUserServiceJson(`${US_USERS_BASE}/${encodeURIComponent(userId)}`)
 }
 
-export async function updateAdminUser(
-  userId: string,
-  body: UserUpdateRequest,
-): Promise<AdminUser> {
-  return fetchAdminJson(`${API_BASE}/users/${encodeURIComponent(userId)}`, {
-    method: 'PATCH',
+// Role catalog (name → id). Any authenticated user may read it; the admin panel
+// needs it to translate a role *name* (what the UI shows) into the role *id*
+// (uuid) the assign/remove endpoints require.
+export async function fetchRoles(): Promise<Role[]> {
+  return fetchUserServiceJson(US_ROLES_BASE)
+}
+
+export async function assignUserRole(userId: string, roleId: string): Promise<Role> {
+  return fetchUserServiceJson(`${US_USERS_BASE}/${encodeURIComponent(userId)}/roles`, {
+    method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ role_id: roleId }),
   })
+}
+
+export async function removeUserRole(userId: string, roleId: string): Promise<void> {
+  return sendUserServiceRequest(
+    `${US_USERS_BASE}/${encodeURIComponent(userId)}/roles/${encodeURIComponent(roleId)}`,
+    { method: 'DELETE' },
+  )
+}
+
+// Soft-delete (deactivate) a user. The user-service has no reactivate endpoint,
+// so this is one-way — callers should confirm before invoking.
+export async function deactivateUser(userId: string): Promise<void> {
+  return sendUserServiceRequest(`${US_USERS_BASE}/${encodeURIComponent(userId)}`, {
+    method: 'DELETE',
+  })
+}
+
+// Switch a user to exactly one role. The user-service models roles as an
+// additive set (assign / remove by role_id) rather than a single mutable field,
+// so "set role" = assign the target (if absent) then remove every *other*
+// catalog role the user currently holds. `catalog` is {@link fetchRoles}'s
+// output (name → id); `currentRoleNames` is the user's present `roles`.
+export async function setUserRole(
+  userId: string,
+  targetRoleName: string,
+  currentRoleNames: string[],
+  catalog: Role[],
+): Promise<void> {
+  const target = catalog.find((r) => r.name === targetRoleName)
+  if (!target) {
+    throw new Error(`Unknown role: ${targetRoleName}`)
+  }
+  if (!currentRoleNames.includes(targetRoleName)) {
+    await assignUserRole(userId, target.id)
+  }
+  for (const role of catalog) {
+    if (role.name !== targetRoleName && currentRoleNames.includes(role.name)) {
+      await removeUserRole(userId, role.id)
+    }
+  }
 }
 
 export async function fetchSystemHealth(): Promise<SystemHealth> {
@@ -107,55 +210,3 @@ export async function fetchDashboardStats(): Promise<DashboardStats> {
   return fetchAdminJson(`${API_BASE}/dashboard/stats`)
 }
 
-export interface BulkActionResponse {
-  affected: number
-  action: string
-}
-
-export async function bulkUserAction(
-  userIds: string[],
-  action: string,
-  role?: string,
-): Promise<BulkActionResponse> {
-  return fetchAdminJson(`${API_BASE}/users/bulk`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_ids: userIds, action, role }),
-  })
-}
-
-export interface UserDetail {
-  id: string
-  email: string
-  name: string
-  provider: string
-  is_admin: boolean
-  is_suspended: boolean
-  created_at: string
-  role: string | null
-  login_count: number
-  last_login: string | null
-}
-
-export async function fetchUserDetail(userId: string): Promise<UserDetail> {
-  return fetchAdminJson(`${API_BASE}/users/${encodeURIComponent(userId)}/detail`)
-}
-
-export function getUsersExportUrl(search?: string, role?: string): string {
-  const params = new URLSearchParams()
-  if (search) params.set('search', search)
-  if (role) params.set('role', role)
-  const qs = params.toString()
-  return `${API_BASE}/users/export/csv${qs ? `?${qs}` : ''}`
-}
-
-export async function updateUserRole(
-  userId: string,
-  role: string,
-): Promise<AdminUser> {
-  return fetchAdminJson(`${API_BASE}/users/${encodeURIComponent(userId)}/role`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ role }),
-  })
-}

--- a/frontend/src/pages/admin/UserManagementPage.tsx
+++ b/frontend/src/pages/admin/UserManagementPage.tsx
@@ -2,215 +2,242 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   fetchAdminUsers,
-  updateAdminUser,
-  updateUserRole,
-  bulkUserAction,
-  fetchUserDetail,
-  getUsersExportUrl,
+  fetchAdminUser,
+  fetchRoles,
+  setUserRole,
 } from '../../api/admin-client'
-import type { AdminUser } from '../../types/admin'
+import { deriveHighestRole, type UserRole } from '../../hooks/useAuth'
 
-const ROLES = ['trial', 'reader', 'researcher', 'admin'] as const
+// The selectable role vocabulary mirrors the user-service canonical hierarchy
+// (ontology/repos/user-service.yaml → trial | reader | researcher | admin).
+// The live options shown come from the role *catalog* (fetchRoles) so the panel
+// reflects whatever roles the user-service actually defines; this constant is
+// only the fallback ordering for the highest-role display.
+const ROLE_ORDER: UserRole[] = ['trial', 'reader', 'researcher', 'admin']
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
 
 export default function UserManagementPage() {
   const queryClient = useQueryClient()
-  const [page, setPage] = useState(1)
-  const [search, setSearch] = useState('')
-  const [inputValue, setInputValue] = useState('')
-  const [roleFilter, setRoleFilter] = useState('')
-  const [statusFilter, setStatusFilter] = useState('')
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [bulkRole, setBulkRole] = useState('trial')
+  // user-service list pagination is cursor-based (opaque `next_cursor`), not
+  // page-numbered. Keep a stack of the cursors we've visited so "Previous" can
+  // pop back; the first entry is `null` (the initial, un-cursored page).
+  const [cursorStack, setCursorStack] = useState<(string | null)[]>([null])
+  const cursor = cursorStack[cursorStack.length - 1]
   const [detailUserId, setDetailUserId] = useState<string | null>(null)
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['admin-users', page, search, roleFilter, statusFilter],
-    queryFn: () => fetchAdminUsers(page, 20, search || undefined, roleFilter || undefined),
+    queryKey: ['admin-users', cursor],
+    queryFn: () => fetchAdminUsers(cursor, 20),
+  })
+
+  const { data: roles } = useQuery({
+    queryKey: ['admin-roles'],
+    queryFn: fetchRoles,
   })
 
   const { data: userDetail } = useQuery({
     queryKey: ['admin-user-detail', detailUserId],
-    queryFn: () => fetchUserDetail(detailUserId!),
+    queryFn: () => fetchAdminUser(detailUserId!),
     enabled: !!detailUserId,
   })
 
-  const suspendMutation = useMutation({
-    mutationFn: (user: AdminUser) =>
-      updateAdminUser(user.id, { is_suspended: !user.is_suspended }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
-  })
-
   const roleMutation = useMutation({
-    mutationFn: ({ userId, role }: { userId: string; role: string }) =>
-      updateUserRole(userId, role),
+    mutationFn: ({
+      userId,
+      role,
+      currentRoles,
+    }: {
+      userId: string
+      role: string
+      currentRoles: string[]
+    }) => setUserRole(userId, role, currentRoles, roles ?? []),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
   })
 
-  const bulkMutation = useMutation({
-    mutationFn: ({ action, role }: { action: string; role?: string }) =>
-      bulkUserAction(Array.from(selectedIds), action, role),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin-users'] })
-      setSelectedIds(new Set())
-    },
-  })
-
-  const handleSearch = () => {
-    setSearch(inputValue)
-    setPage(1)
-  }
-
-  const toggleSelect = (id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
-
-  const toggleSelectAll = () => {
-    if (!data) return
-    const allIds = data.items.map((u) => u.id)
-    const allSelected = allIds.every((id) => selectedIds.has(id))
-    if (allSelected) {
-      setSelectedIds(new Set())
-    } else {
-      setSelectedIds(new Set(allIds))
+  const goNext = () => {
+    if (data?.next_cursor) {
+      setCursorStack((s) => [...s, data.next_cursor!])
     }
   }
 
-  const filteredItems = data?.items.filter((u) => {
-    if (statusFilter === 'active' && u.is_suspended) return false
-    if (statusFilter === 'suspended' && !u.is_suspended) return false
-    return true
-  })
+  const goPrev = () => {
+    setCursorStack((s) => (s.length > 1 ? s.slice(0, -1) : s))
+  }
 
-  const totalPages = data ? Math.ceil(data.total / data.limit) : 0
+  // Role names available for assignment. Prefer the live catalog; fall back to
+  // the canonical ordering before the catalog query resolves.
+  const roleOptions: string[] = roles?.length
+    ? roles.map((r) => r.name)
+    : ROLE_ORDER
 
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' }}>
+      <div style={{ marginBottom: '1rem' }}>
         <h2>User Management</h2>
-        <a
-          href={getUsersExportUrl(search || undefined, roleFilter || undefined)}
-          className="btn"
-          style={{ textDecoration: 'none' }}
-          download
-        >
-          Export CSV
-        </a>
+        <p style={{ fontSize: 'var(--text-sm)', color: 'var(--color-muted-foreground)' }}>
+          Users and roles are managed by the user-service. Admin access requires
+          the <code>admin</code> role on your user-service account.
+        </p>
       </div>
-
-      <div className="flex-row" style={{ marginBottom: '1rem', gap: '0.5rem', flexWrap: 'wrap' }}>
-        <input
-          type="text"
-          placeholder="Search users by name or email..."
-          aria-label="Search users by name or email"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-          className="form-input"
-          style={{ flex: 1, maxWidth: 300 }}
-        />
-        <button onClick={handleSearch} className="btn">Search</button>
-        <select className="form-input" value={roleFilter} onChange={(e) => { setRoleFilter(e.target.value); setPage(1) }} style={{ width: 140 }}>
-          <option value="">All Roles</option>
-          {ROLES.map((r) => <option key={r} value={r}>{r.charAt(0).toUpperCase() + r.slice(1)}</option>)}
-        </select>
-        <select className="form-input" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} style={{ width: 140 }}>
-          <option value="">All Status</option>
-          <option value="active">Active</option>
-          <option value="suspended">Suspended</option>
-        </select>
-      </div>
-
-      {selectedIds.size > 0 && (
-        <div className="flex-row" style={{ marginBottom: '1rem', gap: '0.5rem', padding: '0.75rem', background: 'var(--color-accent)', borderRadius: 'var(--radius-md)', alignItems: 'center' }}>
-          <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500 }}>{selectedIds.size} selected</span>
-          <button className="btn-action btn-action-suspend" onClick={() => bulkMutation.mutate({ action: 'suspend' })} disabled={bulkMutation.isPending}>Bulk Suspend</button>
-          <button className="btn-action btn-action-unsuspend" onClick={() => bulkMutation.mutate({ action: 'unsuspend' })} disabled={bulkMutation.isPending}>Bulk Unsuspend</button>
-          <select className="form-input" value={bulkRole} onChange={(e) => setBulkRole(e.target.value)} style={{ width: 120 }}>
-            {ROLES.map((r) => <option key={r} value={r}>{r.charAt(0).toUpperCase() + r.slice(1)}</option>)}
-          </select>
-          <button className="btn-action" onClick={() => bulkMutation.mutate({ action: 'role_change', role: bulkRole })} disabled={bulkMutation.isPending}>Set Role</button>
-        </div>
-      )}
 
       {isLoading && <p>Loading...</p>}
       {error && <p className="error-text">Error: {(error as Error).message}</p>}
 
-      {filteredItems && (
+      {data && (
         <>
           <table className="data-table">
             <thead>
               <tr>
-                <th style={{ width: 40 }}>
-                  <input type="checkbox" checked={filteredItems.length > 0 && filteredItems.every((u) => selectedIds.has(u.id))} onChange={toggleSelectAll} aria-label="Select all users" />
-                </th>
                 <th>Name</th>
                 <th>Email</th>
-                <th>Provider</th>
+                <th>Verified</th>
                 <th>Role</th>
                 <th>Status</th>
-                <th>Actions</th>
               </tr>
             </thead>
             <tbody>
-              {filteredItems.map((u) => (
-                <tr key={u.id}>
-                  <td><input type="checkbox" checked={selectedIds.has(u.id)} onChange={() => toggleSelect(u.id)} aria-label={`Select ${u.name}`} /></td>
-                  <td>
-                    <button onClick={() => setDetailUserId(u.id)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-primary)', textDecoration: 'underline', fontFamily: 'inherit', fontSize: 'inherit', padding: 0 }}>
-                      {u.name}
-                    </button>
-                  </td>
-                  <td>{u.email}</td>
-                  <td>{u.provider}</td>
-                  <td>
-                    <select className="form-input" value={u.role ?? 'trial'} onChange={(e) => roleMutation.mutate({ userId: u.id, role: e.target.value })} disabled={roleMutation.isPending} style={{ width: 120, padding: '0.25rem' }}>
-                      {ROLES.map((r) => <option key={r} value={r}>{r.charAt(0).toUpperCase() + r.slice(1)}</option>)}
-                    </select>
-                  </td>
-                  <td>
-                    <span className={u.is_suspended ? 'text-suspended' : 'text-active'}>{u.is_suspended ? 'Suspended' : 'Active'}</span>
-                  </td>
-                  <td className="flex-row" style={{ gap: '0.25rem' }}>
-                    <button onClick={() => suspendMutation.mutate(u)} disabled={suspendMutation.isPending} className={`btn-action ${u.is_suspended ? 'btn-action-unsuspend' : 'btn-action-suspend'}`}>
-                      {u.is_suspended ? 'Unsuspend' : 'Suspend'}
-                    </button>
-                  </td>
-                </tr>
-              ))}
+              {data.items.map((u) => {
+                const currentRoles = u.roles ?? []
+                return (
+                  <tr key={u.id}>
+                    <td>
+                      <button
+                        onClick={() => setDetailUserId(u.id)}
+                        style={{
+                          background: 'none',
+                          border: 'none',
+                          cursor: 'pointer',
+                          color: 'var(--color-primary)',
+                          textDecoration: 'underline',
+                          fontFamily: 'inherit',
+                          fontSize: 'inherit',
+                          padding: 0,
+                        }}
+                      >
+                        {u.display_name ?? u.email}
+                      </button>
+                    </td>
+                    <td>{u.email}</td>
+                    <td>
+                      <span className={u.email_verified ? 'text-active' : 'text-suspended'}>
+                        {u.email_verified ? 'Verified' : 'Unverified'}
+                      </span>
+                    </td>
+                    <td>
+                      <select
+                        className="form-input"
+                        value={deriveHighestRole(currentRoles)}
+                        onChange={(e) =>
+                          roleMutation.mutate({
+                            userId: u.id,
+                            role: e.target.value,
+                            currentRoles,
+                          })
+                        }
+                        disabled={roleMutation.isPending || !roles}
+                        aria-label={`Role for ${u.display_name ?? u.email}`}
+                        style={{ width: 130, padding: '0.25rem' }}
+                      >
+                        {roleOptions.map((r) => (
+                          <option key={r} value={r}>
+                            {titleCase(r)}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td>
+                      <span className={u.is_active ? 'text-active' : 'text-suspended'}>
+                        {u.is_active ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
 
+          {data.items.length === 0 && <p>No users found.</p>}
+
           <div className="pagination">
-            <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Previous</button>
-            <span>Page {data!.page} of {totalPages}</span>
-            <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>Next</button>
+            <button disabled={cursorStack.length <= 1} onClick={goPrev}>
+              Previous
+            </button>
+            <button disabled={!data.next_cursor} onClick={goNext}>
+              Next
+            </button>
           </div>
         </>
       )}
 
       {detailUserId && userDetail && (
-        <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 }} onClick={() => setDetailUserId(null)}>
-          <div style={{ background: 'var(--color-card)', borderRadius: 'var(--radius-lg)', padding: 'var(--spacing-6)', minWidth: 400, maxWidth: 600, boxShadow: 'var(--shadow-lg)' }} onClick={(e) => e.stopPropagation()}>
-            <h3 style={{ marginBottom: 'var(--spacing-4)', fontFamily: 'var(--font-heading)' }}>User Detail</h3>
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 100,
+          }}
+          onClick={() => setDetailUserId(null)}
+        >
+          <div
+            style={{
+              background: 'var(--color-card)',
+              borderRadius: 'var(--radius-lg)',
+              padding: 'var(--spacing-6)',
+              minWidth: 400,
+              maxWidth: 600,
+              boxShadow: 'var(--shadow-lg)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ marginBottom: 'var(--spacing-4)', fontFamily: 'var(--font-heading)' }}>
+              User Detail
+            </h3>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--spacing-3)' }}>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Name</div><div style={{ fontWeight: 500 }}>{userDetail.name}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Email</div><div style={{ fontWeight: 500 }}>{userDetail.email}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Provider</div><div style={{ fontWeight: 500 }}>{userDetail.provider}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Role</div><div style={{ fontWeight: 500 }}>{userDetail.role ?? 'trial'}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Status</div><div style={{ fontWeight: 500 }}>{userDetail.is_suspended ? 'Suspended' : 'Active'}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Member Since</div><div style={{ fontWeight: 500 }}>{new Date(userDetail.created_at).toLocaleDateString()}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Total Logins</div><div style={{ fontWeight: 500 }}>{userDetail.login_count}</div></div>
-              <div><div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>Last Login</div><div style={{ fontWeight: 500 }}>{userDetail.last_login ? new Date(userDetail.last_login).toLocaleString() : '-'}</div></div>
+              <DetailField label="Name" value={userDetail.display_name ?? '—'} />
+              <DetailField label="Email" value={userDetail.email} />
+              <DetailField
+                label="Email Verified"
+                value={userDetail.email_verified ? 'Yes' : 'No'}
+              />
+              <DetailField label="Status" value={userDetail.is_active ? 'Active' : 'Inactive'} />
+              <DetailField label="Locale" value={userDetail.locale ?? '—'} />
+              <DetailField
+                label="Roles"
+                value={userDetail.roles?.length ? userDetail.roles.join(', ') : '—'}
+              />
+              <DetailField
+                label="Member Since"
+                value={new Date(userDetail.created_at).toLocaleDateString()}
+              />
             </div>
-            <button className="btn" onClick={() => setDetailUserId(null)} style={{ marginTop: 'var(--spacing-4)' }}>Close</button>
+            <button
+              className="btn"
+              onClick={() => setDetailUserId(null)}
+              style={{ marginTop: 'var(--spacing-4)' }}
+            >
+              Close
+            </button>
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>
+        {label}
+      </div>
+      <div style={{ fontWeight: 500 }}>{value}</div>
     </div>
   )
 }

--- a/frontend/src/pages/admin/__tests__/UserManagementPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UserManagementPage.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import UserManagementPage from '../UserManagementPage'
+import {
+  fetchAdminUsers,
+  fetchAdminUser,
+  fetchRoles,
+  setUserRole,
+} from '../../../api/admin-client'
+import type { AdminUser, AdminUserList, Role } from '../../../api/admin-client'
+
+vi.mock('../../../api/admin-client', () => ({
+  fetchAdminUsers: vi.fn(),
+  fetchAdminUser: vi.fn(),
+  fetchRoles: vi.fn(),
+  setUserRole: vi.fn(),
+}))
+
+// Role names kept as variables so the test survives any future vocab change.
+const READER = 'reader'
+const ADMIN = 'admin'
+
+const CATALOG: Role[] = [
+  { id: 'r-trial', name: 'trial', description: null, created_at: '2026-01-01T00:00:00Z' },
+  { id: 'r-reader', name: READER, description: null, created_at: '2026-01-01T00:00:00Z' },
+  { id: 'r-researcher', name: 'researcher', description: null, created_at: '2026-01-01T00:00:00Z' },
+  { id: 'r-admin', name: ADMIN, description: null, created_at: '2026-01-01T00:00:00Z' },
+]
+
+function makeUser(over: Partial<AdminUser> = {}): AdminUser {
+  return {
+    id: 'u1',
+    email: 'amina@example.com',
+    display_name: 'Amina',
+    email_verified: true,
+    avatar_url: null,
+    locale: 'en',
+    is_active: true,
+    created_at: '2026-02-01T00:00:00Z',
+    roles: [READER],
+    ...over,
+  }
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UserManagementPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('UserManagementPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchRoles).mockResolvedValue(CATALOG)
+  })
+
+  it('shows the loading state initially', () => {
+    vi.mocked(fetchAdminUsers).mockImplementation(() => new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument()
+  })
+
+  it('renders an error state when the list query fails', async () => {
+    vi.mocked(fetchAdminUsers).mockRejectedValue(new Error('boom: users unreachable'))
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText(/Error: boom: users unreachable/)).toBeInTheDocument(),
+    )
+  })
+
+  it('renders user rows with name, email, verified and status from user-service shape', async () => {
+    const list: AdminUserList = { items: [makeUser()], next_cursor: null }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    renderPage()
+
+    expect(await screen.findByText('Amina')).toBeInTheDocument()
+    expect(screen.getByText('amina@example.com')).toBeInTheDocument()
+    // scope to the cell — "Verified" is also the column header text
+    expect(screen.getByRole('cell', { name: 'Verified' })).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'Active' })).toBeInTheDocument()
+  })
+
+  it('falls back to email when display_name is null, and reflects inactive/unverified', async () => {
+    const list: AdminUserList = {
+      items: [makeUser({ display_name: null, email_verified: false, is_active: false })],
+      next_cursor: null,
+    }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    renderPage()
+
+    // name cell falls back to the email
+    expect(await screen.findByRole('button', { name: 'amina@example.com' })).toBeInTheDocument()
+    expect(screen.getByText('Unverified')).toBeInTheDocument()
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+
+  it('shows the highest current role in the select and calls setUserRole on change', async () => {
+    const list: AdminUserList = { items: [makeUser({ roles: [READER] })], next_cursor: null }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    vi.mocked(setUserRole).mockResolvedValue(undefined)
+    renderPage()
+
+    const select = (await screen.findByLabelText('Role for Amina')) as HTMLSelectElement
+    await waitFor(() => expect(select.value).toBe(READER))
+
+    fireEvent.change(select, { target: { value: ADMIN } })
+
+    await waitFor(() => expect(setUserRole).toHaveBeenCalledOnce())
+    expect(setUserRole).toHaveBeenCalledWith('u1', ADMIN, [READER], CATALOG)
+  })
+
+  it('opens the detail modal and shows user-service fields', async () => {
+    const list: AdminUserList = { items: [makeUser()], next_cursor: null }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    vi.mocked(fetchAdminUser).mockResolvedValue(makeUser({ roles: [READER, ADMIN] }))
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Amina' }))
+
+    const heading = await screen.findByText('User Detail')
+    const modal = heading.parentElement as HTMLElement
+    expect(within(modal).getByText('reader, admin')).toBeInTheDocument()
+    expect(within(modal).getByText('en')).toBeInTheDocument()
+  })
+
+  it('disables Previous on the first page and Next when there is no next_cursor', async () => {
+    const list: AdminUserList = { items: [makeUser()], next_cursor: null }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    renderPage()
+
+    await screen.findByText('Amina')
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+  })
+
+  it('advances the cursor when Next is clicked', async () => {
+    vi.mocked(fetchAdminUsers)
+      .mockResolvedValueOnce({ items: [makeUser({ display_name: 'Page One' })], next_cursor: 'cur-2' })
+      .mockResolvedValueOnce({ items: [makeUser({ display_name: 'Page Two' })], next_cursor: null })
+    renderPage()
+
+    await screen.findByText('Page One')
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    await screen.findByText('Page Two')
+    expect(vi.mocked(fetchAdminUsers).mock.calls[1]?.[0]).toBe('cur-2')
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeEnabled()
+  })
+
+  it('renders an empty-state message when there are no users', async () => {
+    vi.mocked(fetchAdminUsers).mockResolvedValue({ items: [], next_cursor: null })
+    renderPage()
+    expect(await screen.findByText('No users found.')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -1,19 +1,7 @@
-export interface AdminUser {
-  id: string
-  email: string
-  name: string
-  provider: string
-  is_admin: boolean
-  is_suspended: boolean
-  created_at: string
-  role: string | null
-}
-
-export interface UserUpdateRequest {
-  is_admin?: boolean
-  is_suspended?: boolean
-  role?: string
-}
+// User/role shapes for the admin user-management panel are sourced from the
+// user-service OpenAPI snapshot (re-exported as `AdminUser` / `Role` from
+// `../api/admin-client`) since user CRUD moved to the user-service (#805).
+// The types below back the system / content / analytics panels (#806).
 
 export interface SystemHealth {
   status: string


### PR DESCRIPTION
## Summary

Rewires the admin **user-management** panel to call the **user-service** admin API directly with the existing admin Bearer JWT, instead of the dead isnad-graph `/api/v1/admin/users` 501 stub. User CRUD/roles live in the user-service (the JWT issuer / RBAC service).

Closes #805.

## What changed

**`frontend/src/api/admin-client.ts`** (user-fn group only — data-panel fns left for #806):
- `fetchAdminUsers` / `fetchAdminUser` now target the user-service vhost. Origin resolved at runtime from `window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN` → `VITE_USER_SERVICE_ORIGIN` → `''` (same-origin), mirroring `useAuth.ts` / `profile-client.ts` (isnad-graph#932). Not hardcoded.
- New role operations over the user-service **additive** role model: `fetchRoles`, `assignUserRole`, `removeUserRole`, `deactivateUser`, and a `setUserRole(userId, targetName, currentRoles, catalog)` helper that turns a single "set role" into *assign-target* + *remove-other-held-roles-by-id* (the user-service has no single PATCH-role endpoint — roles are assign/remove by `role_id` uuid).
- User/role types now sourced from the generated user-service OpenAPI snapshot (`components['schemas']['UserRead' | 'UserListResponse' | 'RoleRead']`), drift-enforced by the existing `frontend-typegen-drift` job — replacing the bespoke `AdminUser`/`UserUpdateRequest`.
- user-service calls authorize purely via the admin Bearer JWT and do **not** set `credentials: 'include'` (avoids a credentialed-CORS requirement on the user-service vhost; matches `profile-client.ts`). The same-origin isnad-graph admin helper is unchanged.
- Dropped client fns with no user-service equivalent: `updateAdminUser`, `bulkUserAction`, `fetchUserDetail`, `getUsersExportUrl`, `updateUserRole` — they hit isnad-graph admin routes that no longer exist (the 501 stub only ever exposed list/get/patch/patch-role; bulk/detail/export were already 404).

**`frontend/src/pages/admin/UserManagementPage.tsx`**: rebuilt on the real `UserRead` shape — cursor-based pagination (Prev/Next over `next_cursor`, not page numbers), columns + detail modal showing `display_name ?? email`, `email_verified`, `is_active`, `locale`, `roles`; role change via the live catalog + `setUserRole`. Removed search / role-filter / bulk-action / CSV-export / suspend UI that had no user-service backing.

**`frontend/src/types/admin.ts`**: removed the now-dead `AdminUser` / `UserUpdateRequest`; left the system/content/analytics types for #806.

**isnad-graph `users.py` 501 stub — retained.** Rationale: it documents the move, keeps the admin router registration intact, and returns a clear 501 to any stale client still hitting isnad-graph. Removing it would touch `admin/__init__.py` router wiring (collision risk with #806/#970 backend areas) for no functional gain.

## "Sole admin = parametrization" seeding (carried from #804)

The panel now reflects user-service roles faithfully (`UserRead.roles` → `deriveHighestRole`; role changes go through the user-service). The **admin role definition** is seeded by user-service migration `0001_initial_schema` — but **no user is granted it**. Bootstrapping the *first* admin cannot happen through this panel (chicken-and-egg: every admin endpoint requires an admin JWT). Seeding "parametrization as the sole admin" is therefore a **user-service action** (a seed/migration granting the parametrization account the `admin` role, or a one-time operator grant). Flagged to the team lead with a draft us issue — not silently dropped, and out of scope for this frontend PR.

## Testing

- `frontend/src/api/__tests__/admin-client.test.ts` — paths/query (cursor+limit), Bearer header + no-credentials, assign/remove/deactivate verbs+body, `setUserRole` diff logic, 401 (emits session-expired) / 403 handling.
- `frontend/src/pages/admin/__tests__/UserManagementPage.test.tsx` — rows from `UserRead` shape, `display_name` fallback, role select + `setUserRole` wiring, detail modal, cursor paging (Prev/Next enable/disable, cursor advance), empty state.
- Full frontend suite green: **127 tests** (21 files). `eslint src/` clean, `tsc --noEmit` clean. Backend untouched (no pytest impact).

## Reviewers
- **Anya Kowalczyk** (primary)
- **Mateo Salazar** (secondary)
