### PR TITLE
feat(frontend): derive ForceGraph colors from DS data-viz tokens (#979)

### DIFF
--- a/frontend/src/components/ForceGraph.tsx
+++ b/frontend/src/components/ForceGraph.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback, useMemo, useState } from 'react'
 import ForceGraph2D, { type ForceGraphMethods } from 'react-force-graph-2d'
+import { dataViz, dataVizDark } from '@noorinalabs/design-system'
 import type { GraphNode, GraphEdge } from '../types/api'
 
 /** Read current theme colors from CSS custom properties. */
@@ -7,11 +8,18 @@ function getThemeColors() {
   const style = getComputedStyle(document.documentElement)
   const isDark = document.documentElement.getAttribute('data-theme') === 'dark' ||
     document.documentElement.classList.contains('dark')
+  // Graph/community palette + accent come from the DS data-viz tokens. Canvas can't
+  // consume `var()`, so we pick the resolved light/dark constant array by current
+  // theme (mirrors how the link colors below switch on `isDark`). The mutation
+  // observer in `useThemeColors` re-reads this on theme change for reactivity.
+  const viz = isDark ? dataVizDark : dataViz
   return {
     background: style.getPropertyValue('--color-background').trim() || '#fafafa',
     foreground: style.getPropertyValue('--color-foreground').trim() || '#333',
     card: style.getPropertyValue('--color-card').trim() || '#fff',
     muted: style.getPropertyValue('--color-muted-foreground').trim() || '#999',
+    community: viz.categorical,
+    accent: viz.accent,
     // Pre-computed link colors for canvas (canvas doesn't reliably support color-mix)
     linkDefault: isDark ? 'rgba(160, 160, 160, 0.4)' : 'rgba(204, 204, 204, 0.4)',
     linkActive: isDark ? 'rgba(160, 160, 160, 0.8)' : 'rgba(204, 204, 204, 0.8)',
@@ -37,21 +45,22 @@ function useThemeColors() {
   return colors
 }
 
-/** Hex community palette — CVD-distinguishable, meets AA contrast on #fafafa. */
-const COMMUNITY_HEX = [
-  '#4285f4', // blue
-  '#e8a735', // amber
-  '#34a853', // green
-  '#9c27b0', // purple
-  '#ea4335', // red-orange
-  '#00897b', // teal
-  '#7cb342', // yellow-green
-  '#ad1457', // magenta
-]
-
-function communityColor(id: number | null | undefined): string {
+/**
+ * Map a community id to a categorical color from the DS data-viz palette.
+ *
+ * `palette` defaults to the light-mode DS categorical scale so DOM consumers
+ * (e.g. the GraphExplorer legend swatches) can call this with just an id, while
+ * the canvas renderer passes the theme-reactive `themeColors.community` array so
+ * node fills track light/dark mode. The DS palette is CVD-distinguishable and
+ * meets WCAG non-text contrast against the matching-mode background. The scale
+ * has 10 entries (was 8); >10 communities cycle by modulo.
+ */
+function communityColor(
+  id: number | null | undefined,
+  palette: readonly string[] = dataViz.categorical,
+): string {
   if (id == null) return '#999'
-  return COMMUNITY_HEX[id % COMMUNITY_HEX.length] ?? '#999'
+  return palette[id % palette.length] ?? '#999'
 }
 
 /** Map degree to node radius per wireframe spec. */
@@ -104,7 +113,6 @@ interface InternalLink {
   weight: number
 }
 
-const ACCENT = '#1a73e8'
 const REDUCED_MOTION =
   typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
@@ -207,7 +215,7 @@ export default function ForceGraph({
       const y = node.y ?? 0
       const origNode = nodeMap.get(node.id)
       const r = origNode ? nodeRadius(origNode) : 6
-      const color = communityColor(node.community_id)
+      const color = communityColor(node.community_id, themeColors.community)
       const isSelected = selectedNodeId === node.id
       const isChainHighlighted = highlightedChainNodeIds?.has(node.id)
 
@@ -234,7 +242,7 @@ export default function ForceGraph({
       if (isSelected || isChainHighlighted) {
         ctx.beginPath()
         ctx.arc(x, y, r + 2, 0, 2 * Math.PI)
-        ctx.strokeStyle = ACCENT
+        ctx.strokeStyle = themeColors.accent
         ctx.lineWidth = 3
         ctx.stroke()
       }
@@ -284,7 +292,7 @@ export default function ForceGraph({
           highlightedChainNodeIds.has(sourceId) &&
           highlightedChainNodeIds.has(targetId)
         ) {
-          return ACCENT
+          return themeColors.accent
         }
         return themeColors.linkDimmed
       }
@@ -359,4 +367,4 @@ export default function ForceGraph({
   )
 }
 
-export { COMMUNITY_HEX, communityColor, nodeRadius, edgeWidth }
+export { communityColor, nodeRadius, edgeWidth }

--- a/frontend/src/components/__tests__/ForceGraph.test.ts
+++ b/frontend/src/components/__tests__/ForceGraph.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { dataViz, dataVizDark } from '@noorinalabs/design-system'
+
+// ForceGraph.tsx reads `window.matchMedia` at module load (REDUCED_MOTION). jsdom
+// doesn't implement it, so stub before the dynamic import below. We import the
+// module dynamically (after the stub) rather than statically so the stub is in
+// place when the module body executes.
+let communityColor: (typeof import('../ForceGraph'))['communityColor']
+
+beforeAll(async () => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  )
+  ;({ communityColor } = await import('../ForceGraph'))
+})
+
+describe('communityColor', () => {
+  it('derives the palette from the DS data-viz tokens (no bespoke hardcoded hex)', () => {
+    // Each community id maps to the matching DS categorical token, not a local
+    // hex constant — this is the core #979 contract.
+    for (let i = 0; i < dataViz.categorical.length; i++) {
+      expect(communityColor(i)).toBe(dataViz.categorical[i])
+    }
+  })
+
+  it('cycles by modulo for ids beyond the palette length', () => {
+    const len = dataViz.categorical.length
+    expect(communityColor(len)).toBe(dataViz.categorical[0])
+    expect(communityColor(len + 3)).toBe(dataViz.categorical[3])
+  })
+
+  it('uses the supplied (theme-reactive) palette when one is passed', () => {
+    // The canvas renderer passes themeColors.community, which is dataVizDark in
+    // dark mode — so the same community id resolves to the dark token.
+    expect(communityColor(2, dataVizDark.categorical)).toBe(dataVizDark.categorical[2])
+    expect(communityColor(0, dataVizDark.categorical)).not.toBe(communityColor(0))
+  })
+
+  it('returns a neutral fallback for a null/undefined community', () => {
+    expect(communityColor(null)).toBe('#999')
+    expect(communityColor(undefined)).toBe('#999')
+  })
+})


### PR DESCRIPTION
## What & why

Closes #979 (parent #967 bucket B). `frontend/src/components/ForceGraph.tsx` hardcoded the community/categorical palette (`COMMUNITY_HEX`, 8 colors) and `ACCENT` (`#1a73e8`), so they drifted from the brand palette and never participated in dark-mode adjustments. This wires the graph viz colors to the design-system **data-viz tokens** shipped in `@noorinalabs/design-system@0.0.5-wave4.0` (ds#102).

## How the canvas colors resolve from DS tokens

The graph renders to `<canvas>`, which can't consume `var()`. The DS exposes the data-viz palette two ways — CSS custom props (`--color-viz-categorical-1..10`, `--color-viz-accent`) **and** resolved TS constants (`dataViz` / `dataVizDark`, each `{ categorical: string[10], accent }`).

I used the **TS-constant** path rather than `getComputedStyle` of the viz CSS vars, deliberately:

- This frontend keeps its **own** `src/styles/theme.css` copy of color tokens and does **not** import DS `colors.css`, so `--color-viz-*` are not present on `document.documentElement`. A `getComputedStyle` read would return empty strings unless I duplicated all 22 viz var declarations (light + dark) into `theme.css` — i.e. re-introducing the exact drift surface #979 exists to remove.
- Importing `dataViz` / `dataVizDark` is a single source of truth, type-safe, and independent of CSS load order.

Theme reactivity is preserved by picking the array inside `getThemeColors()` via the existing `isDark` switch (the same one already used for the link colors), and `useThemeColors`' `MutationObserver` re-reads on `data-theme`/`class` change — so node fills + the selection/chain accent now track light/dark mode, which the old static palette never did.

Specifics:
- `getThemeColors()` exposes `community` (10-entry categorical scale) + `accent`, both theme-reactive.
- `communityColor(id, palette?)` gains an optional palette (defaults to the light DS scale). The **canvas** passes `themeColors.community`; the **GraphExplorer legend swatches** (`GraphExplorerPage.tsx`) keep calling it single-arg, unchanged. Palette now cycles by modulo over 10 entries (was 8 — more headroom for >10 communities).
- Selection ring + highlighted-chain links use `themeColors.accent`.
- Drops the `COMMUNITY_HEX` export (no external consumers — only `communityColor` is imported elsewhere).

## Files
- `frontend/src/components/ForceGraph.tsx` — token wiring (the only production file #979 touches)
- `frontend/src/components/__tests__/ForceGraph.test.ts` — new unit test

## Test Plan
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only; none new in changed file)
- [x] `npx vitest run` — full suite 161/161 pass (incl. new ForceGraph test 4/4 + GraphExplorerPage 13/13)
- [x] `npm run build` — production build succeeds
- New test asserts: palette derives from DS `dataViz` tokens (not bespoke hex), cycles by modulo past the palette length, honors a passed (dark) palette, and falls back to neutral for null community.
- [ ] **Manual (post-merge, runtime):** visually verify light + dark render in the running app — canvas unit tests can't assert pixel output. The DS tokens are `oklch()` strings (canvas `fillStyle` supports oklch in current Chromium/Safari/Firefox); confirm node fills + selection accent in both themes.

## Reviewers
@Mateo Salazar (primary) · @Arjun Raghavan (secondary)
