### PR TITLE
feat(admin): data-management panel — read-only graph inventory + provenance (#806)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import ReportsPage from './pages/admin/ReportsPage'
 import ConfigPage from './pages/admin/ConfigPage'
 import AuditLogPage from './pages/admin/AuditLogPage'
 import DashboardPage from './pages/admin/DashboardPage'
+import DataManagementPage from './pages/admin/DataManagementPage'
 import ProfilePage from './pages/ProfilePage'
 import PricingPage from './pages/PricingPage'
 import CheckoutPage from './pages/CheckoutPage'
@@ -86,6 +87,7 @@ export default function App() {
                   <Route path="users" element={<UserManagementPage />} />
                   <Route path="health" element={<SystemHealthPage />} />
                   <Route path="stats" element={<ContentStatsPage />} />
+                  <Route path="data" element={<DataManagementPage />} />
                   <Route path="analytics" element={<UsageAnalyticsPage />} />
                   <Route path="moderation" element={<ModerationPage />} />
                   <Route path="reports" element={<ReportsPage />} />

--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -1,5 +1,11 @@
 import type { components } from '../types/user-service'
-import type { SystemHealth, ContentStats, UsageAnalytics } from '../types/admin'
+import type {
+  SystemHealth,
+  ContentStats,
+  UsageAnalytics,
+  DataOverview,
+  DataSources,
+} from '../types/admin'
 import type { PaginatedResponse } from '../types/api'
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
@@ -210,3 +216,12 @@ export async function fetchDashboardStats(): Promise<DashboardStats> {
   return fetchAdminJson(`${API_BASE}/dashboard/stats`)
 }
 
+// --- Data management (read-only) ---
+
+export async function fetchDataOverview(): Promise<DataOverview> {
+  return fetchAdminJson(`${API_BASE}/data/overview`)
+}
+
+export async function fetchDataSources(): Promise<DataSources> {
+  return fetchAdminJson(`${API_BASE}/data/sources`)
+}

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -8,6 +8,7 @@ const adminNavItems = [
   { to: '/admin/users', label: 'User Management' },
   { to: '/admin/health', label: 'System Health' },
   { to: '/admin/stats', label: 'Content Stats' },
+  { to: '/admin/data', label: 'Data Management' },
   { to: '/admin/analytics', label: 'Usage Analytics' },
   { to: '/admin/audit', label: 'Audit Log' },
 ]

--- a/frontend/src/pages/admin/DataManagementPage.module.css
+++ b/frontend/src/pages/admin/DataManagementPage.module.css
@@ -1,0 +1,46 @@
+.cardGrid {
+  display: flex;
+  gap: var(--spacing-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-6);
+}
+
+.card {
+  border: var(--border-width-thin) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-6);
+  min-width: 180px;
+  text-align: center;
+  background: var(--color-card);
+  box-shadow: var(--shadow-xs);
+}
+
+.cardLabel {
+  font-size: var(--text-sm);
+  color: var(--color-muted-foreground);
+  margin-bottom: var(--spacing-2);
+}
+
+.cardValue {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-foreground);
+}
+
+.section {
+  margin-top: var(--spacing-8);
+}
+
+.sectionTitle {
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--spacing-3);
+}
+
+.emptyText {
+  color: var(--color-muted-foreground);
+}
+
+.errorText {
+  color: var(--color-destructive);
+}

