### PR TITLE
feat: Browse Parallels spans both sects (intra + cross-sect) (#964)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -83,8 +83,13 @@ export async function fetchHadithParallels(id: string): Promise<ParallelsRespons
 export async function fetchParallelPairs(
   page = 1,
   limit = 20,
+  crossSect?: boolean,
 ): Promise<ParallelPairsResponse> {
-  return fetchJson(`${API_BASE}/parallels?page=${page}&limit=${limit}`)
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (crossSect !== undefined) {
+    params.set('cross_sect', String(crossSect))
+  }
+  return fetchJson(`${API_BASE}/parallels?${params.toString()}`)
 }
 
 export async function fetchCollections(

--- a/frontend/src/pages/ComparativePage.tsx
+++ b/frontend/src/pages/ComparativePage.tsx
@@ -149,13 +149,24 @@ function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
   )
 }
 
+type SectFilter = 'all' | 'cross' | 'intra'
+
+const SECT_FILTERS: { value: SectFilter; label: string; crossSect?: boolean }[] = [
+  { value: 'all', label: 'All parallels', crossSect: undefined },
+  { value: 'intra', label: 'Within a sect', crossSect: false },
+  { value: 'cross', label: 'Cross-sect', crossSect: true },
+]
+
 export default function ComparativePage() {
   const [page, setPage] = useState(1)
+  const [sectFilter, setSectFilter] = useState<SectFilter>('all')
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
 
   const compareA = searchParams.get('a') ?? ''
   const compareB = searchParams.get('b') ?? ''
+
+  const crossSect = SECT_FILTERS.find((f) => f.value === sectFilter)?.crossSect
 
   const setCompare = useCallback(
     (key: 'a' | 'b', value: string) => {
@@ -171,9 +182,14 @@ export default function ComparativePage() {
   )
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['parallel-pairs', page],
-    queryFn: () => fetchParallelPairs(page, 20),
+    queryKey: ['parallel-pairs', page, sectFilter],
+    queryFn: () => fetchParallelPairs(page, 20, crossSect),
   })
+
+  const selectSectFilter = useCallback((value: SectFilter) => {
+    setSectFilter(value)
+    setPage(1)
+  }, [])
 
   const totalPages = data ? Math.ceil(data.total / data.limit) : 0
   const hasParallels = data && data.items.length > 0
@@ -183,7 +199,8 @@ export default function ComparativePage() {
     <div>
       <h2 className="page-heading">Comparative Analysis</h2>
       <p className="muted-text" style={{ marginBottom: 'var(--spacing-4)' }}>
-        Compare hadith texts side by side and browse cross-sectarian parallel pairs.
+        Compare hadith texts side by side and browse parallel pairs — within each sect
+        (sunni-sunni, shia-shia) and across the Sunni and Shia corpora.
       </p>
 
       <Tabs defaultValue={hasComparison ? 'compare' : 'browse'}>
@@ -234,6 +251,20 @@ export default function ComparativePage() {
         </TabsContent>
 
         <TabsContent value="browse">
+          <div className="flex flex-wrap gap-2 mb-4" role="group" aria-label="Filter parallels by sect pairing">
+            {SECT_FILTERS.map((f) => (
+              <Button
+                key={f.value}
+                variant={sectFilter === f.value ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => selectSectFilter(f.value)}
+                aria-pressed={sectFilter === f.value}
+              >
+                {f.label}
+              </Button>
+            ))}
+          </div>
+
           {isLoading && (
             <div>
               {[1, 2, 3, 4, 5].map((i) => (
@@ -255,9 +286,10 @@ export default function ComparativePage() {
               </div>
               <h3 className="empty-state-heading">No parallel hadith pairs yet</h3>
               <p className="empty-state-body">
-                Cross-sectarian parallel hadith pairs will appear here once the deduplication
-                pipeline has identified matching texts across Sunni and Shia collections.
-                You can still compare individual hadiths using the Compare tab.
+                Parallel hadith pairs — both within a single sect (sunni-sunni, shia-shia)
+                and across the Sunni and Shia collections — will appear here once the
+                deduplication pipeline has identified matching texts. You can still compare
+                individual hadiths using the Compare tab.
               </p>
             </div>
           )}
@@ -271,7 +303,7 @@ export default function ComparativePage() {
                     <th>Hadith B</th>
                     <th>Similarity</th>
                     <th>Variant Type</th>
-                    <th>Cross-Sect</th>
+                    <th>Sect Pairing</th>
                     <th></th>
                   </tr>
                 </thead>
@@ -304,7 +336,7 @@ export default function ComparativePage() {
                         )}
                       </td>
                       <td>{pair.variant_type ?? '-'}</td>
-                      <td>{pair.cross_sect ? 'Yes' : 'No'}</td>
+                      <td>{pair.cross_sect ? 'Cross-sect' : 'Within-sect'}</td>
                       <td>
                         <Button
                           variant="ghost"

--- a/src/api/routes/parallels.py
+++ b/src/api/routes/parallels.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
@@ -20,19 +22,34 @@ router = APIRouter()
 def list_parallels(
     page: int = Query(1, ge=1, description="Page number"),
     limit: int = Query(20, ge=1, le=100),
+    cross_sect: bool | None = Query(
+        None,
+        description=(
+            "Optional facet. Omit to span both sects (intra-sunni, intra-shia, AND "
+            "cross-sect); pass true for cross-sect only, false for intra-sect only."
+        ),
+    ),
     neo4j: Neo4jClient = Depends(get_neo4j),
 ) -> ParallelPairsResponse:
-    """Return paginated list of all parallel hadith pairs with similarity scores."""
+    """Return paginated list of parallel hadith pairs with similarity scores.
+
+    Spans every sect combination by default — sunni-sunni, shia-shia, and
+    sunni-shia. ``cross_sect`` is an optional facet, not a mandatory filter.
+    """
+    where = "WHERE r.cross_sect = $cross_sect" if cross_sect is not None else ""
+    filter_params: dict[str, Any] = {} if cross_sect is None else {"cross_sect": cross_sect}
+
     count_rows = neo4j.execute_read(
-        "MATCH (:Hadith)-[r:PARALLEL_OF]->(:Hadith) RETURN count(r) AS total",
-        {},
+        f"MATCH (:Hadith)-[r:PARALLEL_OF]->(:Hadith) {where} RETURN count(r) AS total",
+        filter_params,
     )
     total = count_rows[0]["total"] if count_rows else 0
 
     skip = (page - 1) * limit
     rows = neo4j.execute_read(
-        """
+        f"""
         MATCH (a:Hadith)-[r:PARALLEL_OF]->(b:Hadith)
+        {where}
         RETURN a.id AS a_id, a.source_corpus AS a_corpus,
                b.id AS b_id, b.source_corpus AS b_corpus,
                r.similarity_score AS similarity_score,
@@ -42,7 +59,7 @@ def list_parallels(
         SKIP $skip
         LIMIT $limit
         """,
-        {"skip": skip, "limit": limit},
+        {**filter_params, "skip": skip, "limit": limit},
     )
 
     items = [

--- a/tests/test_api/test_parallels.py
+++ b/tests/test_api/test_parallels.py
@@ -1,0 +1,123 @@
+"""Tests for parallel hadith endpoints.
+
+Browse Parallels must span every sect combination (sunni-sunni, shia-shia, and
+sunni-shia); ``cross_sect`` is an optional facet, not a mandatory filter (#964).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from .routes import PARALLELS
+
+# An intra-sect (sunni-sunni) pair and a cross-sect (sunni-shia) pair, proving the
+# Browse feed is not restricted to cross-sect pairings.
+INTRA_PAIR = {
+    "a_id": "hadith:bukhari:1",
+    "a_corpus": "bukhari",
+    "b_id": "hadith:muslim:1",
+    "b_corpus": "muslim",
+    "similarity_score": 0.97,
+    "variant_type": "verbatim",
+    "cross_sect": False,
+}
+CROSS_PAIR = {
+    "a_id": "hadith:bukhari:2",
+    "a_corpus": "bukhari",
+    "b_id": "hadith:kafi:5",
+    "b_corpus": "kafi",
+    "similarity_score": 0.88,
+    "variant_type": "close_paraphrase",
+    "cross_sect": True,
+}
+
+
+def test_list_parallels_empty(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /parallels returns an empty paginated response when no edges exist."""
+    mock_neo4j.execute_read.side_effect = [[{"total": 0}], []]
+    resp = client.get(PARALLELS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+    assert body["page"] == 1
+
+
+def test_list_parallels_spans_both_sects(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """By default the Browse feed returns intra-sect AND cross-sect pairs (#964)."""
+    mock_neo4j.execute_read.side_effect = [[{"total": 2}], [INTRA_PAIR, CROSS_PAIR]]
+    resp = client.get(PARALLELS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert {p["cross_sect"] for p in body["items"]} == {False, True}
+    intra = next(p for p in body["items"] if not p["cross_sect"])
+    assert intra["hadith_a_id"] == "hadith:bukhari:1"
+    assert intra["hadith_b_corpus"] == "muslim"
+
+
+def test_list_parallels_no_facet_omits_where_clause(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Without the cross_sect facet, no cross_sect predicate is sent to Neo4j."""
+    mock_neo4j.execute_read.side_effect = [[{"total": 0}], []]
+    client.get(PARALLELS)
+    count_query = mock_neo4j.execute_read.call_args_list[0].args[0]
+    count_params = mock_neo4j.execute_read.call_args_list[0].args[1]
+    assert "r.cross_sect" not in count_query
+    assert "cross_sect" not in count_params
+
+
+def test_list_parallels_cross_sect_true_filters(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """cross_sect=true adds a WHERE predicate binding cross_sect to True."""
+    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [CROSS_PAIR]]
+    resp = client.get(f"{PARALLELS}?cross_sect=true")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["cross_sect"] is True
+    count_query = mock_neo4j.execute_read.call_args_list[0].args[0]
+    count_params = mock_neo4j.execute_read.call_args_list[0].args[1]
+    assert "WHERE r.cross_sect = $cross_sect" in count_query
+    assert count_params["cross_sect"] is True
+
+
+def test_list_parallels_cross_sect_false_filters(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """cross_sect=false restricts to intra-sect pairs."""
+    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [INTRA_PAIR]]
+    resp = client.get(f"{PARALLELS}?cross_sect=false")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["cross_sect"] is False
+    data_params = mock_neo4j.execute_read.call_args_list[1].args[1]
+    assert data_params["cross_sect"] is False
+
+
+def test_get_parallels_not_found(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /parallels/{id} returns 404 when the hadith does not exist."""
+    mock_neo4j.execute_read.side_effect = [[]]
+    resp = client.get(f"{PARALLELS}/hadith:missing:1")
+    assert resp.status_code == 404
+
+
+def test_get_parallels_found_spans_sects(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """GET /parallels/{id} returns parallels regardless of sect pairing."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"id": "hadith:bukhari:1"}],  # hadith exists
+        [
+            {
+                "id": "hadith:muslim:1",
+                "matn_ar": "إنما الأعمال بالنيات",
+                "matn_en": "Actions are by intentions.",
+                "source_corpus": "muslim",
+                "grade": "sahih",
+                "similarity_score": 0.97,
+                "variant_type": "verbatim",
+                "cross_sect": False,
+            }
+        ],
+    ]
+    resp = client.get(f"{PARALLELS}/hadith:bukhari:1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["parallels"][0]["cross_sect"] is False


### PR DESCRIPTION
## Summary

`Browse Parallels` "didn't really do anything" and read as cross-sect-only. Investigation found the **backend `/parallels` query already returned every `PARALLEL_OF` edge unfiltered**, and upstream `da` dedup (`_is_cross_sect`) emits intra-sect pairs too — so the "exclusively cross-sect" character was **framing + the absence of an explicit sect facet**, not a hard filter.

This PR makes both-sects spanning explicit and gives `cross_sect` a real optional facet.

### Backend — `src/api/routes/parallels.py`
- `/parallels` gains an optional `cross_sect` query param:
  - omitted → spans **every** sect combination (sunni-sunni, shia-shia, sunni-shia)
  - `true` → cross-sect only · `false` → intra-sect only
- `cross_sect` is now an **optional facet, not a mandatory filter**.

### Frontend — `ComparativePage.tsx`, `api/client.ts`
- Sect-pairing filter control: **All parallels / Within a sect / Cross-sect** (resets paging on change).
- Copy no longer frames parallels as exclusively cross-sectarian (subtitle + empty state).
- "Cross-Sect" column relabeled **"Sect Pairing"** → `Cross-sect` / `Within-sect`.

### Tests — `tests/test_api/test_parallels.py`
Default both-sects span, the `cross_sect` facet (true/false) and that **no predicate is sent when omitted**, plus the per-hadith endpoint.

## Acceptance (#964)
- [x] Browse Parallels returns parallels for any sect combination
- [x] `cross_sect` is an optional facet, not a mandatory filter
- [x] Compare route remains; parallels feed it

## Data dependency (not faked)
Live data is gated on the pipeline load (**#965**) — the graph currently holds only da#73's hadith slice, so few/no `PARALLEL_OF` edges exist to display yet. The code is complete and ready; the view populates once the pipeline loads parallels.

## Verification
- `ruff check` + `ruff format --check` (0.15.11): clean
- `mypy` (strict): clean
- frontend `tsc && vite build`: clean; `eslint`: 0 errors
- backend `pytest tests/test_api/test_parallels.py`: passing locally but **slow per-test** (each `TestClient` lifespan blocks on Neo4j/Redis connect-timeouts without local infra); CI runs them green against real services.

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
