### PR TITLE
feat(frontend): bridge DS color tokens into Tailwind @theme so color utilities resolve (#1000)

### DIFF
--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -12,6 +12,111 @@
  */
 
 /* ============================================================
+ * DESIGN-SYSTEM COLOR TOKENS → TAILWIND THEME (#1000)
+ * ------------------------------------------------------------
+ * The design system ships its color tokens to `:root` as plain CSS
+ * (per DS#104, so non-Tailwind consumers get them) — NOT into Tailwind's
+ * `@theme` namespace. As a result Tailwind never learned them as colors,
+ * so semantic color utilities (`bg-card`, `bg-background`, `bg-primary`,
+ * `border-border`, `text-foreground`, `text-muted-foreground`, `bg-accent`,
+ * `bg-muted`, the grading/sect/tier domain colors, …) generated NO rules —
+ * they were silent no-ops in the shipped bundle.
+ *
+ * This `@theme inline` block registers each DS `--color-*` token as a
+ * Tailwind theme color that references the DS runtime variable. Because the
+ * value is a `var()` to the DS token, the generated utilities stay
+ * light/dark-adaptive automatically (the DS swaps the variables under
+ * `:root` / `[data-theme="dark"]` / `prefers-color-scheme`). `inline` keeps
+ * Tailwind from re-emitting these variables into its own layer, so the DS
+ * `:root` definitions remain the single source of truth and win the cascade.
+ *
+ * Spacing/radius utilities already resolve (Tailwind's default scale is
+ * numerically identical to the DS scale), so only colors need bridging.
+ * ============================================================ */
+@theme inline {
+  /* Semantic */
+  --color-primary: var(--color-primary);
+  --color-primary-hover: var(--color-primary-hover);
+  --color-primary-foreground: var(--color-primary-foreground);
+  --color-secondary: var(--color-secondary);
+  --color-secondary-foreground: var(--color-secondary-foreground);
+  --color-muted: var(--color-muted);
+  --color-muted-foreground: var(--color-muted-foreground);
+  --color-accent: var(--color-accent);
+  --color-accent-foreground: var(--color-accent-foreground);
+  --color-destructive: var(--color-destructive);
+  --color-destructive-foreground: var(--color-destructive-foreground);
+  --color-success: var(--color-success);
+  --color-success-foreground: var(--color-success-foreground);
+  --color-warning: var(--color-warning);
+  --color-warning-foreground: var(--color-warning-foreground);
+  --color-info: var(--color-info);
+  --color-info-foreground: var(--color-info-foreground);
+
+  /* Surface */
+  --color-background: var(--color-background);
+  --color-foreground: var(--color-foreground);
+  --color-card: var(--color-card);
+  --color-card-foreground: var(--color-card-foreground);
+  --color-popover: var(--color-popover);
+  --color-popover-foreground: var(--color-popover-foreground);
+
+  /* Interactive */
+  --color-border: var(--color-border);
+  --color-input: var(--color-input);
+  --color-ring: var(--color-ring);
+
+  /* Brand — landing-page palette */
+  --color-brand-navy: var(--color-brand-navy);
+  --color-brand-navy-light: var(--color-brand-navy-light);
+  --color-brand-navy-dark: var(--color-brand-navy-dark);
+  --color-brand-gold: var(--color-brand-gold);
+  --color-brand-gold-light: var(--color-brand-gold-light);
+  --color-brand-gold-dark: var(--color-brand-gold-dark);
+
+  /* Domain — hadith grading */
+  --color-sahih: var(--color-sahih);
+  --color-sahih-bg: var(--color-sahih-bg);
+  --color-hasan: var(--color-hasan);
+  --color-hasan-bg: var(--color-hasan-bg);
+  --color-daif: var(--color-daif);
+  --color-daif-bg: var(--color-daif-bg);
+  --color-mawdu: var(--color-mawdu);
+  --color-mawdu-bg: var(--color-mawdu-bg);
+
+  /* Domain — sect indicators */
+  --color-sunni: var(--color-sunni);
+  --color-sunni-bg: var(--color-sunni-bg);
+  --color-shia: var(--color-shia);
+  --color-shia-bg: var(--color-shia-bg);
+
+  /* Domain — narrator reliability tiers */
+  --color-tier-thiqah: var(--color-tier-thiqah);
+  --color-tier-thiqah-bg: var(--color-tier-thiqah-bg);
+  --color-tier-saduq: var(--color-tier-saduq);
+  --color-tier-saduq-bg: var(--color-tier-saduq-bg);
+  --color-tier-daif-narrator: var(--color-tier-daif-narrator);
+  --color-tier-daif-narrator-bg: var(--color-tier-daif-narrator-bg);
+  --color-tier-matruk: var(--color-tier-matruk);
+  --color-tier-matruk-bg: var(--color-tier-matruk-bg);
+  --color-tier-kadhdhab: var(--color-tier-kadhdhab);
+  --color-tier-kadhdhab-bg: var(--color-tier-kadhdhab-bg);
+
+  /* Visualization (also consumed by ForceGraph via getComputedStyle) */
+  --color-viz-accent: var(--color-viz-accent);
+  --color-viz-categorical-1: var(--color-viz-categorical-1);
+  --color-viz-categorical-2: var(--color-viz-categorical-2);
+  --color-viz-categorical-3: var(--color-viz-categorical-3);
+  --color-viz-categorical-4: var(--color-viz-categorical-4);
+  --color-viz-categorical-5: var(--color-viz-categorical-5);
+  --color-viz-categorical-6: var(--color-viz-categorical-6);
+  --color-viz-categorical-7: var(--color-viz-categorical-7);
+  --color-viz-categorical-8: var(--color-viz-categorical-8);
+  --color-viz-categorical-9: var(--color-viz-categorical-9);
+  --color-viz-categorical-10: var(--color-viz-categorical-10);
+}
+
+/* ============================================================
  * OAUTH PROVIDER BRAND TOKENS
  * Brand colors for third-party OAuth buttons. These are provider-
  * mandated values and intentionally not part of the shared DS.


### PR DESCRIPTION
Closes #1000 — **PR 1 of 2** (the enabler). This is the "right thing" path per the owner directive: fix the root cause so the semantic color utilities actually work, instead of keeping color inline. PR 2 (#981 proper) rebases on this.

## Problem
The design system ships its color tokens to `:root` as plain CSS (per **DS#104**, so non-Tailwind consumers get them) — **not** into Tailwind's `@theme` namespace. So Tailwind never learned them as colors, and **every semantic color utility generated zero rules** in the shipped bundle: `bg-card`, `bg-background`, `bg-primary`, `border-border`, `text-foreground`, `text-muted-foreground`, `bg-accent`, `bg-muted`, and the grading/sect/tier domain colors. **~200 color-utility usages across ~30 components were silent no-ops** — e.g. `AuthCallbackPage`'s error card `className="… bg-card border-border …"` rendered with **no background and no border**.

## Fix (app-only, 1 file)
An `@theme inline` block in `frontend/src/styles/theme.css` registers each DS `--color-*` token as a Tailwind theme color that references the DS runtime variable:
```css
@theme inline {
  --color-card: var(--color-card);
  --color-muted-foreground: var(--color-muted-foreground);
  /* …full DS palette… */
}
```
- Utilities now **generate** and, because they reference `var(--color-*)`, stay **light/dark-adaptive automatically** (the DS swaps the vars under `:root` / `[data-theme="dark"]` / `prefers-color-scheme`).
- `inline` keeps Tailwind from re-emitting the vars, so the **DS `:root` stays the single source of truth** and wins the cascade.
- **No DS-side change needed** — confirmed the DS already exposes every semantic `--color-*` in `:root`. (Spacing/radius utilities already resolved since Tailwind's default scale is numerically identical to the DS scale, so only colors needed bridging.)

## What this activates app-wide (intentional, not accidental)
This **activates the previously-inert utilities across ~30 files at once** — by design. With no users yet (owner's call), the visual changes are acceptable; each is the **DS-intended rendering that the no-op was suppressing** (e.g. the AuthCallback error card now actually shows its card surface + border). I found **no page relying on the no-op** for a deliberately-transparent effect (overlays/scrims use inline `rgba()`, not these classes; `text-*` utilities correctly set only `color`, leaving `background` transparent).

## Verification (no users, but proven correct in light + dark)
The sandbox has no live cluster, but the repo's Playwright Chromium runs headless — so this is **real browser verification**, not just CSS inspection:

**1. CSS-level:** all **31 distinct** color utilities used in app source now generate a rule referencing `var(--color-*)` (incl. opacity modifiers via `color-mix`, e.g. `focus:ring-primary/20` → `--tw-ring-color: var(--color-primary)`). Zero remaining no-ops.

**2. Headless-browser computed styles (Playwright), `/login` + `/`, light AND dark** — values match the DS light/dark tokens exactly:

| utility | light | dark |
|---|---|---|
| `bg-card` | `oklch(0.99 0.005 85)` | `oklch(0.25 0.015 260)` |
| `bg-background` | `oklch(0.96 0.01 85)` | `oklch(0.2 0.015 260)` |
| `bg-muted` | `oklch(0.93 0.005 85)` | `oklch(0.25 0.01 260)` |
| `border-border` | `oklch(0.85 0.01 85)` | `oklch(0.35 0.01 260)` |
| `text-muted-foreground` | `oklch(0.45 0.01 260)` | `oklch(0.6 0.01 260)` |
| `bg-primary` | `oklch(0.55 0.14 45)` | `oklch(0.65 0.14 45)` |

(dark via `prefers-color-scheme: dark`; the DS also swaps under `[data-theme="dark"]`, same values.) All were `rgba(0,0,0,0)` / unset before.

**3.** `npm run build` (tsc+vite) green; `npm run lint` 0 errors (11 pre-existing warnings); `npm run test` 186/186 pass.

## Reviewers
@Ravi Desai (DS lens), @Junseo Park (code lens), @Anya Kowalczyk (tech-lead — app-wide blast radius).

Next: #981 proper (full inline→utility migration of the 3 heaviest files) rebases on this once merged.
