### PR TITLE
test: Playwright harness (authenticated, stg-targeted) + smoke + CI (#968)

### DIFF
--- a/.github/workflows/e2e-stg-smoke.yml
+++ b/.github/workflows/e2e-stg-smoke.yml
@@ -1,0 +1,80 @@
+# Browser-automation smoke against a DEPLOYED environment (#968).
+#
+# Deliberately NOT on `pull_request` — it drives the live stg/prod app and
+# needs deploy-environment secrets (test-user creds), which fork/PR contexts
+# don't get. Running it only on manual dispatch + a schedule means a PR
+# lacking secrets is never broken by it (the prerequisite the issue calls out).
+#
+# The public leg (login page / runtime-config) needs no creds; the
+# authenticated leg self-skips when STG_TEST_EMAIL / STG_TEST_PASSWORD are
+# absent (see frontend/tests/stg-smoke/env.ts).
+name: e2e-stg-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_env:
+        description: 'Environment to smoke-test'
+        type: choice
+        options: [stg, prod]
+        default: stg
+  schedule:
+    # Daily at 06:17 UTC — catch deploy/data regressions out-of-band of PRs.
+    - cron: '17 6 * * *'
+
+concurrency:
+  group: e2e-stg-smoke-${{ github.event.inputs.target_env || 'stg' }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    defaults:
+      run:
+        working-directory: frontend
+    env:
+      TARGET_ENV: ${{ github.event.inputs.target_env || 'stg' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          # @noorinalabs/* resolves from GitHub Packages — see the
+          # frontend-lint-and-test job in ci.yml for the registry/token pairing.
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@noorinalabs'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npx playwright install --with-deps chromium
+      - name: Run stg smoke suite
+        run: npm run e2e:stg
+        env:
+          # URLs default to the stg/prod vhosts in env.ts; override via repo
+          # vars if the deployed hosts ever change. Creds are secrets-only —
+          # the authenticated leg self-skips if they're unset.
+          STG_BASE_URL: ${{ vars.STG_BASE_URL }}
+          USER_SERVICE_URL: ${{ vars.STG_USER_SERVICE_URL }}
+          PROD_BASE_URL: ${{ vars.PROD_BASE_URL }}
+          PROD_USER_SERVICE_URL: ${{ vars.PROD_USER_SERVICE_URL }}
+          STG_TEST_EMAIL: ${{ secrets.STG_TEST_EMAIL }}
+          STG_TEST_PASSWORD: ${{ secrets.STG_TEST_PASSWORD }}
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: stg-smoke-report-${{ env.TARGET_ENV }}
+          path: frontend/playwright-report-stg/
+          retention-days: 14
+      - name: Upload traces / screenshots (on failure)
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: stg-smoke-artifacts-${{ env.TARGET_ENV }}
+          path: frontend/test-results-stg/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ coverage/
 # Playwright
 frontend/test-results/
 frontend/playwright-report/
+# stg smoke harness (#968) — generated report/results + seeded auth state
+frontend/test-results-stg/
+frontend/playwright-report-stg/
+frontend/tests/stg-smoke/.auth/
 
 # Terraform
 terraform/.terraform/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint src/",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
+    "e2e:stg": "playwright test -c playwright.stg.config.ts",
+    "e2e:stg:ui": "playwright test -c playwright.stg.config.ts --ui",
     "gen:types": "openapi-typescript docs/openapi-snapshot.json -o src/types/user-service.d.ts"
   },
   "dependencies": {

--- a/frontend/playwright.stg.config.ts
+++ b/frontend/playwright.stg.config.ts
@@ -1,0 +1,60 @@
+/**
+ * Playwright config for the stg-targeted browser-automation smoke harness (#968).
+ *
+ * Deliberately SEPARATE from the default `playwright.config.ts` (which drives a
+ * local `vite preview` with a fully-mocked backend under `tests/e2e/`). This
+ * config drives a real deployed environment and authenticates against the live
+ * user-service. Run it explicitly:
+ *
+ *   npm run e2e:stg                 # against staging
+ *   TARGET_ENV=prod npm run e2e:stg # against prod (read-only / smoke-only)
+ *
+ * Projects:
+ *   - `setup`        — programmatic login → persisted storage-state (no-op skip
+ *                      when stg creds are absent; see tests/stg-smoke/env.ts).
+ *   - `smoke-public` — unauthenticated invariants (login page, runtime-config).
+ *                      Always runs; needs no creds.
+ *   - `smoke-auth`   — protected-route invariants; depends on `setup` and reuses
+ *                      its storage-state. Self-skips when creds are absent.
+ */
+import { defineConfig, devices } from '@playwright/test'
+import { BASE_URL, STORAGE_STATE } from './tests/stg-smoke/env'
+
+export default defineConfig({
+  testDir: './tests/stg-smoke',
+  // Real network round-trips against a deployed env — give pages room to load.
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [['html', { outputFolder: 'playwright-report-stg', open: 'never' }], ['list']]
+    : 'list',
+  outputDir: 'test-results-stg',
+  use: {
+    baseURL: BASE_URL,
+    // Capture diagnostics on failure so a red run is actionable from artifacts.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'smoke-public',
+      testMatch: /.*\.public\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'smoke-auth',
+      testMatch: /.*\.auth\.spec\.ts/,
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+    },
+  ],
+})

--- a/frontend/tests/stg-smoke/README.md
+++ b/frontend/tests/stg-smoke/README.md
@@ -1,0 +1,56 @@
+# Stg-targeted browser-automation smoke harness (#968)
+
+A Playwright suite that drives a **real deployed environment** (staging by
+default, prod in read-only/smoke-only mode) and authenticates against the live
+user-service. It is the foundation the exploratory-sweep epic (#969) builds on.
+
+> This is **separate** from the mock-based suite in `tests/e2e/` (which drives a
+> local `vite preview` with every API call stubbed and is wired through the
+> default `playwright.config.ts`). This harness uses its own
+> `playwright.stg.config.ts` and never touches the local-mock suite.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `env.ts` | Resolves target URLs + creds from env vars; exposes `hasAuthCreds`. |
+| `auth.setup.ts` | Setup project: programmatic `POST /auth/login/email` → persisted storage-state (JWT seeded into `localStorage.access_token`). No-op when creds absent. |
+| `helpers.ts` | `requireAuth()` skip-guard, `looksLikeHtml`, page-error collector. |
+| `login.public.spec.ts` | Unauthenticated invariants — login surface + `/runtime-config.js`. Needs no creds. |
+| `smoke.auth.spec.ts` | Authenticated invariants — home/narrators/hadiths/graph-explorer render + `/api/v1/search` status. Self-skips without creds. |
+
+## Run it
+
+```bash
+cd frontend
+npm install
+npx playwright install --with-deps chromium
+
+# Staging (public leg only, no creds):
+npm run e2e:stg
+
+# Staging with the authenticated leg:
+STG_TEST_EMAIL='qa-bot@example.com' STG_TEST_PASSWORD='…' npm run e2e:stg
+
+# Prod (read-only / smoke-only):
+TARGET_ENV=prod npm run e2e:stg
+```
+
+## Environment variables
+
+| Var | Default | Notes |
+|-----|---------|-------|
+| `TARGET_ENV` | `stg` | `stg` or `prod`. |
+| `STG_BASE_URL` | `https://isnad.stg.noorinalabs.com` | Frontend origin under test. |
+| `USER_SERVICE_URL` | `https://users.stg.noorinalabs.com` | JWT issuer. |
+| `PROD_BASE_URL` / `PROD_USER_SERVICE_URL` | prod vhosts | Used when `TARGET_ENV=prod`. |
+| `STG_TEST_EMAIL` / `STG_TEST_PASSWORD` | _(unset)_ | Test-user creds. **Secrets only — never commit.** Absent ⇒ authenticated leg skips. |
+
+## CI
+
+`.github/workflows/e2e-stg-smoke.yml` runs on **manual dispatch** (with a
+`target_env` input) and a **daily schedule** — never on `pull_request`, so a PR
+without deploy secrets is never broken by it. The workflow publishes the HTML
+report always and traces/screenshots on failure. Wire `STG_TEST_EMAIL` /
+`STG_TEST_PASSWORD` as repo secrets and (optionally) the `*_BASE_URL` /
+`*_USER_SERVICE_URL` as repo vars.

--- a/frontend/tests/stg-smoke/auth.setup.ts
+++ b/frontend/tests/stg-smoke/auth.setup.ts
@@ -1,0 +1,69 @@
+/**
+ * Authentication setup project for the stg smoke harness (#968).
+ *
+ * Performs a PROGRAMMATIC email/password login against the live user-service
+ * (`POST {USER_SERVICE_URL}/auth/login/email` — the same endpoint the real
+ * LoginPage posts to) and persists a Playwright storage-state with the issued
+ * JWT seeded into the frontend origin's localStorage under `access_token` —
+ * which is exactly where `src/api/client.ts` and `ProtectedRoute` read it from.
+ *
+ * The storage-state is then reused by every `*.auth.spec.ts` (the `smoke-auth`
+ * project depends on this `setup` project), so each spec starts already logged
+ * in without re-hitting the auth endpoint.
+ *
+ * Credential-less contexts (e.g. a manual run without secrets exported): we
+ * write an EMPTY storage-state so the dependent project still loads, and the
+ * authenticated specs self-skip via `requireAuth()`.
+ */
+import { test as setup, expect, request } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import {
+  BASE_URL,
+  USER_SERVICE_URL,
+  TEST_EMAIL,
+  TEST_PASSWORD,
+  hasAuthCreds,
+  STORAGE_STATE,
+} from './env'
+
+const EMPTY_STATE = JSON.stringify({ cookies: [], origins: [] })
+
+setup('authenticate', async () => {
+  mkdirSync(dirname(STORAGE_STATE), { recursive: true })
+
+  if (!hasAuthCreds) {
+    // No creds in this environment — write an empty state so the dependent
+    // project can still load; `*.auth.spec.ts` self-skip via requireAuth().
+    writeFileSync(STORAGE_STATE, EMPTY_STATE)
+    setup.skip(true, 'stg creds not configured (STG_TEST_EMAIL / STG_TEST_PASSWORD) — auth leg skipped')
+    return
+  }
+
+  const api = await request.newContext({ baseURL: USER_SERVICE_URL })
+  const res = await api.post('/auth/login/email', {
+    data: { email: TEST_EMAIL, password: TEST_PASSWORD },
+  })
+
+  expect(
+    res.ok(),
+    `login/email failed: ${res.status()} ${res.statusText()} — check test-user creds and ${USER_SERVICE_URL}`,
+  ).toBeTruthy()
+
+  const body = (await res.json()) as { access_token?: string }
+  expect(body.access_token, 'login response missing access_token').toBeTruthy()
+  await api.dispose()
+
+  // Seed the JWT into the frontend origin's localStorage — matches how the
+  // real app stores it (LoginPage → localStorage.setItem('access_token', …)).
+  const state = {
+    cookies: [],
+    origins: [
+      {
+        origin: new URL(BASE_URL).origin,
+        localStorage: [{ name: 'access_token', value: body.access_token as string }],
+      },
+    ],
+  }
+  writeFileSync(STORAGE_STATE, JSON.stringify(state, null, 2))
+})

--- a/frontend/tests/stg-smoke/env.ts
+++ b/frontend/tests/stg-smoke/env.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared environment resolution for the stg-targeted smoke harness (#968).
+ *
+ * Unlike the mock-based `tests/e2e/` suite — which drives a locally-built
+ * `vite preview` with every API call stubbed — this suite drives a REAL
+ * deployed environment (staging by default, prod in read-only/smoke-only
+ * mode) and authenticates against the live user-service.
+ *
+ * Everything is sourced from env vars so the same specs run unchanged in
+ * local-dev (export the vars), CI (wired from repo secrets/vars), or against
+ * prod (`TARGET_ENV=prod`). Credentials are NEVER hardcoded; when they are
+ * absent the authenticated leg self-skips (see `hasAuthCreds`).
+ */
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+/** `stg` (default) or `prod`. Prod is treated as read-only / smoke-only. */
+export const TARGET_ENV = (process.env.TARGET_ENV ?? 'stg').toLowerCase()
+
+export const IS_PROD = TARGET_ENV === 'prod'
+
+/** Frontend origin under test. */
+export const BASE_URL =
+  process.env.STG_BASE_URL ??
+  (IS_PROD
+    ? process.env.PROD_BASE_URL ?? 'https://isnad.noorinalabs.com'
+    : 'https://isnad.stg.noorinalabs.com')
+
+/**
+ * user-service origin that issues JWTs. Defaults to the `users.{env}` vhost
+ * (deploy#220/#245 carve-out). Overridable for envs where the user-service is
+ * reachable under a different host.
+ */
+export const USER_SERVICE_URL =
+  process.env.USER_SERVICE_URL ??
+  (IS_PROD
+    ? process.env.PROD_USER_SERVICE_URL ?? 'https://users.noorinalabs.com'
+    : 'https://users.stg.noorinalabs.com')
+
+/** Test-user credentials for the authenticated leg — secrets only, no defaults. */
+export const TEST_EMAIL = process.env.STG_TEST_EMAIL ?? ''
+export const TEST_PASSWORD = process.env.STG_TEST_PASSWORD ?? ''
+
+/**
+ * True only when BOTH credentials are present. Drives the authenticated
+ * leg's skip-guard so the public smoke (login page / runtime-config) stays
+ * green in a credential-less context while the protected-route checks run
+ * wherever real creds are provisioned.
+ */
+export const hasAuthCreds = Boolean(TEST_EMAIL && TEST_PASSWORD)
+
+/** Persisted storage-state (seeded localStorage JWT) reused across auth specs. */
+export const STORAGE_STATE = join(here, '.auth', 'storage-state.json')

--- a/frontend/tests/stg-smoke/helpers.ts
+++ b/frontend/tests/stg-smoke/helpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared helpers for the stg smoke specs (#968).
+ */
+import { test, type Page } from '@playwright/test'
+import { hasAuthCreds } from './env'
+
+/**
+ * Skip the current authenticated spec when no stg creds are provisioned.
+ * Call at the top of every `*.auth.spec.ts` test (or describe) so the suite
+ * stays green in a credential-less context.
+ */
+export function requireAuth(): void {
+  test.skip(!hasAuthCreds, 'stg creds not configured (STG_TEST_EMAIL / STG_TEST_PASSWORD)')
+}
+
+/** True if a response body looks like an SPA HTML document rather than an asset. */
+export function looksLikeHtml(body: string): boolean {
+  const head = body.trimStart().slice(0, 200).toLowerCase()
+  return head.startsWith('<!doctype html') || head.startsWith('<html')
+}
+
+/**
+ * Attach a page-error collector. Returns a getter for any uncaught page
+ * errors observed since attach — used to guard against the prod-login
+ * `JSON.parse` crash (noorinalabs-main#637).
+ */
+export function collectPageErrors(page: Page): () => string[] {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  return () => errors
+}

--- a/frontend/tests/stg-smoke/login.public.spec.ts
+++ b/frontend/tests/stg-smoke/login.public.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Public (unauthenticated) smoke — login surface + runtime-config (#968).
+ *
+ * These run with NO storage-state and need no creds, so they stay green in any
+ * context. They encode the load-bearing invariants the P4W2 live sweep found
+ * broken in prod:
+ *   - `/login` renders providers and does NOT throw a `JSON.parse` (guards the
+ *     prod-login crash, noorinalabs-main#637 — caused by the SPA serving HTML
+ *     where the app expected JSON).
+ *   - `/runtime-config.js` must not be SPA HTML masquerading as a 200 script
+ *     (the exact prod regression in feedback_prod_frontend_runtime_config_lag).
+ */
+import { test, expect } from '@playwright/test'
+import { collectPageErrors, looksLikeHtml } from './helpers'
+
+test.describe('public smoke: login surface', () => {
+  test('login page renders sign-in options without a JSON.parse crash', async ({ page }) => {
+    const pageErrors = collectPageErrors(page)
+
+    await page.goto('/login', { waitUntil: 'networkidle' })
+
+    // The app heading proves the SPA mounted rather than erroring to a blank page.
+    await expect(page.getByRole('heading', { name: 'Isnad Graph' })).toBeVisible()
+
+    // Sign-in affordances are present: either the provider buttons (from
+    // /auth/providers) or the email form. We assert the email form, which is
+    // always rendered, plus at least one OAuth provider button.
+    await expect(page.getByLabel('Email')).toBeVisible()
+    await expect(page.getByLabel('Password')).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /sign in with (google|github)/i }).first(),
+    ).toBeVisible()
+
+    // #637 guard: no uncaught error (the prod bug surfaced as `JSON.parse`).
+    const errs = pageErrors()
+    expect(
+      errs.filter((m) => /json|parse|unexpected token/i.test(m)),
+      `unexpected JSON/parse page errors on /login: ${errs.join(' | ')}`,
+    ).toHaveLength(0)
+  })
+
+  test('runtime-config.js is a real asset, never SPA HTML masquerading as 200', async ({
+    request,
+  }) => {
+    const res = await request.get('/runtime-config.js')
+    const status = res.status()
+    const body = await res.text()
+
+    // The regression we guard: a 200 whose body is the SPA index.html — the
+    // app then tries to execute/parse HTML as a config script. A legitimate
+    // 404 (asset simply not deployed for this build) is acceptable; a
+    // 200-with-HTML is not.
+    expect(
+      !(status === 200 && looksLikeHtml(body)),
+      `runtime-config.js returned 200 with SPA HTML (the prod-login regression). First bytes: ${body
+        .trimStart()
+        .slice(0, 80)}`,
+    ).toBeTruthy()
+  })
+})

--- a/frontend/tests/stg-smoke/smoke.auth.spec.ts
+++ b/frontend/tests/stg-smoke/smoke.auth.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Authenticated smoke — protected routes + API status against the live env (#968).
+ *
+ * Runs with the storage-state seeded by `auth.setup.ts` (JWT in localStorage),
+ * so `ProtectedRoute` sees an authenticated user and does NOT bounce to /login.
+ * Self-skips when stg creds are absent (see requireAuth()).
+ *
+ * Asserts the load-bearing invariants the P4W2 live sweep found broken:
+ *   - key pages (home, narrators, hadiths) render their shell, not a redirect
+ *   - the graph explorer mounts its canvas surface
+ *   - `/api/v1/search` returns 200 for a representative query (not 500/422)
+ */
+import { test, expect } from '@playwright/test'
+import { requireAuth } from './helpers'
+
+test.describe('authenticated smoke: protected pages', () => {
+  test.beforeEach(() => requireAuth())
+
+  test('home does not redirect to /login (auth session is live)', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' })
+    await expect(page).not.toHaveURL(/\/login/)
+    // Main app chrome renders for an authenticated user.
+    await expect(page.getByRole('navigation').first()).toBeVisible()
+  })
+
+  test('narrators page renders its heading', async ({ page }) => {
+    await page.goto('/narrators', { waitUntil: 'networkidle' })
+    await expect(page).not.toHaveURL(/\/login/)
+    await expect(page.getByRole('heading', { name: 'Narrators' })).toBeVisible()
+  })
+
+  test('hadiths page renders its heading', async ({ page }) => {
+    await page.goto('/hadiths', { waitUntil: 'networkidle' })
+    await expect(page).not.toHaveURL(/\/login/)
+    await expect(page.getByRole('heading', { name: 'Hadiths' })).toBeVisible()
+  })
+
+  test('graph explorer mounts its canvas surface', async ({ page }) => {
+    await page.goto('/graph', { waitUntil: 'networkidle' })
+    await expect(page).not.toHaveURL(/\/login/)
+    // The explorer shell is present regardless of how much data staging holds:
+    // the narrator search input + the graph canvas region both render.
+    await expect(page.getByPlaceholder('Search narrator...')).toBeVisible()
+    await expect(
+      page.getByRole('img', { name: 'Narrator transmission network graph' }),
+    ).toBeVisible()
+  })
+})
+
+test.describe('authenticated smoke: search API status', () => {
+  test.beforeEach(() => requireAuth())
+
+  test('/api/v1/search returns 200 (not 500/422) for a representative query', async ({ page }) => {
+    // Pull the JWT the setup project seeded so the API call is authenticated;
+    // page.request shares the browser context (cookies) but not localStorage.
+    await page.goto('/', { waitUntil: 'commit' })
+    const token = await page.evaluate(() => localStorage.getItem('access_token'))
+    expect(token, 'no access_token in storage-state — auth setup did not seed it').toBeTruthy()
+
+    const res = await page.request.get('/api/v1/search?q=iman&limit=5', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(
+      res.status(),
+      `search returned ${res.status()} — body: ${(await res.text()).slice(0, 200)}`,
+    ).toBe(200)
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
-    exclude: ["tests/e2e/**", "node_modules/**"],
+    exclude: ["tests/e2e/**", "tests/stg-smoke/**", "node_modules/**"],
   },
 })


### PR DESCRIPTION
Closes #968

Stands up a Playwright **browser-automation smoke harness** that drives the **real deployed environment** (staging by default; prod in read-only/smoke-only mode) and authenticates against the **live user-service**. This is the prerequisite for the exploratory-sweep epic (#969).

> Deliberately **separate** from the mock-based `tests/e2e/` suite (local `vite preview`, all API mocked, wired through the default `playwright.config.ts`). This harness has its own `playwright.stg.config.ts` and never touches the local-mock suite or its (currently disabled, #812) CI job.

## Harness structure
`frontend/tests/stg-smoke/`
| File | Purpose |
|------|---------|
| `env.ts` | Resolves target URLs + creds from env; exposes `hasAuthCreds`, `STORAGE_STATE`. |
| `auth.setup.ts` | **Setup project**: programmatic `POST {USER_SERVICE_URL}/auth/login/email` → JWT seeded into `localStorage.access_token` via persisted **storage-state**, reused across specs (matches how the real `LoginPage` stores the token + how `api/client.ts` reads it). |
| `helpers.ts` | `requireAuth()` skip-guard, `looksLikeHtml`, page-error collector. |
| `login.public.spec.ts` | Public leg — needs no creds. |
| `smoke.auth.spec.ts` | Authenticated leg — self-skips without creds. |

`frontend/playwright.stg.config.ts` — three projects: `setup`, `smoke-public` (always runs), `smoke-auth` (`dependencies: [setup]`, reuses storage-state).

## How auth / secrets are gated
- Creds come from `STG_TEST_EMAIL` / `STG_TEST_PASSWORD` (**secrets only, never hardcoded**). URLs default to the stg/prod vhosts and are overridable via repo vars.
- **No creds present** → `auth.setup.ts` writes an empty storage-state (so the dependent project still loads) and skips; every `*.auth.spec.ts` self-skips via `requireAuth()`. So the suite is **green without secrets**, and runs the real authenticated leg wherever creds are provisioned — same skip-guard idiom as the repo's other infra-gated tests.

## Smoke coverage (the P4W2 live-sweep invariants)
- **Public:** `/login` renders providers + email form **without a `JSON.parse` crash** (guards main#637); `/runtime-config.js` must **not** be SPA HTML masquerading as a 200 script (guards `feedback_prod_frontend_runtime_config_lag`; isnad serves it as `application/javascript` via nginx exact-match, ig#949).
- **Authenticated:** home / narrators / hadiths render their shell (no `/login` bounce, proving the session is live); graph explorer mounts its canvas surface; `/api/v1/search` returns **200 (not 500/422)** for a representative query.

## CI
`.github/workflows/e2e-stg-smoke.yml` — `workflow_dispatch` (with `target_env` input) **+ daily schedule**, **never `pull_request`** → a PR lacking secrets is never broken by it. Publishes the HTML report always; traces + screenshots on failure.

## Test Plan
- [x] `--list` → 8 tests across 3 projects.
- [x] Credential-less `setup`+`smoke-auth` run → 6 skipped, **no network**.
- [x] `login.public` "renders without JSON.parse" → **passes** against a real local build.
- [x] `runtime-config` guard → **fails** on a 200-HTML response (proves it has teeth); passes where the asset is served as JS.
- [ ] Full green against stg with provisioned `STG_TEST_EMAIL`/`PASSWORD` secrets — **runtime acceptance** (reachable only from CI / the cluster, not the sandbox; verify on first scheduled/dispatch run).

Reviewers: @Linh Pham (primary), @Anya Kowalczyk (secondary).