--- a/frontend/src/pages/admin/DataManagementPage.tsx
+++ b/frontend/src/pages/admin/DataManagementPage.tsx
@@ -1,0 +1,143 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchDataOverview, fetchDataSources } from '../../api/admin-client'
+import styles from './DataManagementPage.module.css'
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardLabel}>{label}</div>
+      <div className={styles.cardValue}>{value}</div>
+    </div>
+  )
+}
+
+function OverviewSection() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-data-overview'],
+    queryFn: fetchDataOverview,
+  })
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>Graph Inventory</h3>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p className={styles.errorText}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <div className={styles.cardGrid}>
+            <StatCard label="Total Nodes" value={data.total_nodes.toLocaleString()} />
+            <StatCard label="Total Relationships" value={data.total_relationships.toLocaleString()} />
+          </div>
+
+          <h4 className={styles.sectionTitle}>Nodes by Label</h4>
+          {data.node_counts.length === 0 ? (
+            <p className={styles.emptyText}>No nodes loaded.</p>
+          ) : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Label</th>
+                  <th>Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.node_counts.map((n) => (
+                  <tr key={n.label}>
+                    <td>{n.label}</td>
+                    <td>{n.count.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          <h4 className={styles.sectionTitle}>Relationships by Type</h4>
+          {data.relationship_counts.length === 0 ? (
+            <p className={styles.emptyText}>No relationships loaded.</p>
+          ) : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.relationship_counts.map((r) => (
+                  <tr key={r.rel_type}>
+                    <td>{r.rel_type}</td>
+                    <td>{r.count.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+function SourcesSection() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-data-sources'],
+    queryFn: fetchDataSources,
+  })
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>Provenance by Source Corpus</h3>
+
+      {isLoading && <p>Loading...</p>}
+      {error && <p className={styles.errorText}>Error: {(error as Error).message}</p>}
+
+      {data && (
+        <>
+          <div className={styles.cardGrid}>
+            <StatCard label="Distinct Sources" value={data.distinct_sources.toLocaleString()} />
+            <StatCard label="Hadiths" value={data.total_hadiths.toLocaleString()} />
+            <StatCard label="Collections" value={data.total_collections.toLocaleString()} />
+          </div>
+
+          {data.sources.length === 0 ? (
+            <p className={styles.emptyText}>No source-attributed content loaded.</p>
+          ) : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Source Corpus</th>
+                  <th>Hadiths</th>
+                  <th>Collections</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.sources.map((s) => (
+                  <tr key={s.source_corpus}>
+                    <td>{s.source_corpus}</td>
+                    <td>{s.hadith_count.toLocaleString()}</td>
+                    <td>{s.collection_count.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export default function DataManagementPage() {
+  return (
+    <div>
+      <h2>Data Management</h2>
+      <p className={styles.emptyText}>
+        Read-only overview of loaded graph data and its provenance.
+      </p>
+      <OverviewSection />
+      <SourcesSection />
+    </div>
+  )
+}

--- a/frontend/src/pages/admin/__tests__/DataManagementPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DataManagementPage.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import DataManagementPage from "../DataManagementPage"
+import { fetchDataOverview, fetchDataSources } from "../../../api/admin-client"
+import type { DataOverview, DataSources } from "../../../types/admin"
+
+vi.mock("../../../api/admin-client", () => ({
+  fetchDataOverview: vi.fn(),
+  fetchDataSources: vi.fn(),
+}))
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DataManagementPage />
+    </QueryClientProvider>,
+  )
+}
+
+const OVERVIEW: DataOverview = {
+  node_counts: [
+    { label: "Narrator", count: 120 },
+    { label: "Hadith", count: 47 },
+  ],
+  relationship_counts: [{ rel_type: "NARRATED", count: 200 }],
+  total_nodes: 167,
+  total_relationships: 200,
+}
+
+const SOURCES: DataSources = {
+  sources: [
+    { source_corpus: "sunnah", hadith_count: 40, collection_count: 2 },
+    { source_corpus: "thaqalayn", hadith_count: 7, collection_count: 1 },
+  ],
+  total_hadiths: 47,
+  total_collections: 3,
+  distinct_sources: 2,
+}
+
+describe("DataManagementPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows loading state initially", () => {
+    vi.mocked(fetchDataOverview).mockImplementation(() => new Promise(() => {}))
+    vi.mocked(fetchDataSources).mockImplementation(() => new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText("Data Management")).toBeInTheDocument()
+    expect(screen.getAllByText(/Loading\.\.\./).length).toBeGreaterThan(0)
+  })
+
+  it("renders an error state when the overview query fails", async () => {
+    vi.mocked(fetchDataOverview).mockRejectedValue(new Error("overview boom"))
+    vi.mocked(fetchDataSources).mockResolvedValue(SOURCES)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/Error: overview boom/)).toBeInTheDocument()
+    })
+  })
+
+  it("renders inventory totals and per-label/type tables", async () => {
+    vi.mocked(fetchDataOverview).mockResolvedValue(OVERVIEW)
+    vi.mocked(fetchDataSources).mockResolvedValue(SOURCES)
+    renderPage()
+
+    await screen.findByText("Total Nodes")
+    expect(screen.getByText("167")).toBeInTheDocument()
+    expect(screen.getByText("Total Relationships")).toBeInTheDocument()
+    expect(screen.getByText("Nodes by Label")).toBeInTheDocument()
+    expect(screen.getByText("Narrator")).toBeInTheDocument()
+    expect(screen.getByText("120")).toBeInTheDocument()
+    expect(screen.getByText("Relationships by Type")).toBeInTheDocument()
+    expect(screen.getByText("NARRATED")).toBeInTheDocument()
+  })
+
+  it("renders the provenance breakdown by source corpus", async () => {
+    vi.mocked(fetchDataOverview).mockResolvedValue(OVERVIEW)
+    vi.mocked(fetchDataSources).mockResolvedValue(SOURCES)
+    renderPage()
+
+    await screen.findByText("Distinct Sources")
+    expect(screen.getByText("Provenance by Source Corpus")).toBeInTheDocument()
+    expect(screen.getByText("sunnah")).toBeInTheDocument()
+    expect(screen.getByText("40")).toBeInTheDocument()
+    expect(screen.getByText("thaqalayn")).toBeInTheDocument()
+  })
+
+  it("shows empty-state copy when nothing is loaded", async () => {
+    vi.mocked(fetchDataOverview).mockResolvedValue({
+      node_counts: [],
+      relationship_counts: [],
+      total_nodes: 0,
+      total_relationships: 0,
+    })
+    vi.mocked(fetchDataSources).mockResolvedValue({
+      sources: [],
+      total_hadiths: 0,
+      total_collections: 0,
+      distinct_sources: 0,
+    })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("No nodes loaded.")).toBeInTheDocument()
+    })
+    expect(screen.getByText("No relationships loaded.")).toBeInTheDocument()
+    expect(screen.getByText("No source-attributed content loaded.")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -28,3 +28,33 @@ export interface UsageAnalytics {
   api_call_count: number
   popular_narrators: PopularNarrator[]
 }
+
+export interface NodeCount {
+  label: string
+  count: number
+}
+
+export interface RelationshipCount {
+  rel_type: string
+  count: number
+}
+
+export interface DataOverview {
+  node_counts: NodeCount[]
+  relationship_counts: RelationshipCount[]
+  total_nodes: number
+  total_relationships: number
+}
+
+export interface SourceBreakdown {
+  source_corpus: string
+  hadith_count: number
+  collection_count: number
+}
+
+export interface DataSources {
+  sources: SourceBreakdown[]
+  total_hadiths: number
+  total_collections: number
+  distinct_sources: number
+}

--- a/src/api/routes/admin/__init__.py
+++ b/src/api/routes/admin/__init__.py
@@ -8,6 +8,7 @@ from src.api.routes.admin.analytics import router as analytics_router
 from src.api.routes.admin.audit import router as audit_router
 from src.api.routes.admin.config import router as config_router
 from src.api.routes.admin.dashboard import router as dashboard_router
+from src.api.routes.admin.data import router as data_router
 from src.api.routes.admin.health import router as health_router
 from src.api.routes.admin.moderation import router as moderation_router
 from src.api.routes.admin.reports import router as reports_router
@@ -24,3 +25,4 @@ router.include_router(reports_router)
 router.include_router(config_router)
 router.include_router(audit_router)
 router.include_router(dashboard_router)
+router.include_router(data_router)

--- a/src/api/routes/admin/data.py
+++ b/src/api/routes/admin/data.py
@@ -1,0 +1,202 @@
+"""Admin data-management endpoints.
+
+Read-only views over the loaded graph for administrators: a node/edge
+inventory ("what is loaded") and a provenance breakdown by source corpus
+("where did it come from").  Write operations — pipeline reset, reprocess,
+and per-source purge — are intentionally out of scope here and live behind
+their own confirmation-gated surfaces.
+
+All queries degrade gracefully to empty results when Neo4j is unavailable,
+matching the analytics/reports admin endpoints.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict
+
+from src.api.deps import get_neo4j
+from src.utils.neo4j_client import Neo4jClient
+
+router = APIRouter(prefix="/data")
+
+log = structlog.get_logger(logger_name=__name__)
+
+
+class NodeCount(BaseModel):
+    """Count of nodes carrying a given label."""
+
+    model_config = ConfigDict(frozen=True)
+
+    label: str
+    count: int
+
+
+class RelationshipCount(BaseModel):
+    """Count of relationships of a given type."""
+
+    model_config = ConfigDict(frozen=True)
+
+    rel_type: str
+    count: int
+
+
+class DataOverviewResponse(BaseModel):
+    """Graph-wide node/edge inventory for the data-management panel."""
+
+    model_config = ConfigDict(frozen=True)
+
+    node_counts: list[NodeCount]
+    relationship_counts: list[RelationshipCount]
+    total_nodes: int
+    total_relationships: int
+
+
+class SourceBreakdown(BaseModel):
+    """Loaded-content counts for a single source corpus."""
+
+    model_config = ConfigDict(frozen=True)
+
+    source_corpus: str
+    hadith_count: int
+    collection_count: int
+
+
+class DataSourcesResponse(BaseModel):
+    """Provenance breakdown of loaded content by source corpus."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sources: list[SourceBreakdown]
+    total_hadiths: int
+    total_collections: int
+    distinct_sources: int
+
+
+def _node_counts(neo4j: Neo4jClient) -> list[NodeCount]:
+    """Count nodes per label using the built-in ``db.labels()`` procedure.
+
+    Label names come from the database catalog (not user input) and are
+    backtick-quoted before interpolation.  Returns labels with at least one
+    node, ordered by descending count.
+    """
+    try:
+        records = neo4j.execute_read("CALL db.labels() YIELD label RETURN label")
+        labels = [r["label"] for r in records]
+    except Exception:  # noqa: BLE001
+        log.debug("data_node_labels_failed")
+        return []
+
+    counts: list[NodeCount] = []
+    for label in labels:
+        try:
+            records = neo4j.execute_read(f"MATCH (n:`{label}`) RETURN count(n) AS c")
+        except Exception:  # noqa: BLE001
+            log.debug("data_node_count_failed", label=label)
+            continue
+        count = records[0]["c"] if records else 0
+        if count:
+            counts.append(NodeCount(label=label, count=count))
+
+    counts.sort(key=lambda c: c.count, reverse=True)
+    return counts
+
+
+def _relationship_counts(neo4j: Neo4jClient) -> list[RelationshipCount]:
+    """Count relationships per type using ``db.relationshipTypes()``.
+
+    Type names come from the database catalog and are backtick-quoted before
+    interpolation.  Returns types with at least one edge, ordered by
+    descending count.
+    """
+    try:
+        types = [
+            r["relationshipType"]
+            for r in neo4j.execute_read(
+                "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType"
+            )
+        ]
+    except Exception:  # noqa: BLE001
+        log.debug("data_rel_types_failed")
+        return []
+
+    counts: list[RelationshipCount] = []
+    for rel_type in types:
+        try:
+            records = neo4j.execute_read(f"MATCH ()-[r:`{rel_type}`]->() RETURN count(r) AS c")
+        except Exception:  # noqa: BLE001
+            log.debug("data_rel_count_failed", rel_type=rel_type)
+            continue
+        count = records[0]["c"] if records else 0
+        if count:
+            counts.append(RelationshipCount(rel_type=rel_type, count=count))
+
+    counts.sort(key=lambda c: c.count, reverse=True)
+    return counts
+
+
+@router.get("/overview", response_model=DataOverviewResponse)
+def data_overview(
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> DataOverviewResponse:
+    """Return the node/edge inventory of the loaded graph.
+
+    Degrades to empty lists / zero totals when Neo4j is unavailable.
+    """
+    node_counts = _node_counts(neo4j)
+    relationship_counts = _relationship_counts(neo4j)
+
+    return DataOverviewResponse(
+        node_counts=node_counts,
+        relationship_counts=relationship_counts,
+        total_nodes=sum(c.count for c in node_counts),
+        total_relationships=sum(c.count for c in relationship_counts),
+    )
+
+
+def _source_counts(neo4j: Neo4jClient, label: str) -> dict[str, int]:
+    """Group nodes of ``label`` by their ``source_corpus`` property."""
+    try:
+        records = neo4j.execute_read(
+            f"""
+            MATCH (n:`{label}`)
+            WHERE n.source_corpus IS NOT NULL
+            RETURN n.source_corpus AS source, count(n) AS c
+            """
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("data_source_count_failed", label=label)
+        return {}
+    return {r["source"]: r["c"] for r in records if r.get("source")}
+
+
+@router.get("/sources", response_model=DataSourcesResponse)
+def data_sources(
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> DataSourcesResponse:
+    """Return a provenance breakdown of loaded content by source corpus.
+
+    Surfaces, for each corpus that contributed data, how many hadith and
+    collection nodes it loaded.  Degrades to an empty breakdown when Neo4j is
+    unavailable.
+    """
+    hadith_by_source = _source_counts(neo4j, "Hadith")
+    collection_by_source = _source_counts(neo4j, "Collection")
+
+    all_sources = sorted(set(hadith_by_source) | set(collection_by_source))
+    sources = [
+        SourceBreakdown(
+            source_corpus=source,
+            hadith_count=hadith_by_source.get(source, 0),
+            collection_count=collection_by_source.get(source, 0),
+        )
+        for source in all_sources
+    ]
+
+    return DataSourcesResponse(
+        sources=sources,
+        total_hadiths=sum(hadith_by_source.values()),
+        total_collections=sum(collection_by_source.values()),
+        distinct_sources=len(all_sources),
+    )

--- a/tests/test_api/test_admin_data.py
+++ b/tests/test_api/test_admin_data.py
@@ -1,0 +1,119 @@
+"""Tests for admin data-management endpoints.
+
+These exercise the route handlers directly with a mocked Neo4jClient rather
+than through ``TestClient``.  Building multiple ``create_app()`` instances
+OOM-kills the in-sandbox runner; direct calls keep the unit logic fully
+covered without that cost.  Admin auth-gating is enforced at the router-group
+level (``dependencies=[Depends(require_admin)]`` in ``create_app``) and is
+covered by ``test_admin_auth`` for every sub-router, including this one — see
+``test_data_router_is_registered`` for the wiring check.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from src.api.routes.admin.data import data_overview, data_sources
+
+
+def _loaded_read(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Stand-in for Neo4jClient.execute_read against a small loaded graph."""
+    q = " ".join(query.split())
+    if "CALL db.labels()" in q:
+        return [{"label": "Hadith"}, {"label": "Narrator"}, {"label": "Collection"}]
+    if "CALL db.relationshipTypes()" in q:
+        return [{"relationshipType": "NARRATED"}, {"relationshipType": "APPEARS_IN"}]
+    if "source_corpus" in q:
+        if "(n:`Hadith`)" in q:
+            return [{"source": "sunnah", "c": 40}, {"source": "thaqalayn", "c": 7}]
+        if "(n:`Collection`)" in q:
+            return [{"source": "sunnah", "c": 2}, {"source": "thaqalayn", "c": 1}]
+        return []
+    if "(n:`Hadith`)" in q:
+        return [{"c": 47}]
+    if "(n:`Narrator`)" in q:
+        return [{"c": 120}]
+    if "(n:`Collection`)" in q:
+        return [{"c": 3}]
+    if "[r:`NARRATED`]" in q:
+        return [{"c": 200}]
+    if "[r:`APPEARS_IN`]" in q:
+        return [{"c": 47}]
+    return []
+
+
+def _loaded_client() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.side_effect = _loaded_read
+    return client
+
+
+def _empty_client() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.return_value = []
+    return client
+
+
+def _broken_client() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.side_effect = RuntimeError("neo4j down")
+    return client
+
+
+class TestDataOverview:
+    def test_inventory(self) -> None:
+        resp = data_overview(neo4j=_loaded_client())
+
+        # Only labels with a non-zero count appear, sorted by count desc.
+        assert [n.label for n in resp.node_counts] == ["Narrator", "Hadith", "Collection"]
+        assert resp.total_nodes == 47 + 120 + 3
+        assert [r.rel_type for r in resp.relationship_counts] == ["NARRATED", "APPEARS_IN"]
+        assert resp.total_relationships == 200 + 47
+
+    def test_empty_graph(self) -> None:
+        resp = data_overview(neo4j=_empty_client())
+        assert resp.node_counts == []
+        assert resp.relationship_counts == []
+        assert resp.total_nodes == 0
+        assert resp.total_relationships == 0
+
+    def test_neo4j_unavailable_degrades(self) -> None:
+        resp = data_overview(neo4j=_broken_client())
+        assert resp.total_nodes == 0
+        assert resp.total_relationships == 0
+
+
+class TestDataSources:
+    def test_provenance_breakdown(self) -> None:
+        resp = data_sources(neo4j=_loaded_client())
+
+        assert resp.distinct_sources == 2
+        assert resp.total_hadiths == 47
+        assert resp.total_collections == 3
+        by_source = {s.source_corpus: s for s in resp.sources}
+        assert by_source["sunnah"].hadith_count == 40
+        assert by_source["sunnah"].collection_count == 2
+        assert by_source["thaqalayn"].hadith_count == 7
+        assert by_source["thaqalayn"].collection_count == 1
+
+    def test_empty(self) -> None:
+        resp = data_sources(neo4j=_empty_client())
+        assert resp.sources == []
+        assert resp.distinct_sources == 0
+        assert resp.total_hadiths == 0
+        assert resp.total_collections == 0
+
+    def test_unavailable_degrades(self) -> None:
+        resp = data_sources(neo4j=_broken_client())
+        assert resp.sources == []
+        assert resp.distinct_sources == 0
+
+
+def test_data_router_is_registered() -> None:
+    """The data sub-router is mounted under the admin group with both routes."""
+    from src.api.routes.admin import router as admin_router
+
+    paths = {route.path for route in admin_router.routes}  # type: ignore[attr-defined]
+    assert "/data/overview" in paths
+    assert "/data/sources" in paths


### PR DESCRIPTION
## Summary
Adds the admin **Data Management** panel (greenfield, #806) — a read-only view over the loaded graph for administrators.

### Backend — `src/api/routes/admin/data.py` (new admin sub-router)
Registered in `src/api/routes/admin/__init__.py`; inherits `require_admin` via the admin router group.
- `GET /api/v1/admin/data/overview` — node counts by label + relationship counts by type (via built-in `db.labels()` / `db.relationshipTypes()`), with totals. Reflects real loaded state, no hardcoded label list.
- `GET /api/v1/admin/data/sources` — provenance breakdown by `source_corpus` (hadith + collection counts per corpus, distinct-source count).
- Both degrade gracefully to empty results when Neo4j is unavailable (matches analytics/reports idiom).

### Frontend
- `DataManagementPage.tsx` under `/admin/data` (route in `App.tsx`, nav item in `AdminLayout`), with loading/error/empty states matching the existing admin page idiom (card grid + `data-table`).
- New `fetchDataOverview` / `fetchDataSources` data-fn block appended to `admin-client.ts`; `DataOverview` / `DataSources` types appended to `types/admin.ts`.

### Tests
- Backend: **direct-call unit tests** for both handlers (loaded / empty / Neo4j-unavailable) + a router-registration wiring check. Note: TestClient tests that build multiple `create_app()` instances OOM-kill the in-sandbox runner, so these call the handlers directly; admin auth-gating is covered group-wide by `test_admin_auth`. 7/7 pass locally (~1s).
- Frontend: vitest page tests (loading/error/data/provenance/empty) — 5/5 pass.
- ruff (format+lint), mypy strict, eslint, and `tsc --noEmit` all clean on touched files.

### Deferred (collision-safe ownership split)
- Pipeline **reset** + per-source purge → **#970** (owns its own ResetPage + reset fns).
- Reprocess-from-stage (write op) and Kafka / B2-size / Grafana panels — require infra connectors not present in this repo. Scoped this issue to a read-only data overview; these are noted for follow-up.

## Reviewers
- **Mateo Salazar** (primary)
- **Nneka Obi** (secondary)

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
