### PR TITLE
fix(frontend): remove hardcoded color fallbacks + fix non-DS token names (#980)

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -281,7 +281,7 @@ export default function UserMenu() {
               cursor: 'pointer',
               fontFamily: 'var(--font-body)',
               fontSize: 'var(--text-sm)',
-              color: 'var(--color-destructive, #ef4444)',
+              color: 'var(--color-destructive)',
               textAlign: 'left',
             }}
           >

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -67,7 +67,7 @@ export default function AuthCallbackPage() {
               width: 48,
               height: 48,
               background: 'var(--color-destructive)',
-              color: 'var(--color-destructive-foreground, #fff)',
+              color: 'var(--color-destructive-foreground)',
             }}
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -26,9 +26,9 @@ function providerLabel(provider: string): string {
 function roleBadgeColor(role: string | null): string {
   switch (role) {
     case 'admin':
-      return 'var(--color-destructive, #ef4444)'
+      return 'var(--color-destructive)'
     case 'researcher':
-      return 'var(--color-warning, #f59e0b)'
+      return 'var(--color-warning)'
     case 'reader':
       return 'var(--color-primary)'
     default:
@@ -172,7 +172,7 @@ export default function ProfilePage() {
                 fontSize: 'var(--text-xs)',
                 fontWeight: 600,
                 borderRadius: 'var(--radius-full)',
-                color: '#fff',
+                color: 'var(--color-primary-foreground)',
                 background: roleBadgeColor(profile.role),
               }}
             >

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -102,7 +102,7 @@ export default function VerifyEmailPage() {
             width: 64,
             height: 64,
             borderRadius: 'var(--radius-lg)',
-            background: success ? 'var(--color-green-500, #22c55e)' : 'var(--color-primary)',
+            background: success ? 'var(--color-success)' : 'var(--color-primary)',
             color: 'var(--color-primary-foreground)',
             transition: 'background 0.3s',
           }}


### PR DESCRIPTION
Closes #980 — bucket C of the FE color-token alignment (parent #967). Step 2 of the FE color chain (#979 merged -> #980 -> #981).

## What changed
DS 0.0.5-wave4.0 (the pinned dep) compiles the semantic color tokens to `:root` (verified `--color-success`, `--color-destructive`, `--color-destructive-foreground`, `--color-warning`, `--color-primary-foreground` all present in light + dark blocks of `src/tokens/colors.css` at that exact version). So the literal hex fallbacks are dead weight and one token name was simply wrong.

| File | Before | After |
|------|--------|-------|
| `VerifyEmailPage.tsx:105` | `var(--color-green-500, #22c55e)` | `var(--color-success)` |
| `ProfilePage.tsx:29` | `var(--color-destructive, #ef4444)` | `var(--color-destructive)` |
| `ProfilePage.tsx:31` | `var(--color-warning, #f59e0b)` | `var(--color-warning)` |
| `ProfilePage.tsx:175` | `color: '#fff'` (role badge) | `var(--color-primary-foreground)` |
| `UserMenu.tsx:284` | `var(--color-destructive, #ef4444)` | `var(--color-destructive)` |
| `AuthCallbackPage.tsx:70` | `var(--color-destructive-foreground, #fff)` | `var(--color-destructive-foreground)` |

`--color-green-500` does **not** exist in the DS; `--color-success` is the semantic equivalent.

## Out of scope (intentional)
- `ForceGraph.tsx:19` — `style.getPropertyValue('--color-card').trim() || '#fff'` is a **JS canvas runtime fallback**, not a CSS `var()` fallback, and `#979` owns ForceGraph. Left untouched.
- OAuth / Google-logo brand hexes — app-specific per the issue.

## Test Plan
- `npm run build` (tsc + vite) — green
- `npm run lint` — 0 errors (11 pre-existing warnings, none in the changed files)
- `npm run test` — 186/186 passing
- Residual grep: only the ForceGraph JS fallback remains (expected).

## Reviewers
@Jun-Seo Park (primary), @Anya Kowalczyk (secondary)

## Note for #981
#981 (style migration) also touches `UserMenu.tsx` — it should branch off after this merges.
