### PR TITLE
feat(frontend): i18n — toggleable UI language, 6 locales (#703)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,9 +18,11 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
+        "i18next": "^24.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-force-graph-2d": "^1.29.1",
+        "react-i18next": "^15.4.0",
         "react-router-dom": "^7.13.2",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2"
@@ -366,7 +368,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5399,6 +5400,15 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -5411,6 +5421,37 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -6511,6 +6552,32 @@
         "react": "*"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.4.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7089,7 +7156,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7392,6 +7459,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,9 +24,11 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
+    "i18next": "^24.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-force-graph-2d": "^1.29.1",
+    "react-i18next": "^15.4.0",
     "react-router-dom": "^7.13.2",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2"

--- a/frontend/src/components/LanguageToggle.tsx
+++ b/frontend/src/components/LanguageToggle.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useLocale } from '../i18n/useLocale'
+import type { LocaleCode } from '../i18n/config'
+
+/**
+ * Language switcher for the UI chrome. A globe button opens a dropdown of the
+ * supported locales (shown by their native name); selecting one switches the UI
+ * language instantly — persistence and RTL `dir` flipping are handled by the i18n
+ * bootstrap. Scope is UI chrome only; scholarly API data is never translated.
+ */
+export default function LanguageToggle() {
+  const { t } = useTranslation()
+  const { locale, locales, setLocale } = useLocale()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open])
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open])
+
+  function choose(code: LocaleCode) {
+    setLocale(code)
+    setOpen(false)
+  }
+
+  return (
+    <div ref={menuRef} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="theme-toggle"
+        aria-label={t('language.select')}
+        title={t('language.label')}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        {/* Globe icon — matches the inline-SVG style of ThemeToggle. */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="2" y1="12" x2="22" y2="12" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label={t('language.label')}
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + var(--spacing-2))',
+            insetInlineEnd: 0,
+            minWidth: 180,
+            background: 'var(--color-card)',
+            border: 'var(--border-width-thin) solid var(--color-border)',
+            borderRadius: 'var(--radius-lg)',
+            boxShadow: 'var(--shadow-lg)',
+            zIndex: 50,
+            overflow: 'hidden',
+            padding: 'var(--spacing-1)',
+          }}
+        >
+          {locales.map((l) => {
+            const active = l.code === locale
+            return (
+              <button
+                key={l.code}
+                role="menuitemradio"
+                aria-checked={active}
+                lang={l.code}
+                dir={l.dir}
+                onClick={() => choose(l.code)}
+                style={{
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 'var(--spacing-3)',
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  background: active ? 'var(--color-accent)' : 'none',
+                  border: 'none',
+                  borderRadius: 'var(--radius-md)',
+                  cursor: 'pointer',
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 'var(--text-sm)',
+                  fontWeight: active ? 600 : 400,
+                  color: active ? 'var(--color-primary)' : 'var(--color-foreground)',
+                  textAlign: 'start',
+                }}
+              >
+                {l.nativeName}
+                {active && (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,10 +1,13 @@
 import { Link, Outlet } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import Sidebar from './Sidebar'
 import TrialBanner from './TrialBanner'
 import UserMenu from './UserMenu'
+import LanguageToggle from './LanguageToggle'
 import { PageHeaderAccent } from '@noorinalabs/design-system'
 
 export default function Layout() {
+  const { t } = useTranslation()
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <TrialBanner />
@@ -69,8 +72,9 @@ export default function Layout() {
           </Link>
         </div>
         <span className="small-muted" style={{ fontFamily: 'var(--font-heading)' }}>
-          Hadith Analysis Platform
+          {t('common.platformTagline')}
         </span>
+        <LanguageToggle />
         <UserMenu />
       </header>
       <div style={{ display: 'flex', flex: 1 }}>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../hooks/useAuth'
 import {
   NarratorsIcon,
@@ -13,22 +14,25 @@ import {
   GeometricBorder,
 } from '@noorinalabs/design-system'
 
+// `labelKey` indexes into the `nav.*` translation namespace; resolved at render
+// time so the sidebar re-labels live when the UI language changes.
 const navItems = [
-  { to: '/narrators', label: 'Narrators', Icon: NarratorsIcon },
-  { to: '/hadiths', label: 'Hadiths', Icon: HadithsIcon },
-  { to: '/collections', label: 'Collections', Icon: CollectionsIcon },
-  { to: '/search', label: 'Search', Icon: SearchIcon },
-  { to: '/timeline', label: 'Timeline', Icon: TimelineIcon },
-  { to: '/compare', label: 'Compare', Icon: CompareIcon },
-  { to: '/graph', label: 'Graph Explorer', Icon: GraphExplorerIcon },
-]
+  { to: '/narrators', labelKey: 'nav.narrators', Icon: NarratorsIcon },
+  { to: '/hadiths', labelKey: 'nav.hadiths', Icon: HadithsIcon },
+  { to: '/collections', labelKey: 'nav.collections', Icon: CollectionsIcon },
+  { to: '/search', labelKey: 'nav.search', Icon: SearchIcon },
+  { to: '/timeline', labelKey: 'nav.timeline', Icon: TimelineIcon },
+  { to: '/compare', labelKey: 'nav.compare', Icon: CompareIcon },
+  { to: '/graph', labelKey: 'nav.graphExplorer', Icon: GraphExplorerIcon },
+] as const
 
 export default function Sidebar() {
+  const { t } = useTranslation()
   const { user, isAdmin, signOut } = useAuth()
 
   return (
     <nav
-      aria-label="Main navigation"
+      aria-label={t('nav.ariaLabel')}
       style={{
         width: 240,
         padding: 'var(--spacing-4)',
@@ -62,7 +66,7 @@ export default function Sidebar() {
               })}
             >
               <item.Icon size={16} style={{ flexShrink: 0, opacity: 0.7 }} />
-              {item.label}
+              {t(item.labelKey)}
             </NavLink>
           </li>
         ))}
@@ -94,7 +98,7 @@ export default function Sidebar() {
               })}
             >
               <AdminIcon size={16} style={{ flexShrink: 0, opacity: 0.7 }} />
-              Admin Dashboard
+              {t('nav.adminDashboard')}
             </NavLink>
           </li>
         )}
@@ -144,7 +148,7 @@ export default function Sidebar() {
             }}
           >
             <SignOutIcon size={16} />
-            Sign out
+            {t('nav.signOut')}
           </button>
         </div>
       )}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../hooks/useAuth'
 import { useSubscription } from '../hooks/useSubscription'
 import { useTheme } from '../hooks/useTheme'
