### PR TITLE
fix(frontend): guard non-JSON auth responses in LoginPage (#977)

### DIFF
--- a/frontend/src/lib/__tests__/authJson.test.ts
+++ b/frontend/src/lib/__tests__/authJson.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  readJsonResponse,
+  NonJsonResponseError,
+  NON_JSON_RESPONSE_MESSAGE,
+} from '../authJson'
+
+describe('readJsonResponse', () => {
+  it('parses a genuine application/json response', async () => {
+    const res = new Response(JSON.stringify({ access_token: 'abc' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    await expect(readJsonResponse<{ access_token: string }>(res)).resolves.toEqual({
+      access_token: 'abc',
+    })
+  })
+
+  it('honours a charset-suffixed JSON content-type', async () => {
+    const res = new Response(JSON.stringify([{ a: 1 }]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    })
+    await expect(readJsonResponse(res)).resolves.toEqual([{ a: 1 }])
+  })
+
+  it('throws NonJsonResponseError on a 200 text/html body (the deploy#420 misroute)', async () => {
+    // A reverse-proxy fallback serving the SPA index.html with HTTP 200.
+    const res = new Response('<!DOCTYPE html><html><body>SPA</body></html>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html' },
+    })
+    await expect(readJsonResponse(res)).rejects.toBeInstanceOf(NonJsonResponseError)
+    await expect(readJsonResponse(res)).rejects.toThrow(NON_JSON_RESPONSE_MESSAGE)
+  })
+
+  it('throws NonJsonResponseError when content-type is absent', async () => {
+    const res = new Response('not json', { status: 200 })
+    res.headers.delete('content-type')
+    await expect(readJsonResponse(res)).rejects.toBeInstanceOf(NonJsonResponseError)
+  })
+
+  it('throws NonJsonResponseError when the body claims JSON but fails to parse', async () => {
+    const res = new Response('<<< not json >>>', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    await expect(readJsonResponse(res)).rejects.toBeInstanceOf(NonJsonResponseError)
+  })
+
+  it('never leaks the raw SyntaxError ("Unexpected token") to the caller', async () => {
+    const res = new Response('<!DOCTYPE html>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html' },
+    })
+    await expect(readJsonResponse(res)).rejects.not.toThrow(/unexpected token/i)
+  })
+})

--- a/frontend/src/lib/authJson.ts
+++ b/frontend/src/lib/authJson.ts
@@ -1,0 +1,41 @@
+/**
+ * Defensive JSON reader for auth-service responses.
+ *
+ * When the user-service origin mis-resolves — e.g. a stale runtime-config or a
+ * reverse-proxy fallback serving the SPA's `index.html` — the auth endpoints
+ * can answer HTTP 200 with `text/html` instead of JSON. A bare `res.json()`
+ * then throws a cryptic `Unexpected token '<'` straight at the user, and the
+ * 200 status masks the misroute. This helper checks the content-type (and
+ * guards the parse) so a misroute degrades to a clear "service unreachable /
+ * misconfigured" message instead of a raw parse exception. It is the
+ * frontend-side complement to the deploy runtime-config fix (deploy#420).
+ */
+export const NON_JSON_RESPONSE_MESSAGE =
+  'The authentication service returned an unexpected response. ' +
+  'It may be temporarily unreachable or misconfigured. Please try again later.'
+
+export class NonJsonResponseError extends Error {
+  constructor(message: string = NON_JSON_RESPONSE_MESSAGE) {
+    super(message)
+    this.name = 'NonJsonResponseError'
+  }
+}
+
+/**
+ * Parse a `Response` body as JSON, but only when it actually claims to be JSON.
+ *
+ * Throws `NonJsonResponseError` (carrying a user-facing message) when the
+ * `Content-Type` is not `application/json`, or when the body fails to parse —
+ * never the raw `SyntaxError` from `Response.json()`.
+ */
+export async function readJsonResponse<T = unknown>(res: Response): Promise<T> {
+  const contentType = res.headers.get('content-type') ?? ''
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new NonJsonResponseError()
+  }
+  try {
+    return (await res.json()) as T
+  } catch {
+    throw new NonJsonResponseError()
+  }
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/Tabs'
 import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
+import { readJsonResponse } from '../lib/authJson'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
 // useAuth.ts for the full BASE-constant set and the runtime-vs-build-time
@@ -91,8 +92,8 @@ export default function LoginPage() {
 
   useEffect(() => {
     fetch(`${AUTH_BASE}/providers`)
-      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
-      .then((data: string[]) => setProviders(data))
+      .then((res) => (res.ok ? readJsonResponse<string[]>(res) : Promise.reject(res)))
+      .then((data) => setProviders(data))
       .catch(() => setProviders(['google', 'github']))
   }, [])
 
@@ -114,11 +115,13 @@ export default function LoginPage() {
       const res = await fetch(`${AUTH_BASE}/oauth/${provider}/login`)
 
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }))
+        const data = await readJsonResponse<{ detail?: string }>(res).catch(() => ({
+          detail: `HTTP ${res.status}`,
+        }))
         throw new Error(data.detail || `Failed to initiate ${provider} login`)
       }
 