@@ -16,6 +17,7 @@ function providerLabel(provider: string): string {
 }
 
 export default function UserMenu() {
+  const { t } = useTranslation()
   const { user, logout, signOutAll, role } = useAuth()
   const { isTrial, daysRemaining, subscription } = useSubscription()
   const { resolvedTheme, toggle } = useTheme()
@@ -60,7 +62,7 @@ export default function UserMenu() {
     <div ref={menuRef} style={{ position: 'relative' }}>
       <button
         onClick={() => setOpen((prev) => !prev)}
-        aria-label="User menu"
+        aria-label={t('userMenu.openMenu')}
         aria-expanded={open}
         aria-haspopup="true"
         style={{
@@ -88,7 +90,7 @@ export default function UserMenu() {
           style={{
             position: 'absolute',
             top: 'calc(100% + var(--spacing-2))',
-            right: 0,
+            insetInlineEnd: 0,
             minWidth: 240,
             background: 'var(--color-card)',
             border: 'var(--border-width-thin) solid var(--color-border)',
@@ -139,13 +141,13 @@ export default function UserMenu() {
           {/* My Profile */}
           <button role="menuitem" onClick={() => { setOpen(false); navigate('/profile') }} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 'var(--spacing-3)', padding: 'var(--spacing-3) var(--spacing-4)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-sm)', color: 'var(--color-foreground)', textAlign: 'left', borderBottom: 'var(--border-width-thin) solid var(--color-border)' }}>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></svg>
-            My Profile
+            {t('userMenu.myProfile')}
           </button>
 
           {/* Preferences */}
           <button role="menuitem" onClick={() => { setOpen(false); navigate('/profile') }} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 'var(--spacing-3)', padding: 'var(--spacing-3) var(--spacing-4)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-sm)', color: 'var(--color-foreground)', textAlign: 'left', borderBottom: 'var(--border-width-thin) solid var(--color-border)' }}>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
-            Preferences
+            {t('userMenu.preferences')}
           </button>
 
           {/* Subscription info */}
@@ -162,12 +164,15 @@ export default function UserMenu() {
               <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>
                 {isTrial ? (
                   <span>
-                    Trial: <strong style={{ color: daysRemaining <= 2 ? 'var(--color-destructive)' : 'var(--color-foreground)' }}>
-                      {daysRemaining} day{daysRemaining !== 1 ? 's' : ''} left
+                    {t('userMenu.trialLabel')}{' '}
+                    <strong style={{ color: daysRemaining <= 2 ? 'var(--color-destructive)' : 'var(--color-foreground)' }}>
+                      {t('userMenu.daysLeft', { count: daysRemaining })}
                     </strong>
                   </span>
                 ) : (
-                  <span style={{ textTransform: 'capitalize' }}>{subscription.tier} plan</span>
+                  <span style={{ textTransform: 'capitalize' }}>
+                    {t('userMenu.planSuffix', { tier: subscription.tier })}
+                  </span>
                 )}
               </div>
               <Link
@@ -180,7 +185,7 @@ export default function UserMenu() {
                   textDecoration: 'none',
                 }}
               >
-                {isTrial ? 'Upgrade' : 'Plans'}
+                {isTrial ? t('userMenu.upgrade') : t('userMenu.plans')}
               </Link>
             </div>
           )}
@@ -224,7 +229,7 @@ export default function UserMenu() {
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
               </svg>
             )}
-            Switch to {resolvedTheme === 'dark' ? 'light' : 'dark'} mode
+            {resolvedTheme === 'dark' ? t('userMenu.switchToLight') : t('userMenu.switchToDark')}
           </button>
 
           {/* Sign out */}
@@ -255,7 +260,7 @@ export default function UserMenu() {
               <polyline points="16 17 21 12 16 7" />
               <line x1="21" y1="12" x2="9" y2="12" />
             </svg>
-            Sign out
+            {t('userMenu.signOut')}
           </button>
 
           {/* Sign out everywhere */}
@@ -287,7 +292,7 @@ export default function UserMenu() {
               <line x1="16" y1="4" x2="16" y2="8" />
               <line x1="14" y1="6" x2="18" y2="6" />
             </svg>
-            Sign out everywhere
+            {t('userMenu.signOutEverywhere')}
           </button>
         </div>
       )}

--- a/frontend/src/components/__tests__/LanguageToggle.test.tsx
+++ b/frontend/src/components/__tests__/LanguageToggle.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, it, expect } from 'vitest'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import LanguageToggle from '../LanguageToggle'
+import i18n from '../../i18n'
+import { STORAGE_KEY } from '../../i18n/config'
+
+afterEach(async () => {
+  await act(async () => {
+    await i18n.changeLanguage('en')
+  })
+  localStorage.clear()
+})
+
+describe('LanguageToggle', () => {
+  it('opens the menu and lists all seven locales by native name', async () => {
+    const user = userEvent.setup()
+    render(<LanguageToggle />)
+
+    await user.click(screen.getByRole('button', { name: /select language/i }))
+
+    const menu = screen.getByRole('menu')
+    const items = within(menu).getAllByRole('menuitemradio')
+    expect(items).toHaveLength(7)
+    expect(within(menu).getByText('العربية')).toBeInTheDocument()
+    expect(within(menu).getByText('Türkçe')).toBeInTheDocument()
+    expect(within(menu).getByText('English')).toBeInTheDocument()
+  })
+
+  it('switches the active locale and flips document dir for RTL', async () => {
+    const user = userEvent.setup()
+    render(<LanguageToggle />)
+
+    await user.click(screen.getByRole('button', { name: /select language/i }))
+    await user.click(screen.getByRole('menuitemradio', { name: /العربية/ }))
+
+    await waitFor(() => expect(i18n.language).toBe('ar'))
+    expect(document.documentElement.getAttribute('dir')).toBe('rtl')
+    expect(document.documentElement.getAttribute('lang')).toBe('ar')
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('ar')
+
+    // Menu closes after selecting.
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('returns to LTR when switching back to an LTR locale', async () => {
+    const user = userEvent.setup()
+    render(<LanguageToggle />)
+
+    await i18n.changeLanguage('ar')
+    expect(document.documentElement.getAttribute('dir')).toBe('rtl')
+
+    await user.click(screen.getByRole('button', { name: /select language/i }))
+    await user.click(screen.getByRole('menuitemradio', { name: /Türkçe/ }))
+
+    await waitFor(() => expect(i18n.language).toBe('tr'))
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr')
+  })
+
+  it('marks the active locale as checked', async () => {
+    const user = userEvent.setup()
+    render(<LanguageToggle />)
+
+    await user.click(screen.getByRole('button', { name: /select language/i }))
+    const english = screen.getByRole('menuitemradio', { name: /English/ })
+    expect(english).toHaveAttribute('aria-checked', 'true')
+  })
+})

--- a/frontend/src/i18n/__tests__/locales.test.ts
+++ b/frontend/src/i18n/__tests__/locales.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+
+import { DEFAULT_LOCALE, LOCALES, getLocaleDir, isSupportedLocale } from '../config'
+import ar from '../locales/ar.json'
+import bs from '../locales/bs.json'
+import en from '../locales/en.json'
+import id from '../locales/id.json'
+import ms from '../locales/ms.json'
+import tr from '../locales/tr.json'
+import ur from '../locales/ur.json'
+
+const BUNDLES: Record<string, unknown> = { en, tr, id, ms, ar, bs, ur }
+
+// CLDR plural-category suffixes appended to a base key by i18next. Two locales
+// can legitimately differ in which of these exist, so parity is checked on the
+// suffix-stripped base key.
+const PLURAL_SUFFIX = /_(zero|one|two|few|many|other)$/
+
+function flattenKeys(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix]
+  return Object.entries(obj as Record<string, unknown>).flatMap(([k, v]) =>
+    flattenKeys(v, prefix ? `${prefix}.${k}` : k),
+  )
+}
+
+function baseKeySet(bundle: unknown): Set<string> {
+  return new Set(flattenKeys(bundle).map((k) => k.replace(PLURAL_SUFFIX, '')))
+}
+
+describe('locale bundles', () => {
+  const enKeys = baseKeySet(en)
+
+  it('ships a bundle for every configured locale', () => {
+    for (const { code } of LOCALES) {
+      expect(BUNDLES[code], `missing bundle for ${code}`).toBeDefined()
+    }
+  })
+
+  it.each(LOCALES.map((l) => l.code))('locale %s has the same base keys as English', (code) => {
+    const keys = baseKeySet(BUNDLES[code])
+    const missing = [...enKeys].filter((k) => !keys.has(k))
+    const extra = [...keys].filter((k) => !enKeys.has(k))
+    expect({ code, missing, extra }).toEqual({ code, missing: [], extra: [] })
+  })
+
+  it.each(LOCALES.map((l) => l.code))('locale %s has no empty strings', (code) => {
+    const empties = flattenKeys(BUNDLES[code]).filter((path) => {
+      const value = path
+        .split('.')
+        .reduce<unknown>((acc, part) => (acc as Record<string, unknown>)?.[part], BUNDLES[code])
+      return typeof value === 'string' && value.trim() === ''
+    })
+    expect(empties).toEqual([])
+  })
+})
+
+describe('locale config', () => {
+  it('includes exactly the six toggleable locales plus English', () => {
+    expect(LOCALES.map((l) => l.code).sort()).toEqual(['ar', 'bs', 'en', 'id', 'ms', 'tr', 'ur'])
+  })
+
+  it('uses unique locale codes', () => {
+    const codes = LOCALES.map((l) => l.code)
+    expect(new Set(codes).size).toBe(codes.length)
+  })
+
+  it('marks Arabic and Urdu as RTL and the rest as LTR', () => {
+    const rtl = LOCALES.filter((l) => l.dir === 'rtl').map((l) => l.code)
+    expect(rtl.sort()).toEqual(['ar', 'ur'])
+  })
+
+  it('defaults to English (LTR)', () => {
+    expect(DEFAULT_LOCALE).toBe('en')
+    expect(getLocaleDir(DEFAULT_LOCALE)).toBe('ltr')
+  })
+
+  it('getLocaleDir falls back to ltr for unknown codes', () => {
+    expect(getLocaleDir('xx')).toBe('ltr')
+  })
+
+  it('isSupportedLocale narrows known codes only', () => {
+    expect(isSupportedLocale('ar')).toBe(true)
+    expect(isSupportedLocale('xx')).toBe(false)
+    expect(isSupportedLocale(null)).toBe(false)
+  })
+})

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,59 @@
+// i18n locale configuration — the single source of truth for which UI languages
+// are supported, how they render, and how the preference is persisted.
+//
+// SCOPE: this powers translation of UI chrome only (navigation, buttons, labels,
+// error pages). Scholarly source data (hadith text, narrator names, collection
+// names) comes from the API and is rendered as-is — it is never routed through
+// i18next. See issue #703.
+
+export type Direction = 'ltr' | 'rtl'
+
+export interface LocaleMeta {
+  /** BCP-47 / ISO-639-1 code used as the i18next language key. */
+  code: string
+  /** English name of the language (for documentation / fallback labels). */
+  name: string
+  /** Native endonym shown in the language switcher. */
+  nativeName: string
+  /** Text direction — drives the `dir` attribute on <html> for RTL locales. */
+  dir: Direction
+}
+
+/**
+ * Supported UI locales. English is the default + fallback; the other six are the
+ * toggleable locales requested in #703. Arabic and Urdu are right-to-left.
+ */
+export const LOCALES: readonly LocaleMeta[] = [
+  { code: 'en', name: 'English', nativeName: 'English', dir: 'ltr' },
+  { code: 'tr', name: 'Turkish', nativeName: 'Türkçe', dir: 'ltr' },
+  { code: 'id', name: 'Indonesian', nativeName: 'Bahasa Indonesia', dir: 'ltr' },
+  { code: 'ms', name: 'Malay', nativeName: 'Bahasa Melayu', dir: 'ltr' },
+  { code: 'ar', name: 'Arabic', nativeName: 'العربية', dir: 'rtl' },
+  { code: 'bs', name: 'Bosnian', nativeName: 'Bosanski', dir: 'ltr' },
+  { code: 'ur', name: 'Urdu', nativeName: 'اردو', dir: 'rtl' },
+] as const
+
+export type LocaleCode = (typeof LOCALES)[number]['code']
+
+/** Default + fallback locale. */
+export const DEFAULT_LOCALE: LocaleCode = 'en'
+
+/** localStorage key holding the persisted locale preference. */
+export const STORAGE_KEY = 'isnad-graph-locale'
+
+const LOCALE_BY_CODE = new Map(LOCALES.map((l) => [l.code, l]))
+
+/** Type guard: is the given string one of our supported locale codes? */
+export function isSupportedLocale(code: string | null | undefined): code is LocaleCode {
+  return typeof code === 'string' && LOCALE_BY_CODE.has(code)
+}
+
+/** Text direction for a locale code; falls back to `ltr` for unknown codes. */
+export function getLocaleDir(code: string): Direction {
+  return LOCALE_BY_CODE.get(code)?.dir ?? 'ltr'
+}
+
+/** Metadata for a locale code, or `undefined` if unsupported. */
+export function getLocaleMeta(code: string): LocaleMeta | undefined {
+  return LOCALE_BY_CODE.get(code)
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,87 @@
+// i18next bootstrap for the UI. Imported once from `main.tsx` (and from the test
+// setup) so the singleton is initialised before any component renders.
+//
+// Resources are bundled statically (no async backend) — the translation set is
+// small UI-chrome only, so eager-loading all locales keeps the language switch
+// instantaneous and avoids a loading flash. See issue #703.
+
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import {
+  DEFAULT_LOCALE,
+  LOCALES,
+  STORAGE_KEY,
+  getLocaleDir,
+  isSupportedLocale,
+} from './config'
+import ar from './locales/ar.json'
+import bs from './locales/bs.json'
+import en from './locales/en.json'
+import id from './locales/id.json'
+import ms from './locales/ms.json'
+import tr from './locales/tr.json'
+import ur from './locales/ur.json'
+
+const resources = {
+  en: { translation: en },
+  tr: { translation: tr },
+  id: { translation: id },
+  ms: { translation: ms },
+  ar: { translation: ar },
+  bs: { translation: bs },
+  ur: { translation: ur },
+}
+
+/** Read the persisted locale, falling back to the default. */
+function detectInitialLocale(): string {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (isSupportedLocale(stored)) return stored
+  } catch {
+    // localStorage can throw in private-mode / SSR — fall through to default.
+  }
+  return DEFAULT_LOCALE
+}
+
+/**
+ * Reflect the active locale onto the document root: the `lang` attribute for
+ * accessibility/SEO and the `dir` attribute so the whole layout mirrors for RTL
+ * locales (Arabic, Urdu). Safe to call when `document` is undefined.
+ */
+export function applyDocumentLocale(locale: string): void {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+  root.setAttribute('lang', locale)
+  root.setAttribute('dir', getLocaleDir(locale))
+}
+
+const initialLocale = detectInitialLocale()
+
+void i18n.use(initReactI18next).init({
+  resources,
+  lng: initialLocale,
+  fallbackLng: DEFAULT_LOCALE,
+  supportedLngs: LOCALES.map((l) => l.code),
+  // Keys are namespaced via dot-paths inside a single `translation` namespace.
+  interpolation: {
+    escapeValue: false, // React already escapes interpolated values.
+  },
+  returnNull: false,
+})
+
+// Keep the document direction/lang and the persisted preference in sync whenever
+// the language changes at runtime.
+i18n.on('languageChanged', (lng) => {
+  applyDocumentLocale(lng)
+  try {
+    localStorage.setItem(STORAGE_KEY, lng)
+  } catch {
+    // Persisting is best-effort; ignore storage failures.
+  }
+})
+
+// Apply once for the initial render (the event above only fires on changes).
+applyDocumentLocale(initialLocale)
+
+export default i18n

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -1,0 +1,45 @@
+{
+  "common": {
+    "platformTagline": "منصة تحليل الحديث",
+    "returnHome": "العودة إلى الصفحة الرئيسية",
+    "loading": "جارٍ التحميل…"
+  },
+  "nav": {
+    "ariaLabel": "التنقل الرئيسي",
+    "narrators": "الرواة",
+    "hadiths": "الأحاديث",
+    "collections": "المجموعات",
+    "search": "بحث",
+    "timeline": "الخط الزمني",
+    "compare": "مقارنة",
+    "graphExplorer": "مستكشف الرسم البياني",
+    "adminDashboard": "لوحة تحكم المشرف",
+    "signOut": "تسجيل الخروج"
+  },
+  "userMenu": {
+    "openMenu": "قائمة المستخدم",
+    "myProfile": "ملفي الشخصي",
+    "preferences": "التفضيلات",
+    "switchToLight": "التبديل إلى الوضع الفاتح",
+    "switchToDark": "التبديل إلى الوضع الداكن",
+    "signOut": "تسجيل الخروج",
+    "signOutEverywhere": "تسجيل الخروج من جميع الأجهزة",
+    "upgrade": "ترقية",
+    "plans": "الخطط",
+    "trialLabel": "تجربة:",
+    "daysLeft_one": "بقي يوم واحد",
+    "daysLeft_two": "بقي يومان",
+    "daysLeft_few": "بقيت {{count}} أيام",
+    "daysLeft_many": "بقي {{count}} يومًا",
+    "daysLeft_other": "بقي {{count}} يوم",
+    "planSuffix": "خطة {{tier}}"
+  },
+  "language": {
+    "label": "اللغة",
+    "select": "اختر اللغة"
+  },
+  "errors": {
+    "notFoundTitle": "الصفحة غير موجودة",
+    "notFoundBody": "الصفحة التي تبحث عنها غير موجودة أو تم نقلها."
+  }
+}

--- a/frontend/src/i18n/locales/bs.json
+++ b/frontend/src/i18n/locales/bs.json
@@ -1,0 +1,43 @@
+{
+  "common": {
+    "platformTagline": "Platforma za analizu hadisa",
+    "returnHome": "Povratak na početnu",
+    "loading": "Učitavanje…"
+  },
+  "nav": {
+    "ariaLabel": "Glavna navigacija",
+    "narrators": "Prenosioci",
+    "hadiths": "Hadisi",
+    "collections": "Zbirke",
+    "search": "Pretraga",
+    "timeline": "Vremenska linija",
+    "compare": "Uporedi",
+    "graphExplorer": "Istraživač grafa",
+    "adminDashboard": "Administratorska ploča",
+    "signOut": "Odjava"
+  },
+  "userMenu": {
+    "openMenu": "Korisnički meni",
+    "myProfile": "Moj profil",
+    "preferences": "Postavke",
+    "switchToLight": "Pređi na svijetli način",
+    "switchToDark": "Pređi na tamni način",
+    "signOut": "Odjava",
+    "signOutEverywhere": "Odjavi se sa svih uređaja",
+    "upgrade": "Nadogradi",
+    "plans": "Planovi",
+    "trialLabel": "Probni period:",
+    "daysLeft_one": "Preostao {{count}} dan",
+    "daysLeft_few": "Preostala {{count}} dana",
+    "daysLeft_other": "Preostalo {{count}} dana",
+    "planSuffix": "{{tier}} plan"
+  },
+  "language": {
+    "label": "Jezik",
+    "select": "Odaberi jezik"
+  },
+  "errors": {
+    "notFoundTitle": "Stranica nije pronađena",
+    "notFoundBody": "Stranica koju tražite ne postoji ili je premještena."
+  }
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,0 +1,42 @@
+{
+  "common": {
+    "platformTagline": "Hadith Analysis Platform",
+    "returnHome": "Return home",
+    "loading": "Loading…"
+  },
+  "nav": {
+    "ariaLabel": "Main navigation",
+    "narrators": "Narrators",
+    "hadiths": "Hadiths",
+    "collections": "Collections",
+    "search": "Search",
+    "timeline": "Timeline",
+    "compare": "Compare",
+    "graphExplorer": "Graph Explorer",
+    "adminDashboard": "Admin Dashboard",
+    "signOut": "Sign out"
+  },
+  "userMenu": {
+    "openMenu": "User menu",
+    "myProfile": "My Profile",
+    "preferences": "Preferences",
+    "switchToLight": "Switch to light mode",
+    "switchToDark": "Switch to dark mode",
+    "signOut": "Sign out",
+    "signOutEverywhere": "Sign out everywhere",
+    "upgrade": "Upgrade",
+    "plans": "Plans",
+    "trialLabel": "Trial:",
+    "daysLeft_one": "{{count}} day left",
+    "daysLeft_other": "{{count}} days left",
+    "planSuffix": "{{tier}} plan"
+  },
+  "language": {
+    "label": "Language",
+    "select": "Select language"
+  },
+  "errors": {
+    "notFoundTitle": "Page not found",
+    "notFoundBody": "The page you are looking for does not exist or has been moved."
+  }
+}

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -1,0 +1,42 @@
+{
+  "common": {
+    "platformTagline": "Platform Analisis Hadis",
+    "returnHome": "Kembali ke beranda",
+    "loading": "Memuat…"
+  },
+  "nav": {
+    "ariaLabel": "Navigasi utama",
+    "narrators": "Perawi",
+    "hadiths": "Hadis",
+    "collections": "Koleksi",
+    "search": "Cari",
+    "timeline": "Lini Masa",
+    "compare": "Bandingkan",
+    "graphExplorer": "Penjelajah Grafik",
+    "adminDashboard": "Dasbor Admin",
+    "signOut": "Keluar"
+  },
+  "userMenu": {
+    "openMenu": "Menu pengguna",
+    "myProfile": "Profil Saya",
+    "preferences": "Preferensi",
+    "switchToLight": "Beralih ke mode terang",
+    "switchToDark": "Beralih ke mode gelap",
+    "signOut": "Keluar",
+    "signOutEverywhere": "Keluar dari semua perangkat",
+    "upgrade": "Tingkatkan",
+    "plans": "Paket",
+    "trialLabel": "Uji coba:",
+    "daysLeft_one": "Sisa {{count}} hari",
+    "daysLeft_other": "Sisa {{count}} hari",
+    "planSuffix": "Paket {{tier}}"
+  },
+  "language": {
+    "label": "Bahasa",
+    "select": "Pilih bahasa"
+  },
+  "errors": {
+    "notFoundTitle": "Halaman tidak ditemukan",
+    "notFoundBody": "Halaman yang Anda cari tidak ada atau telah dipindahkan."
+  }
+}

--- a/frontend/src/i18n/locales/ms.json
+++ b/frontend/src/i18n/locales/ms.json
@@ -1,0 +1,42 @@
+{
+  "common": {
+    "platformTagline": "Platform Analisis Hadis",
+    "returnHome": "Kembali ke laman utama",
+    "loading": "Memuatkan…"
+  },
+  "nav": {
+    "ariaLabel": "Navigasi utama",
+    "narrators": "Perawi",
+    "hadiths": "Hadis",
+    "collections": "Koleksi",
+    "search": "Cari",
+    "timeline": "Garis Masa",
+    "compare": "Bandingkan",
+    "graphExplorer": "Penjelajah Graf",
+    "adminDashboard": "Papan Pemuka Admin",
+    "signOut": "Log keluar"
+  },
+  "userMenu": {
+    "openMenu": "Menu pengguna",
+    "myProfile": "Profil Saya",
+    "preferences": "Keutamaan",
+    "switchToLight": "Tukar ke mod terang",
+    "switchToDark": "Tukar ke mod gelap",
+    "signOut": "Log keluar",
+    "signOutEverywhere": "Log keluar dari semua peranti",
+    "upgrade": "Naik taraf",
+    "plans": "Pelan",
+    "trialLabel": "Percubaan:",
+    "daysLeft_one": "{{count}} hari lagi",
+    "daysLeft_other": "{{count}} hari lagi",
+    "planSuffix": "Pelan {{tier}}"
+  },
+  "language": {
+    "label": "Bahasa",
+    "select": "Pilih bahasa"
+  },
+  "errors": {
+    "notFoundTitle": "Halaman tidak dijumpai",
+    "notFoundBody": "Halaman yang anda cari tidak wujud atau telah dialihkan."
+  }
+}

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -1,0 +1,42 @@
+{
+  "common": {
+    "platformTagline": "Hadis Analiz Platformu",
+    "returnHome": "Ana sayfaya dön",
+    "loading": "Yükleniyor…"
+  },
+  "nav": {
+    "ariaLabel": "Ana gezinme",
+    "narrators": "Raviler",
+    "hadiths": "Hadisler",
+    "collections": "Koleksiyonlar",
+    "search": "Ara",
+    "timeline": "Zaman çizelgesi",
+    "compare": "Karşılaştır",
+    "graphExplorer": "Grafik Gezgini",
+    "adminDashboard": "Yönetim Paneli",
+    "signOut": "Çıkış yap"
+  },
+  "userMenu": {
+    "openMenu": "Kullanıcı menüsü",
+    "myProfile": "Profilim",
+    "preferences": "Tercihler",
+    "switchToLight": "Açık moda geç",
+    "switchToDark": "Koyu moda geç",
+    "signOut": "Çıkış yap",
+    "signOutEverywhere": "Her yerden çıkış yap",
+    "upgrade": "Yükselt",
+    "plans": "Planlar",
+    "trialLabel": "Deneme:",
+    "daysLeft_one": "{{count}} gün kaldı",
+    "daysLeft_other": "{{count}} gün kaldı",
+    "planSuffix": "{{tier}} planı"
+  },
+  "language": {
+    "label": "Dil",
+    "select": "Dil seçin"
+  },
+  "errors": {
+    "notFoundTitle": "Sayfa bulunamadı",
+    "notFoundBody": "Aradığınız sayfa mevcut değil veya taşınmış."
+  }
+}

--- a/frontend/src/i18n/locales/ur.json
+++ b/frontend/src/i18n/locales/ur.json
@@ -1,0 +1,42 @@
+{
+  "common": {
+    "platformTagline": "حدیث تجزیہ پلیٹ فارم",
+    "returnHome": "ہوم پیج پر واپس جائیں",
+    "loading": "لوڈ ہو رہا ہے…"
+  },
+  "nav": {
+    "ariaLabel": "مرکزی نیویگیشن",
+    "narrators": "راوی",
+    "hadiths": "احادیث",
+    "collections": "مجموعے",
+    "search": "تلاش",
+    "timeline": "ٹائم لائن",
+    "compare": "موازنہ",
+    "graphExplorer": "گراف ایکسپلورر",
+    "adminDashboard": "ایڈمن ڈیش بورڈ",
+    "signOut": "سائن آؤٹ"
+  },
+  "userMenu": {
+    "openMenu": "صارف مینو",
+    "myProfile": "میرا پروفائل",
+    "preferences": "ترجیحات",
+    "switchToLight": "لائٹ موڈ پر جائیں",
+    "switchToDark": "ڈارک موڈ پر جائیں",
+    "signOut": "سائن آؤٹ",
+    "signOutEverywhere": "تمام آلات سے سائن آؤٹ کریں",
+    "upgrade": "اپ گریڈ",
+    "plans": "پلانز",
+    "trialLabel": "آزمائش:",
+    "daysLeft_one": "{{count}} دن باقی",
+    "daysLeft_other": "{{count}} دن باقی",
+    "planSuffix": "{{tier}} پلان"
+  },
+  "language": {
+    "label": "زبان",
+    "select": "زبان منتخب کریں"
+  },
+  "errors": {
+    "notFoundTitle": "صفحہ نہیں ملا",
+    "notFoundBody": "آپ جس صفحے کو تلاش کر رہے ہیں وہ موجود نہیں ہے یا منتقل کر دیا گیا ہے۔"
+  }
+}

--- a/frontend/src/i18n/useLocale.ts
+++ b/frontend/src/i18n/useLocale.ts
@@ -1,0 +1,33 @@
+// Thin, typed wrapper over react-i18next for reading and switching the UI locale.
+// Components that only translate strings should use `useTranslation()` directly;
+// this hook is for the language switcher and anything that needs the locale list
+// or current direction.
+
+import { useTranslation } from 'react-i18next'
+
+import { DEFAULT_LOCALE, LOCALES, getLocaleDir, type Direction, type LocaleCode } from './config'
+
+export interface UseLocaleResult {
+  /** The active locale code (resolved through fallbacks). */
+  locale: LocaleCode
+  /** Text direction of the active locale. */
+  dir: Direction
+  /** All selectable locales, in display order. */
+  locales: typeof LOCALES
+  /** Switch the active locale; persistence + `dir` are handled by the i18n bootstrap. */
+  setLocale: (code: LocaleCode) => void
+}
+
+export function useLocale(): UseLocaleResult {
+  const { i18n } = useTranslation()
+  const active = (i18n.resolvedLanguage ?? i18n.language ?? DEFAULT_LOCALE) as LocaleCode
+
+  return {
+    locale: active,
+    dir: getLocaleDir(active),
+    locales: LOCALES,
+    setLocale: (code: LocaleCode) => {
+      void i18n.changeLanguage(code)
+    },
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './styles/theme.css'
 import './styles/common.css'
+import './i18n'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 
 export default function NotFoundPage() {
+  const { t } = useTranslation()
   return (
     <div className="error-page">
       {/* Disconnected graph node icon */}
@@ -20,12 +22,10 @@ export default function NotFoundPage() {
         </svg>
       </div>
       <div className="error-page-code">404</div>
-      <div className="error-page-title">Page not found</div>
-      <div className="error-page-body">
-        The page you are looking for does not exist or has been moved.
-      </div>
+      <div className="error-page-title">{t('errors.notFoundTitle')}</div>
+      <div className="error-page-body">{t('errors.notFoundBody')}</div>
       <Link to="/" className="btn-primary" style={{ textDecoration: 'none' }}>
-        Return home
+        {t('common.returnHome')}
       </Link>
     </div>
   )

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom/vitest"
+
+// Initialise the i18n singleton so components that call `useTranslation()`
+// resolve real strings under test instead of raw keys.
+import "../i18n"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
Closes #703

## Summary

Adds internationalization for the frontend **UI chrome** with a header language switcher. Built on **react-i18next** + **i18next** with statically-bundled JSON translation files.

**7 locales** (English default + the 6 requested):

| Code | Language | Dir | Status |
|------|----------|-----|--------|
| `en` | English | LTR | default / fallback |
| `tr` | Türkçe | LTR | fully translated |
| `id` | Bahasa Indonesia | LTR | fully translated |
| `ms` | Bahasa Melayu | LTR | fully translated |
| `ar` | العربية | **RTL** | fully translated (+ CLDR plural forms) |
| `bs` | Bosanski | LTR | fully translated (+ CLDR plural forms) |
| `ur` | اردو | **RTL** | fully translated |

All six are **real translations, not English stubs.**

## Scope (issue #703 / org policy `project_i18n_scope`)

**In scope — UI chrome only:** navigation labels, header tagline, user menu, error pages, the language switcher. Strings externalized in `Layout`, `Sidebar`, `UserMenu`, `NotFoundPage`.

**Untouched — source data:** hadith text, narrator names, collection names from the API are **never** routed through i18next. No backend changes.

## What's included

- **`src/i18n/`** — `config.ts` (single source of truth for supported locales + direction + storage key), `index.ts` (i18next bootstrap, persists preference to `localStorage`, reflects `lang`/`dir` onto `<html>`), `useLocale.ts` (typed hook).
- **`LanguageToggle`** — globe dropdown in the header; native-name list; `menuitemradio` a11y semantics; closes on outside-click / Escape; switches language with no page reload.
- **RTL** — Arabic + Urdu flip the whole layout via the `<html dir>` attribute. The chrome uses CSS **logical properties** (`borderInline*`, `insetInlineEnd`, `paddingInline`) so it mirrors automatically; `UserMenu` popup re-anchored from `right` → `insetInlineEnd`. Noto Naskh Arabic is already loaded in `index.html`.
- **Persistence** — locale stored under `isnad-graph-locale`, mirroring the existing theme pattern.

## Test Plan

- `npx tsc --noEmit` — clean.
- `npm run test` — **182 passed** (28 files), incl. 25 new assertions:
  - `src/i18n/__tests__/locales.test.ts` — key-parity across all 7 bundles (plural-suffix aware), no empty strings, config invariants (RTL flags, default locale, unique codes).
  - `src/components/__tests__/LanguageToggle.test.tsx` — opens menu / lists 7 locales, switches locale, **flips `dir` to rtl for Arabic and back to ltr**, persists to localStorage, marks active locale checked.
- `npm run lint` — 0 errors (11 pre-existing warnings, none in changed files).
- `npm run build` — succeeds.

## Caveats / follow-up

- Externalization covers the navigation/header chrome per the issue scope. Page-body strings on feature/admin pages (search filters, table headers, form labels) still hold inline English — they inherit RTL mirroring (logical props) but their text is a natural follow-up to extend into the same `nav`/`common`/etc. namespaces. Recommend a follow-up issue to sweep page bodies.
- Arabic/Urdu chrome text uses the system Arabic font fallback (Noto Naskh Arabic is preloaded); a dedicated RTL font-stack rule per design-system guidance is a possible polish item.

Reviewers: @Ravi Wickramasinghe (primary), @Anya Kowalczyk (secondary)