-      const data = await res.json()
+      const data = await readJsonResponse<{ authorization_url: string }>(res)
       sessionStorage.setItem('oauth_return_url', from)
       window.location.href = data.authorization_url
     } catch (err) {
@@ -145,11 +148,13 @@ export default function LoginPage() {
       })
 
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }))
+        const data = await readJsonResponse<{ detail?: string }>(res).catch(() => ({
+          detail: `HTTP ${res.status}`,
+        }))
         throw new Error(data.detail || 'Invalid credentials')
       }
 
-      const data = await res.json()
+      const data = await readJsonResponse<{ access_token: string }>(res)
       localStorage.setItem('access_token', data.access_token)
       // Refresh token is set as httpOnly cookie by the server
       navigate(from, { replace: true })
@@ -184,11 +189,13 @@ export default function LoginPage() {
       })
 
       if (!res.ok) {
-        const data = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }))
+        const data = await readJsonResponse<{ detail?: string }>(res).catch(() => ({
+          detail: `HTTP ${res.status}`,
+        }))
         throw new Error(data.detail || 'Registration failed')
       }
 
-      const data = await res.json()
+      const data = await readJsonResponse<{ access_token: string }>(res)
       localStorage.setItem('access_token', data.access_token)
       // Refresh token is set as httpOnly cookie by the server
       navigate(from, { replace: true })

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+import LoginPage from '../LoginPage'
+import { NON_JSON_RESPONSE_MESSAGE } from '../../lib/authJson'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// A reverse-proxy fallback / stale-runtime-config misroute: the SPA's own
+// index.html served with HTTP 200 and a text/html content-type instead of the
+// auth JSON. This is the deploy#420 failure class.
+function htmlResponse(): Response {
+  return new Response('<!DOCTYPE html><html><body>SPA shell</body></html>', {
+    status: 200,
+    headers: { 'Content-Type': 'text/html' },
+  })
+}
+
+function renderLogin() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <LoginPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('LoginPage — non-JSON auth response guard (#977)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces a clean error (not a raw parse throw) when email login is misrouted to HTML', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/auth/providers')) return Promise.resolve(jsonResponse(['google']))
+      if (url.endsWith('/auth/login/email')) return Promise.resolve(htmlResponse())
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderLogin()
+
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+
+    const form = screen.getByLabelText('Email').closest('form') as HTMLFormElement
+    fireEvent.submit(form)
+
+    const alert = await waitFor(() => screen.getByRole('alert'))
+    expect(alert).toHaveTextContent(NON_JSON_RESPONSE_MESSAGE)
+    // The raw SyntaxError must never reach the user.
+    expect(alert).not.toHaveTextContent(/unexpected token/i)
+    // And no bogus token gets persisted from an HTML body.
+    expect(localStorage.getItem('access_token')).toBeNull()
+  })
+
+  it('still completes a genuine JSON login', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/auth/providers')) return Promise.resolve(jsonResponse(['google']))
+      if (url.endsWith('/auth/login/email'))
+        return Promise.resolve(jsonResponse({ access_token: 'real-token' }))
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderLogin()
+
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.submit(screen.getByLabelText('Email').closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(localStorage.getItem('access_token')).toBe('real-token')
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #977

## Context
Defensive frontend complement to **deploy#420 / PR #421** (prod-login JSON.parse). The deploy-side fix promotes the stale prod image + adds an anti-drift smoke guard; this PR is the **code guard** so a future origin/runtime-config drift degrades gracefully instead of throwing a cryptic parse error.

## Problem
`LoginPage.tsx` called `res.json()` on the auth endpoints with no content-type / parse guard on the success paths. When the user-service origin mis-resolves — or any misroute serves the SPA `index.html` with **HTTP 200 + text/html** — `res.json()` parses `<!DOCTYPE html…` and throws a raw `Unexpected token '<'` at the user. The 200 status masks the misroute.

## Fix
- New helper `frontend/src/lib/authJson.ts` → `readJsonResponse<T>(res)`: checks `Content-Type` is `application/json` (charset-suffix tolerant) and guards the parse, throwing `NonJsonResponseError` with a clean user-facing message (`NON_JSON_RESPONSE_MESSAGE`) instead of the raw `SyntaxError`.
- Routed **every** auth-flow `res.json()` in `LoginPage` through it:
  - providers probe (`/auth/providers`) — already fell back to defaults; now consistent
  - OAuth init (`/auth/oauth/{provider}/login`) — success + error paths
  - email login (`/auth/login/email`) — success + error paths
  - register (`/auth/register`) — success + error paths
- Error paths keep their existing `.catch(() => ({ detail: HTTP <status> }))` fallback.

Scoped to LoginPage + the new shared helper. The runtime-config mechanism itself is untouched (deploy-side).

## Test
- `src/lib/__tests__/authJson.test.ts` (6): genuine JSON, charset-suffixed JSON, 200 `text/html` misroute → `NonJsonResponseError`, absent content-type, JSON-typed-but-unparseable body, and "never leaks the raw `Unexpected token` SyntaxError".
- `src/pages/__tests__/LoginPage.test.tsx` (2): HTML-misrouted email login surfaces the clean error and persists **no** `access_token`; a genuine JSON login still succeeds.

## Test Plan
- [x] `vitest run` (new files) — 8/8 pass
- [x] `eslint` clean on changed files
- [x] `tsc -b` (build typecheck) clean
- [ ] Reviewers: @Nneka Obi (primary), @Anya Kowalczyk (secondary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
