### PR TITLE
refactor(frontend): full inline-style → DS/Tailwind utility migration (#981)

### DIFF
--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -184,13 +184,7 @@ export default function GraphExplorerPage() {
   return (
     <div className="flex flex-col" style={{ height: 'calc(100vh - 64px)' }}>
       {/* --- TOOLBAR --- */}
-      <div
-        className="flex flex-wrap items-center gap-3 px-4 py-2"
-        style={{
-          borderBottom: '1px solid var(--color-border)',
-          background: 'var(--color-card)',
-        }}
-      >
+      <div className="flex flex-wrap items-center gap-3 border-b border-border bg-card px-4 py-2">
         {/* Search */}
         <div className="relative w-[300px]">
           <input
@@ -212,11 +206,10 @@ export default function GraphExplorerPage() {
                 setSearchInput('')
                 setSearchOpen(false)
               }}
-              className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer border-none"
+              className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer border-none text-muted-foreground"
               style={{
                 background: 'none',
                 fontSize: '1rem',
-                color: 'var(--color-muted-foreground)',
               }}
               aria-label="Clear search"
             >
@@ -226,11 +219,9 @@ export default function GraphExplorerPage() {
 
           {searchOpen && searchInput && searchResults && searchResults.items.length > 0 && (
             <div
-              className="search-dropdown absolute top-full left-0 right-0 max-h-60 overflow-y-auto rounded-md"
+              className="search-dropdown absolute top-full left-0 right-0 max-h-60 overflow-y-auto rounded-md border border-border bg-card"
               style={{
                 zIndex: 'var(--z-dropdown)',
-                background: 'var(--color-card)',
-                border: '1px solid var(--color-border)',
                 boxShadow: 'var(--shadow-md)',
               }}
             >
@@ -258,9 +249,8 @@ export default function GraphExplorerPage() {
               key={d}
               onClick={() => setDepth(d)}
               title="Number of transmission steps from selected narrator"
-              className="cursor-pointer rounded-sm px-2.5 py-1"
+              className="cursor-pointer rounded-sm border border-border px-2.5 py-1"
               style={{
-                border: '1px solid var(--color-border)',
                 background:
                   d === depth ? 'var(--color-primary, oklch(0.55 0.14 45))' : 'transparent',
                 color: d === depth ? 'var(--color-primary-foreground)' : 'inherit',
@@ -280,9 +270,8 @@ export default function GraphExplorerPage() {
             <button
               key={mode}
               onClick={() => setLayoutMode(mode)}
-              className="cursor-pointer rounded-sm px-2 py-1 capitalize"
+              className="cursor-pointer rounded-sm border border-border px-2 py-1 capitalize"
               style={{
-                border: '1px solid var(--color-border)',
                 background:
                   mode === layoutMode
                     ? 'var(--color-primary, oklch(0.55 0.14 45))'
@@ -323,8 +312,8 @@ export default function GraphExplorerPage() {
         {highlightedChainNodeIds && (
           <button
             onClick={() => setHighlightedChainNodeIds(null)}
-            className="btn"
-            style={{ fontSize: '0.875rem', color: 'var(--color-primary)' }}
+            className="btn text-primary"
+            style={{ fontSize: '0.875rem' }}
           >
             Clear highlight
           </button>
@@ -336,10 +325,8 @@ export default function GraphExplorerPage() {
       {/* --- Node limit warning --- */}
       {overLimit && (
         <div
-          className="px-4 py-2"
+          className="bg-warning px-4 py-2 text-warning-foreground"
           style={{
-            background: 'var(--color-warning)',
-            color: 'var(--color-warning-foreground)',
             fontSize: '0.875rem',
           }}
         >
@@ -360,8 +347,7 @@ export default function GraphExplorerPage() {
         {/* --- GRAPH CANVAS --- */}
         <div
           ref={containerRef}
-          className="relative flex-1"
-          style={{ background: 'var(--color-background)' }}
+          className="relative flex-1 bg-background"
           role="application"
           aria-label="Narrator transmission network graph"
         >
@@ -417,10 +403,8 @@ export default function GraphExplorerPage() {
           {/* Hover tooltip */}
           {hoveredNode && (
             <div
-              className="pointer-events-none absolute top-3 left-3 z-10 max-w-[280px] rounded-md px-3 py-2"
+              className="pointer-events-none absolute top-3 left-3 z-10 max-w-[280px] rounded-md border border-border bg-card px-3 py-2"
               style={{
-                background: 'var(--color-card)',
-                border: '1px solid var(--color-border)',
                 fontSize: '0.8rem',
                 boxShadow: 'var(--shadow-md)',
               }}
@@ -447,11 +431,9 @@ export default function GraphExplorerPage() {
           {/* Legend panel */}
           {legendOpen && (
             <div
-              className="absolute top-3 z-10 w-[220px] rounded-md p-3"
+              className="absolute top-3 z-10 w-[220px] rounded-md border border-border bg-card p-3"
               style={{
                 right: detailOpen ? 340 : 12,
-                background: 'var(--color-card)',
-                border: '1px solid var(--color-border)',
                 fontSize: '0.8rem',
                 boxShadow: 'var(--shadow-md)',
               }}
@@ -513,10 +495,8 @@ export default function GraphExplorerPage() {
                   key={btn.label}
                   title={btn.title}
                   aria-label={btn.title}
-                  className="h-8 w-8 cursor-pointer rounded-sm"
+                  className="h-8 w-8 cursor-pointer rounded-sm border border-border bg-card"
                   style={{
-                    border: '1px solid var(--color-border)',
-                    background: 'var(--color-card)',
                     fontSize: '1rem',
                   }}
                 >
@@ -530,30 +510,24 @@ export default function GraphExplorerPage() {
         {/* --- DETAIL PANEL --- */}
         {detailOpen && selectedNarratorId && (
           <div
-            className="w-[320px] shrink-0 overflow-y-auto p-4"
-            style={{
-              borderLeft: '1px solid var(--color-border)',
-              background: 'var(--color-card)',
-            }}
+            className="w-[320px] shrink-0 overflow-y-auto border-l border-border bg-card p-4"
           >
             <div className="mb-4 flex items-center justify-between">
               <span
-                className="uppercase"
+                className="uppercase text-muted-foreground"
                 style={{
                   fontSize: '0.75rem',
                   letterSpacing: '0.05em',
-                  color: 'var(--color-muted-foreground)',
                 }}
               >
                 Narrator
               </span>
               <button
                 onClick={() => setDetailOpen(false)}
-                className="cursor-pointer border-none"
+                className="cursor-pointer border-none text-muted-foreground"
                 style={{
                   background: 'none',
                   fontSize: '1rem',
-                  color: 'var(--color-muted-foreground)',
                 }}
                 aria-label="Close detail panel"
               >
@@ -580,12 +554,9 @@ export default function GraphExplorerPage() {
 
       {/* --- STATUS BAR --- */}
       <div
-        className="flex gap-6 px-4 py-1"
+        className="flex gap-6 border-t border-border bg-card px-4 py-1 text-muted-foreground"
         style={{
-          borderTop: '1px solid var(--color-border)',
           fontSize: '0.75rem',
-          color: 'var(--color-muted-foreground)',
-          background: 'var(--color-card)',
         }}
       >
         <span>
@@ -673,17 +644,13 @@ function NarratorDetailPanel({
 
       {/* Network statistics */}
       <div
-        className="mb-4 pt-3"
-        style={{
-          borderTop: '1px solid var(--color-border)',
-        }}
+        className="mb-4 border-t border-border pt-3"
       >
         <div
-          className="mb-2 uppercase"
+          className="mb-2 uppercase text-muted-foreground"
           style={{
             fontSize: '0.75rem',
             letterSpacing: '0.05em',
-            color: 'var(--color-muted-foreground)',
           }}
         >
           Network Statistics
@@ -721,18 +688,14 @@ function NarratorDetailPanel({
 
       {/* Chains */}
       <div
-        className="mb-4 pt-3"
-        style={{
-          borderTop: '1px solid var(--color-border)',
-        }}
+        className="mb-4 border-t border-border pt-3"
       >
         <div className="mb-2 flex items-center justify-between">
           <span
-            className="uppercase"
+            className="uppercase text-muted-foreground"
             style={{
               fontSize: '0.75rem',
               letterSpacing: '0.05em',
-              color: 'var(--color-muted-foreground)',
             }}
           >
             Chains ({chainsTotal} total)
@@ -746,9 +709,8 @@ function NarratorDetailPanel({
             <div
               key={c.chain_id}
               onClick={() => onChainSelect(c)}
-              className="cursor-pointer px-0 py-1.5"
+              className="cursor-pointer border-b border-border px-0 py-1.5"
               style={{
-                borderBottom: '1px solid var(--color-border)',
                 fontSize: '0.8rem',
               }}
             >
@@ -774,11 +736,9 @@ function NarratorDetailPanel({
       {/* Link to full profile */}
       <Link
         to={`/narrators/${narrator.id}`}
-        className="block rounded-md p-2 text-center no-underline"
+        className="block rounded-md border border-border p-2 text-center text-primary no-underline"
         style={{
-          color: 'var(--color-primary)',
           fontSize: '0.85rem',
-          border: '1px solid var(--color-border)',
         }}
       >
         View Full Profile

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -182,21 +182,17 @@ export default function GraphExplorerPage() {
   const overLimit = allNodes.length > NODE_LIMIT
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)' }}>
+    <div className="flex flex-col" style={{ height: 'calc(100vh - 64px)' }}>
       {/* --- TOOLBAR --- */}
       <div
+        className="flex flex-wrap items-center gap-3 px-4 py-2"
         style={{
-          padding: '0.5rem 1rem',
           borderBottom: '1px solid var(--color-border)',
-          display: 'flex',
-          flexWrap: 'wrap',
-          alignItems: 'center',
-          gap: '0.75rem',
           background: 'var(--color-card)',
         }}
       >
         {/* Search */}
-        <div style={{ position: 'relative', width: 300 }}>
+        <div className="relative w-[300px]">
           <input
             ref={searchRef}
             type="text"
@@ -207,8 +203,7 @@ export default function GraphExplorerPage() {
               setSearchOpen(true)
             }}
             onFocus={() => setSearchOpen(true)}
-            className="form-input"
-            style={{ width: '100%', paddingRight: '2rem' }}
+            className="form-input w-full pr-8"
             aria-label="Search for a narrator"
           />
           {searchInput && (
@@ -217,14 +212,9 @@ export default function GraphExplorerPage() {
                 setSearchInput('')
                 setSearchOpen(false)
               }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer border-none"
               style={{
-                position: 'absolute',
-                right: 8,
-                top: '50%',
-                transform: 'translateY(-50%)',
                 background: 'none',
-                border: 'none',
-                cursor: 'pointer',
                 fontSize: '1rem',
                 color: 'var(--color-muted-foreground)',
               }}
@@ -236,18 +226,11 @@ export default function GraphExplorerPage() {
 
           {searchOpen && searchInput && searchResults && searchResults.items.length > 0 && (
             <div
-              className="search-dropdown"
+              className="search-dropdown absolute top-full left-0 right-0 max-h-60 overflow-y-auto rounded-md"
               style={{
-                position: 'absolute',
-                top: '100%',
-                left: 0,
-                right: 0,
                 zIndex: 'var(--z-dropdown)',
                 background: 'var(--color-card)',
                 border: '1px solid var(--color-border)',
-                borderRadius: 'var(--radius-md)',
-                maxHeight: 240,
-                overflowY: 'auto',
                 boxShadow: 'var(--shadow-md)',
               }}
             >
@@ -255,17 +238,10 @@ export default function GraphExplorerPage() {
                 <div
                   key={n.id}
                   onClick={() => handleSelectSearch(n.id)}
-                  className="search-dropdown-item"
-                  style={{
-                    padding: '0.5rem 0.75rem',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                  }}
+                  className="search-dropdown-item flex cursor-pointer items-center justify-between px-3 py-2"
                 >
                   <span>{n.name_en}</span>
-                  <span dir="rtl" lang="ar" style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>
+                  <span dir="rtl" lang="ar" className="muted-text" style={{ fontSize: '0.875rem' }}>
                     {n.name_ar}
                   </span>
                 </div>
@@ -275,21 +251,19 @@ export default function GraphExplorerPage() {
         </div>
 
         {/* Depth control */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-          <span style={{ fontSize: '0.875rem', color: 'var(--color-muted-foreground)' }}>Depth:</span>
+        <div className="flex items-center gap-1">
+          <span className="muted-text" style={{ fontSize: '0.875rem' }}>Depth:</span>
           {[1, 2, 3].map((d) => (
             <button
               key={d}
               onClick={() => setDepth(d)}
               title="Number of transmission steps from selected narrator"
+              className="cursor-pointer rounded-sm px-2.5 py-1"
               style={{
-                padding: '0.25rem 0.625rem',
                 border: '1px solid var(--color-border)',
-                borderRadius: 'var(--radius-sm)',
                 background:
                   d === depth ? 'var(--color-primary, oklch(0.55 0.14 45))' : 'transparent',
                 color: d === depth ? 'var(--color-primary-foreground)' : 'inherit',
-                cursor: 'pointer',
                 fontWeight: d === depth ? 600 : 400,
                 fontSize: '0.875rem',
               }}
@@ -300,24 +274,21 @@ export default function GraphExplorerPage() {
         </div>
 
         {/* Layout toggle */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-          <span style={{ fontSize: '0.875rem', color: 'var(--color-muted-foreground)' }}>Layout:</span>
+        <div className="flex items-center gap-1">
+          <span className="muted-text" style={{ fontSize: '0.875rem' }}>Layout:</span>
           {(['force', 'hierarchy', 'radial'] as LayoutMode[]).map((mode) => (
             <button
               key={mode}
               onClick={() => setLayoutMode(mode)}
+              className="cursor-pointer rounded-sm px-2 py-1 capitalize"
               style={{
-                padding: '0.25rem 0.5rem',
                 border: '1px solid var(--color-border)',
-                borderRadius: 'var(--radius-sm)',
                 background:
                   mode === layoutMode
                     ? 'var(--color-primary, oklch(0.55 0.14 45))'
                     : 'transparent',
                 color: mode === layoutMode ? 'var(--color-primary-foreground)' : 'inherit',
-                cursor: 'pointer',
                 fontSize: '0.8rem',
-                textTransform: 'capitalize',
               }}
             >
               {mode}
@@ -359,14 +330,14 @@ export default function GraphExplorerPage() {
           </button>
         )}
 
-        {isLoading && <span style={{ fontSize: '0.875rem', color: 'var(--color-muted-foreground)' }}>Loading...</span>}
+        {isLoading && <span className="muted-text" style={{ fontSize: '0.875rem' }}>Loading...</span>}
       </div>
 
       {/* --- Node limit warning --- */}
       {overLimit && (
         <div
+          className="px-4 py-2"
           style={{
-            padding: '0.5rem 1rem',
             background: 'var(--color-warning)',
             color: 'var(--color-warning-foreground)',
             fontSize: '0.875rem',
@@ -376,8 +347,8 @@ export default function GraphExplorerPage() {
           {NODE_LIMIT}. Apply filters or reduce depth.
           <button
             onClick={() => setFilterOpen(true)}
-            className="btn"
-            style={{ marginLeft: '0.5rem', fontSize: '0.8rem' }}
+            className="btn ml-2"
+            style={{ fontSize: '0.8rem' }}
           >
             Open Filters
           </button>
@@ -385,15 +356,12 @@ export default function GraphExplorerPage() {
       )}
 
       {/* --- MAIN CONTENT --- */}
-      <div style={{ display: 'flex', flex: 1, overflow: 'hidden', position: 'relative' }}>
+      <div className="relative flex flex-1 overflow-hidden">
         {/* --- GRAPH CANVAS --- */}
         <div
           ref={containerRef}
-          style={{
-            flex: 1,
-            position: 'relative',
-            background: 'var(--color-background)',
-          }}
+          className="relative flex-1"
+          style={{ background: 'var(--color-background)' }}
           role="application"
           aria-label="Narrator transmission network graph"
         >
@@ -409,7 +377,7 @@ export default function GraphExplorerPage() {
               height={dimensions.height}
             />
           ) : (
-            <div className="empty-state" style={{ height: '100%' }}>
+            <div className="empty-state h-full">
               <div className="empty-state-icon">
                 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
                   <circle cx="16" cy="16" r="4" />
@@ -425,20 +393,16 @@ export default function GraphExplorerPage() {
               <div className="empty-state-body">
                 Search for a narrator to explore the transmission network.
               </div>
-              <p style={{ fontSize: 'var(--text-sm)', marginTop: 'var(--spacing-4)' }}>
+              <p className="mt-4" style={{ fontSize: 'var(--text-sm)' }}>
                 Try:{' '}
                 {SUGGESTED_NARRATORS.map((name, i) => (
                   <span key={name}>
                     {i > 0 && ', '}
                     <button
                       onClick={() => handleSuggestedSearch(name)}
-                      className="link-primary"
+                      className="link-primary cursor-pointer border-none p-0 underline"
                       style={{
                         background: 'none',
-                        border: 'none',
-                        cursor: 'pointer',
-                        textDecoration: 'underline',
-                        padding: 0,
                         font: 'inherit',
                       }}
                     >
@@ -453,22 +417,15 @@ export default function GraphExplorerPage() {
           {/* Hover tooltip */}
           {hoveredNode && (
             <div
+              className="pointer-events-none absolute top-3 left-3 z-10 max-w-[280px] rounded-md px-3 py-2"
               style={{
-                position: 'absolute',
-                top: 12,
-                left: 12,
                 background: 'var(--color-card)',
                 border: '1px solid var(--color-border)',
-                borderRadius: 'var(--radius-md)',
-                padding: '0.5rem 0.75rem',
                 fontSize: '0.8rem',
-                pointerEvents: 'none',
-                zIndex: 10,
-                maxWidth: 280,
                 boxShadow: 'var(--shadow-md)',
               }}
             >
-              <div style={{ fontWeight: 600 }}>
+              <div className="font-semibold">
                 {hoveredNode.name_en || hoveredNode.label}
               </div>
               {hoveredNode.name_ar && (
@@ -490,25 +447,20 @@ export default function GraphExplorerPage() {
           {/* Legend panel */}
           {legendOpen && (
             <div
+              className="absolute top-3 z-10 w-[220px] rounded-md p-3"
               style={{
-                position: 'absolute',
-                top: 12,
                 right: detailOpen ? 340 : 12,
                 background: 'var(--color-card)',
                 border: '1px solid var(--color-border)',
-                borderRadius: 'var(--radius-md)',
-                padding: '0.75rem',
                 fontSize: '0.8rem',
-                zIndex: 10,
-                width: 220,
                 boxShadow: 'var(--shadow-md)',
               }}
             >
-              <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>Legend</div>
+              <div className="mb-2 font-semibold">Legend</div>
 
-              <div style={{ marginBottom: '0.5rem' }}>
-                <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>Node size: degree</div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <div className="mb-2">
+                <div className="mb-1 font-medium">Node size: degree</div>
+                <div className="flex items-center gap-2">
                   <svg width="8" height="8">
                     <circle cx="4" cy="4" r="3" fill="var(--color-muted-foreground)" />
                   </svg>
@@ -524,28 +476,23 @@ export default function GraphExplorerPage() {
                 </div>
               </div>
 
-              <div style={{ marginBottom: '0.5rem' }}>
-                <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>
+              <div className="mb-2">
+                <div className="mb-1 font-medium">
                   Node color: community
                 </div>
                 {communities.map(([cid, count]) => (
-                  <div key={cid} style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                  <div key={cid} className="flex items-center gap-1">
                     <span
-                      style={{
-                        display: 'inline-block',
-                        width: 10,
-                        height: 10,
-                        borderRadius: '50%',
-                        background: communityColor(cid),
-                      }}
+                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      style={{ background: communityColor(cid) }}
                     />
                     Community {cid} ({count})
                   </div>
                 ))}
               </div>
 
-              <div style={{ marginBottom: '0.5rem' }}>
-                <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>
+              <div className="mb-2">
+                <div className="mb-1 font-medium">
                   Edge: transmission direction
                 </div>
                 <div>Solid = TRANSMITTED_TO</div>
@@ -557,17 +504,7 @@ export default function GraphExplorerPage() {
 
           {/* Zoom controls */}
           {allNodes.length > 0 && (
-            <div
-              style={{
-                position: 'absolute',
-                bottom: 40,
-                left: 12,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 2,
-                zIndex: 10,
-              }}
-            >
+            <div className="absolute bottom-10 left-3 z-10 flex flex-col gap-0.5">
               {[
                 { label: '+', title: 'Zoom in' },
                 { label: '-', title: 'Zoom out' },
@@ -576,13 +513,10 @@ export default function GraphExplorerPage() {
                   key={btn.label}
                   title={btn.title}
                   aria-label={btn.title}
+                  className="h-8 w-8 cursor-pointer rounded-sm"
                   style={{
-                    width: 32,
-                    height: 32,
                     border: '1px solid var(--color-border)',
-                    borderRadius: 'var(--radius-sm)',
                     background: 'var(--color-card)',
-                    cursor: 'pointer',
                     fontSize: '1rem',
                   }}
                 >
@@ -596,27 +530,17 @@ export default function GraphExplorerPage() {
         {/* --- DETAIL PANEL --- */}
         {detailOpen && selectedNarratorId && (
           <div
+            className="w-[320px] shrink-0 overflow-y-auto p-4"
             style={{
-              width: 320,
               borderLeft: '1px solid var(--color-border)',
               background: 'var(--color-card)',
-              overflowY: 'auto',
-              padding: '1rem',
-              flexShrink: 0,
             }}
           >
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: '1rem',
-              }}
-            >
+            <div className="mb-4 flex items-center justify-between">
               <span
+                className="uppercase"
                 style={{
                   fontSize: '0.75rem',
-                  textTransform: 'uppercase',
                   letterSpacing: '0.05em',
                   color: 'var(--color-muted-foreground)',
                 }}
@@ -625,10 +549,9 @@ export default function GraphExplorerPage() {
               </span>
               <button
                 onClick={() => setDetailOpen(false)}
+                className="cursor-pointer border-none"
                 style={{
                   background: 'none',
-                  border: 'none',
-                  cursor: 'pointer',
                   fontSize: '1rem',
                   color: 'var(--color-muted-foreground)',
                 }}
@@ -649,7 +572,7 @@ export default function GraphExplorerPage() {
                 }}
               />
             ) : (
-              <p style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>Loading details...</p>
+              <p className="muted-text" style={{ fontSize: '0.875rem' }}>Loading details...</p>
             )}
           </div>
         )}
@@ -657,13 +580,11 @@ export default function GraphExplorerPage() {
 
       {/* --- STATUS BAR --- */}
       <div
+        className="flex gap-6 px-4 py-1"
         style={{
-          padding: '0.25rem 1rem',
           borderTop: '1px solid var(--color-border)',
           fontSize: '0.75rem',
           color: 'var(--color-muted-foreground)',
-          display: 'flex',
-          gap: '1.5rem',
           background: 'var(--color-card)',
         }}
       >
@@ -700,51 +621,51 @@ function NarratorDetailPanel({
         <div
           dir="rtl"
           lang="ar"
+          className="mb-1"
           style={{
             fontSize: '1.25rem',
             fontFamily: "var(--font-arabic, 'Noto Naskh Arabic', serif)",
-            marginBottom: '0.25rem',
           }}
         >
           {narrator.name_ar}
         </div>
       )}
-      <div style={{ fontSize: '1rem', fontWeight: 500, marginBottom: '1rem' }}>
+      <div className="mb-4 font-medium" style={{ fontSize: '1rem' }}>
         {narrator.name_en}
       </div>
 
       {/* Metadata */}
-      <div style={{ fontSize: '0.85rem', lineHeight: 1.6, marginBottom: '1rem' }}>
+      <div className="mb-4" style={{ fontSize: '0.85rem', lineHeight: 1.6 }}>
         {narrator.kunya && (
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Kunya:</span> {narrator.kunya}
+            <span className="muted-text">Kunya:</span> {narrator.kunya}
           </div>
         )}
         {narrator.nisba && (
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Nisba:</span> {narrator.nisba}
+            <span className="muted-text">Nisba:</span> {narrator.nisba}
           </div>
         )}
         {narrator.generation && (
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Generation:</span> {narrator.generation}
+            <span className="muted-text">Generation:</span> {narrator.generation}
           </div>
         )}
         <div>
-          <span style={{ color: 'var(--color-muted-foreground)' }}>Birth:</span>{' '}
+          <span className="muted-text">Birth:</span>{' '}
           {narrator.birth_year_ah != null ? `${narrator.birth_year_ah} AH` : '\u2014'}
           {' | '}
-          <span style={{ color: 'var(--color-muted-foreground)' }}>Death:</span>{' '}
+          <span className="muted-text">Death:</span>{' '}
           {narrator.death_year_ah != null ? `${narrator.death_year_ah} AH` : '\u2014'}
         </div>
         {narrator.sect_affiliation && (
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Sect:</span> {narrator.sect_affiliation}
+            <span className="muted-text">Sect:</span> {narrator.sect_affiliation}
           </div>
         )}
         {narrator.trustworthiness_consensus && (
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Trustworthiness:</span>{' '}
+            <span className="muted-text">Trustworthiness:</span>{' '}
             {narrator.trustworthiness_consensus}
           </div>
         )}
@@ -752,53 +673,46 @@ function NarratorDetailPanel({
 
       {/* Network statistics */}
       <div
+        className="mb-4 pt-3"
         style={{
           borderTop: '1px solid var(--color-border)',
-          paddingTop: '0.75rem',
-          marginBottom: '1rem',
         }}
       >
         <div
+          className="mb-2 uppercase"
           style={{
             fontSize: '0.75rem',
-            textTransform: 'uppercase',
             letterSpacing: '0.05em',
             color: 'var(--color-muted-foreground)',
-            marginBottom: '0.5rem',
           }}
         >
           Network Statistics
         </div>
         <div style={{ fontSize: '0.85rem', lineHeight: 1.6 }}>
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Teachers (in):</span> {narrator.in_degree ?? '\u2014'}
+            <span className="muted-text">Teachers (in):</span> {narrator.in_degree ?? '\u2014'}
           </div>
           <div>
-            <span style={{ color: 'var(--color-muted-foreground)' }}>Students (out):</span>{' '}
+            <span className="muted-text">Students (out):</span>{' '}
             {narrator.out_degree ?? '\u2014'}
           </div>
           {narrator.betweenness_centrality != null && (
             <div>
-              <span style={{ color: 'var(--color-muted-foreground)' }}>Betweenness:</span>{' '}
+              <span className="muted-text">Betweenness:</span>{' '}
               {narrator.betweenness_centrality.toFixed(4)}
             </div>
           )}
           {narrator.pagerank != null && (
             <div>
-              <span style={{ color: 'var(--color-muted-foreground)' }}>PageRank:</span> {narrator.pagerank.toFixed(4)}
+              <span className="muted-text">PageRank:</span> {narrator.pagerank.toFixed(4)}
             </div>
           )}
           {narrator.community_id != null && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-              <span style={{ color: 'var(--color-muted-foreground)' }}>Community:</span> {narrator.community_id}
+            <div className="flex items-center gap-1">
+              <span className="muted-text">Community:</span> {narrator.community_id}
               <span
-                style={{
-                  display: 'inline-block',
-                  width: 10,
-                  height: 10,
-                  borderRadius: '50%',
-                  background: communityColor(narrator.community_id),
-                }}
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ background: communityColor(narrator.community_id) }}
               />
             </div>
           )}
@@ -807,24 +721,16 @@ function NarratorDetailPanel({
 
       {/* Chains */}
       <div
+        className="mb-4 pt-3"
         style={{
           borderTop: '1px solid var(--color-border)',
-          paddingTop: '0.75rem',
-          marginBottom: '1rem',
         }}
       >
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: '0.5rem',
-          }}
-        >
+        <div className="mb-2 flex items-center justify-between">
           <span
+            className="uppercase"
             style={{
               fontSize: '0.75rem',
-              textTransform: 'uppercase',
               letterSpacing: '0.05em',
               color: 'var(--color-muted-foreground)',
             }}
@@ -832,37 +738,30 @@ function NarratorDetailPanel({
             Chains ({chainsTotal} total)
           </span>
         </div>
-        <div style={{ maxHeight: 200, overflowY: 'auto' }}>
+        <div className="max-h-[200px] overflow-y-auto">
           {chains.length === 0 && (
-            <div style={{ color: 'var(--color-muted-foreground)', fontSize: '0.85rem' }}>No chains found.</div>
+            <div className="muted-text" style={{ fontSize: '0.85rem' }}>No chains found.</div>
           )}
           {chains.map((c) => (
             <div
               key={c.chain_id}
               onClick={() => onChainSelect(c)}
+              className="cursor-pointer px-0 py-1.5"
               style={{
-                padding: '0.375rem 0',
                 borderBottom: '1px solid var(--color-border)',
-                cursor: 'pointer',
                 fontSize: '0.8rem',
               }}
             >
-              <div style={{ fontWeight: 500 }}>
-                {c.grade && <span style={{ color: 'var(--color-muted-foreground)' }}>[{c.grade}]</span>}{' '}
+              <div className="font-medium">
+                {c.grade && <span className="muted-text">[{c.grade}]</span>}{' '}
                 {c.matn_en || c.hadith_id}
               </div>
               {c.matn_ar && (
                 <div
                   dir="rtl"
                   lang="ar"
-                  style={{
-                    color: 'var(--color-muted-foreground)',
-                    fontSize: '0.75rem',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    maxWidth: '100%',
-                  }}
+                  className="muted-text max-w-full truncate"
+                  style={{ fontSize: '0.75rem' }}
                 >
                   {c.matn_ar}
                 </div>
@@ -875,15 +774,11 @@ function NarratorDetailPanel({
       {/* Link to full profile */}
       <Link
         to={`/narrators/${narrator.id}`}
+        className="block rounded-md p-2 text-center no-underline"
         style={{
-          display: 'block',
-          textAlign: 'center',
           color: 'var(--color-primary)',
           fontSize: '0.85rem',
-          textDecoration: 'none',
-          padding: '0.5rem',
           border: '1px solid var(--color-border)',
-          borderRadius: 'var(--radius-md)',
         }}
       >
         View Full Profile

--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -108,38 +108,34 @@ export default function PricingPage() {
 
   return (
     <div
-      className="min-h-screen px-6 py-10"
-      style={{ background: 'var(--color-background)' }}
+      className="min-h-screen bg-background px-6 py-10"
     >
       <div className="mx-auto max-w-[1200px]">
         {/* Header */}
         <div className="mb-10 text-center">
           <Link
             to="/"
-            className="mb-6 inline-block no-underline"
+            className="mb-6 inline-block text-primary no-underline"
             style={{
               fontFamily: 'var(--font-heading)',
               fontSize: 'var(--text-sm)',
-              color: 'var(--color-primary)',
             }}
           >
             &larr; Back to Isnad Graph
           </Link>
           <h1
-            className="mb-3 font-bold"
+            className="mb-3 font-bold text-foreground"
             style={{
               fontFamily: 'var(--font-heading)',
               fontSize: 'var(--text-3xl)',
-              color: 'var(--color-foreground)',
             }}
           >
             Choose your plan
           </h1>
           <p
-            className="mx-auto mb-8 max-w-[600px]"
+            className="mx-auto mb-8 max-w-[600px] text-muted-foreground"
             style={{
               fontSize: 'var(--text-lg)',
-              color: 'var(--color-muted-foreground)',
               lineHeight: 1.6,
             }}
           >
@@ -148,10 +144,7 @@ export default function PricingPage() {
           </p>
 
           {/* Billing toggle */}
-          <div
-            className="inline-flex items-center gap-3 rounded-full p-1"
-            style={{ background: 'var(--color-accent)' }}
-          >
+          <div className="inline-flex items-center gap-3 rounded-full bg-accent p-1">
             <button
               onClick={() => setInterval('monthly')}
               className="cursor-pointer rounded-full border-none px-5 py-2 font-semibold"
@@ -190,11 +183,9 @@ export default function PricingPage() {
             >
               Annual
               <span
-                className="ml-2 rounded-full px-2 py-0.5 font-bold"
+                className="ml-2 rounded-full bg-primary px-2 py-0.5 font-bold text-primary-foreground"
                 style={{
                   fontSize: 'var(--text-xs)',
-                  background: 'var(--color-primary)',
-                  color: 'var(--color-primary-foreground)',
                 }}
               >
                 Save 17%
@@ -217,9 +208,8 @@ export default function PricingPage() {
             return (
               <div
                 key={tier.id}
-                className="relative flex flex-col rounded-xl p-8"
+                className="relative flex flex-col rounded-xl bg-card p-8"
                 style={{
-                  background: 'var(--color-card)',
                   border: tier.popular
                     ? '2px solid var(--color-primary)'
                     : 'var(--border-width-thin) solid var(--color-border)',
@@ -228,7 +218,7 @@ export default function PricingPage() {
               >
                 {tier.popular && (
                   <div
-                    className="absolute rounded-full px-4 py-1 font-bold uppercase whitespace-nowrap"
+                    className="absolute rounded-full bg-primary px-4 py-1 font-bold text-primary-foreground uppercase whitespace-nowrap"
                     style={{
                       top: -12,
                       left: '50%',
@@ -236,8 +226,6 @@ export default function PricingPage() {
                       fontSize: 'var(--text-xs)',
                       fontFamily: 'var(--font-heading)',
                       letterSpacing: '0.05em',
-                      background: 'var(--color-primary)',
-                      color: 'var(--color-primary-foreground)',
                     }}
                   >
                     Most popular
@@ -245,21 +233,19 @@ export default function PricingPage() {
                 )}
 
                 <h2
-                  className="mb-1 font-bold"
+                  className="mb-1 font-bold text-foreground"
                   style={{
                     fontFamily: 'var(--font-heading)',
                     fontSize: 'var(--text-xl)',
-                    color: 'var(--color-foreground)',
                   }}
                 >
                   {tier.name}
                 </h2>
 
                 <p
-                  className="mb-6"
+                  className="mb-6 text-muted-foreground"
                   style={{
                     fontSize: 'var(--text-sm)',
-                    color: 'var(--color-muted-foreground)',
                   }}
                 >
                   {tier.description}
@@ -268,11 +254,10 @@ export default function PricingPage() {
                 <div className="mb-6">
                   {isEnterprise ? (
                     <span
-                      className="font-bold"
+                      className="font-bold text-foreground"
                       style={{
                         fontFamily: 'var(--font-heading)',
                         fontSize: 'var(--text-3xl)',
-                        color: 'var(--color-foreground)',
                       }}
                     >
                       Custom
@@ -280,21 +265,19 @@ export default function PricingPage() {
                   ) : (
                     <>
                       <span
-                        className="font-bold"
+                        className="font-bold text-foreground"
                         style={{
                           fontFamily: 'var(--font-heading)',
                           fontSize: 'var(--text-3xl)',
-                          color: 'var(--color-foreground)',
                         }}
                       >
                         {formatPrice(tier.monthlyPrice!, interval)}
                       </span>
                       {tier.monthlyPrice! > 0 && (
                         <span
-                          className="ml-1"
+                          className="ml-1 text-muted-foreground"
                           style={{
                             fontSize: 'var(--text-sm)',
-                            color: 'var(--color-muted-foreground)',
                           }}
                         >
                           /mo{tier.id === 'team' ? '/user' : ''}
@@ -302,10 +285,9 @@ export default function PricingPage() {
                       )}
                       {tier.monthlyPrice! > 0 && interval === 'annual' && (
                         <div
-                          className="mt-1"
+                          className="mt-1 text-muted-foreground"
                           style={{
                             fontSize: 'var(--text-xs)',
-                            color: 'var(--color-muted-foreground)',
                           }}
                         >
                           Billed annually (${(tier.monthlyPrice! * 10).toFixed(2)}/year)
@@ -318,12 +300,10 @@ export default function PricingPage() {
                 {/* CTA */}
                 {isCurrent ? (
                   <div
-                    className="mb-6 rounded-md p-3 text-center font-semibold"
+                    className="mb-6 rounded-md border-2 border-primary p-3 text-center font-semibold text-primary"
                     style={{
-                      border: '2px solid var(--color-primary)',
                       fontFamily: 'var(--font-body)',
                       fontSize: 'var(--text-sm)',
-                      color: 'var(--color-primary)',
                     }}
                   >
                     Current plan
@@ -331,12 +311,10 @@ export default function PricingPage() {
                 ) : isEnterprise ? (
                   <a
                     href="mailto:contact@noorinalabs.com?subject=Enterprise%20inquiry"
-                    className="mb-6 block rounded-md p-3 text-center font-semibold no-underline"
+                    className="mb-6 block rounded-md bg-accent p-3 text-center font-semibold text-foreground no-underline"
                     style={{
-                      background: 'var(--color-accent)',
                       fontFamily: 'var(--font-body)',
                       fontSize: 'var(--text-sm)',
-                      color: 'var(--color-foreground)',
                       transition: 'opacity var(--duration-fast) var(--ease-default)',
                     }}
                   >
@@ -368,10 +346,9 @@ export default function PricingPage() {
                   {tier.features.map((feature) => (
                     <li
                       key={feature}
-                      className="flex items-start gap-2"
+                      className="flex items-start gap-2 text-foreground"
                       style={{
                         fontSize: 'var(--text-sm)',
-                        color: 'var(--color-foreground)',
                       }}
                     >
                       <CheckIcon />

--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -95,7 +95,7 @@ function CheckIcon() {
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
-      style={{ flexShrink: 0, marginTop: 2 }}
+      className="shrink-0 mt-0.5"
     >
       <polyline points="20 6 9 17 4 12" />
     </svg>
@@ -108,45 +108,38 @@ export default function PricingPage() {
 
   return (
     <div
-      style={{
-        minHeight: '100vh',
-        background: 'var(--color-background)',
-        padding: 'var(--spacing-10) var(--spacing-6)',
-      }}
+      className="min-h-screen px-6 py-10"
+      style={{ background: 'var(--color-background)' }}
     >
-      <div style={{ maxWidth: 1200, margin: '0 auto' }}>
+      <div className="mx-auto max-w-[1200px]">
         {/* Header */}
-        <div style={{ textAlign: 'center', marginBottom: 'var(--spacing-10)' }}>
+        <div className="mb-10 text-center">
           <Link
             to="/"
+            className="mb-6 inline-block no-underline"
             style={{
-              display: 'inline-block',
-              marginBottom: 'var(--spacing-6)',
               fontFamily: 'var(--font-heading)',
               fontSize: 'var(--text-sm)',
               color: 'var(--color-primary)',
-              textDecoration: 'none',
             }}
           >
             &larr; Back to Isnad Graph
           </Link>
           <h1
+            className="mb-3 font-bold"
             style={{
               fontFamily: 'var(--font-heading)',
               fontSize: 'var(--text-3xl)',
-              fontWeight: 700,
               color: 'var(--color-foreground)',
-              marginBottom: 'var(--spacing-3)',
             }}
           >
             Choose your plan
           </h1>
           <p
+            className="mx-auto mb-8 max-w-[600px]"
             style={{
               fontSize: 'var(--text-lg)',
               color: 'var(--color-muted-foreground)',
-              maxWidth: 600,
-              margin: '0 auto var(--spacing-8)',
               lineHeight: 1.6,
             }}
           >
@@ -156,25 +149,15 @@ export default function PricingPage() {
 
           {/* Billing toggle */}
           <div
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 'var(--spacing-3)',
-              padding: 'var(--spacing-1)',
-              background: 'var(--color-accent)',
-              borderRadius: 'var(--radius-full)',
-            }}
+            className="inline-flex items-center gap-3 rounded-full p-1"
+            style={{ background: 'var(--color-accent)' }}
           >
             <button
               onClick={() => setInterval('monthly')}
+              className="cursor-pointer rounded-full border-none px-5 py-2 font-semibold"
               style={{
-                padding: 'var(--spacing-2) var(--spacing-5)',
-                borderRadius: 'var(--radius-full)',
-                border: 'none',
                 fontFamily: 'var(--font-body)',
                 fontSize: 'var(--text-sm)',
-                fontWeight: 600,
-                cursor: 'pointer',
                 background:
                   interval === 'monthly' ? 'var(--color-card)' : 'transparent',
                 color:
@@ -190,14 +173,10 @@ export default function PricingPage() {
             </button>
             <button
               onClick={() => setInterval('annual')}
+              className="cursor-pointer rounded-full border-none px-5 py-2 font-semibold"
               style={{
-                padding: 'var(--spacing-2) var(--spacing-5)',
-                borderRadius: 'var(--radius-full)',
-                border: 'none',
                 fontFamily: 'var(--font-body)',
                 fontSize: 'var(--text-sm)',
-                fontWeight: 600,
-                cursor: 'pointer',
                 background:
                   interval === 'annual' ? 'var(--color-card)' : 'transparent',
                 color:
@@ -211,12 +190,9 @@ export default function PricingPage() {
             >
               Annual
               <span
+                className="ml-2 rounded-full px-2 py-0.5 font-bold"
                 style={{
-                  marginLeft: 'var(--spacing-2)',
-                  padding: 'var(--spacing-0_5) var(--spacing-2)',
                   fontSize: 'var(--text-xs)',
-                  fontWeight: 700,
-                  borderRadius: 'var(--radius-full)',
                   background: 'var(--color-primary)',
                   color: 'var(--color-primary-foreground)',
                 }}
@@ -229,12 +205,9 @@ export default function PricingPage() {
 
         {/* Tier cards */}
         <div
+          className="mx-auto grid gap-6 max-w-[1100px]"
           style={{
-            display: 'grid',
             gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
-            gap: 'var(--spacing-6)',
-            maxWidth: 1100,
-            margin: '0 auto',
           }}
         >
           {tiers.map((tier) => {
@@ -244,36 +217,27 @@ export default function PricingPage() {
             return (
               <div
                 key={tier.id}
+                className="relative flex flex-col rounded-xl p-8"
                 style={{
-                  position: 'relative',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  padding: 'var(--spacing-8)',
                   background: 'var(--color-card)',
                   border: tier.popular
                     ? '2px solid var(--color-primary)'
                     : 'var(--border-width-thin) solid var(--color-border)',
-                  borderRadius: 'var(--radius-xl)',
                   boxShadow: tier.popular ? 'var(--shadow-lg)' : 'var(--shadow-sm)',
                 }}
               >
                 {tier.popular && (
                   <div
+                    className="absolute rounded-full px-4 py-1 font-bold uppercase whitespace-nowrap"
                     style={{
-                      position: 'absolute',
                       top: -12,
                       left: '50%',
                       transform: 'translateX(-50%)',
-                      padding: 'var(--spacing-1) var(--spacing-4)',
                       fontSize: 'var(--text-xs)',
-                      fontWeight: 700,
                       fontFamily: 'var(--font-heading)',
-                      textTransform: 'uppercase',
                       letterSpacing: '0.05em',
-                      borderRadius: 'var(--radius-full)',
                       background: 'var(--color-primary)',
                       color: 'var(--color-primary-foreground)',
-                      whiteSpace: 'nowrap',
                     }}
                   >
                     Most popular
@@ -281,38 +245,33 @@ export default function PricingPage() {
                 )}
 
                 <h2
+                  className="mb-1 font-bold"
                   style={{
                     fontFamily: 'var(--font-heading)',
                     fontSize: 'var(--text-xl)',
-                    fontWeight: 700,
                     color: 'var(--color-foreground)',
-                    marginBottom: 'var(--spacing-1)',
                   }}
                 >
                   {tier.name}
                 </h2>
 
                 <p
+                  className="mb-6"
                   style={{
                     fontSize: 'var(--text-sm)',
                     color: 'var(--color-muted-foreground)',
-                    marginBottom: 'var(--spacing-6)',
                   }}
                 >
                   {tier.description}
                 </p>
 
-                <div
-                  style={{
-                    marginBottom: 'var(--spacing-6)',
-                  }}
-                >
+                <div className="mb-6">
                   {isEnterprise ? (
                     <span
+                      className="font-bold"
                       style={{
                         fontFamily: 'var(--font-heading)',
                         fontSize: 'var(--text-3xl)',
-                        fontWeight: 700,
                         color: 'var(--color-foreground)',
                       }}
                     >
@@ -321,10 +280,10 @@ export default function PricingPage() {
                   ) : (
                     <>
                       <span
+                        className="font-bold"
                         style={{
                           fontFamily: 'var(--font-heading)',
                           fontSize: 'var(--text-3xl)',
-                          fontWeight: 700,
                           color: 'var(--color-foreground)',
                         }}
                       >
@@ -332,10 +291,10 @@ export default function PricingPage() {
                       </span>
                       {tier.monthlyPrice! > 0 && (
                         <span
+                          className="ml-1"
                           style={{
                             fontSize: 'var(--text-sm)',
                             color: 'var(--color-muted-foreground)',
-                            marginLeft: 'var(--spacing-1)',
                           }}
                         >
                           /mo{tier.id === 'team' ? '/user' : ''}
@@ -343,10 +302,10 @@ export default function PricingPage() {
                       )}
                       {tier.monthlyPrice! > 0 && interval === 'annual' && (
                         <div
+                          className="mt-1"
                           style={{
                             fontSize: 'var(--text-xs)',
                             color: 'var(--color-muted-foreground)',
-                            marginTop: 'var(--spacing-1)',
                           }}
                         >
                           Billed annually (${(tier.monthlyPrice! * 10).toFixed(2)}/year)
@@ -359,16 +318,12 @@ export default function PricingPage() {
                 {/* CTA */}
                 {isCurrent ? (
                   <div
+                    className="mb-6 rounded-md p-3 text-center font-semibold"
                     style={{
-                      padding: 'var(--spacing-3)',
-                      borderRadius: 'var(--radius-md)',
                       border: '2px solid var(--color-primary)',
-                      textAlign: 'center',
                       fontFamily: 'var(--font-body)',
                       fontSize: 'var(--text-sm)',
-                      fontWeight: 600,
                       color: 'var(--color-primary)',
-                      marginBottom: 'var(--spacing-6)',
                     }}
                   >
                     Current plan
@@ -376,18 +331,12 @@ export default function PricingPage() {
                 ) : isEnterprise ? (
                   <a
                     href="mailto:contact@noorinalabs.com?subject=Enterprise%20inquiry"
+                    className="mb-6 block rounded-md p-3 text-center font-semibold no-underline"
                     style={{
-                      display: 'block',
-                      padding: 'var(--spacing-3)',
-                      borderRadius: 'var(--radius-md)',
                       background: 'var(--color-accent)',
-                      textAlign: 'center',
                       fontFamily: 'var(--font-body)',
                       fontSize: 'var(--text-sm)',
-                      fontWeight: 600,
                       color: 'var(--color-foreground)',
-                      textDecoration: 'none',
-                      marginBottom: 'var(--spacing-6)',
                       transition: 'opacity var(--duration-fast) var(--ease-default)',
                     }}
                   >
@@ -397,22 +346,16 @@ export default function PricingPage() {
                   <Link
                     to="/billing/checkout"
                     state={{ tier: tier.id, interval }}
+                    className="mb-6 block rounded-md p-3 text-center font-semibold no-underline"
                     style={{
-                      display: 'block',
-                      padding: 'var(--spacing-3)',
-                      borderRadius: 'var(--radius-md)',
                       background: tier.popular
                         ? 'var(--color-primary)'
                         : 'var(--color-accent)',
-                      textAlign: 'center',
                       fontFamily: 'var(--font-body)',
                       fontSize: 'var(--text-sm)',
-                      fontWeight: 600,
                       color: tier.popular
                         ? 'var(--color-primary-foreground)'
                         : 'var(--color-foreground)',
-                      textDecoration: 'none',
-                      marginBottom: 'var(--spacing-6)',
                       transition: 'opacity var(--duration-fast) var(--ease-default)',
                     }}
                   >
@@ -421,24 +364,12 @@ export default function PricingPage() {
                 )}
 
                 {/* Features */}
-                <ul
-                  style={{
-                    listStyle: 'none',
-                    padding: 0,
-                    margin: 0,
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--spacing-3)',
-                  }}
-                >
+                <ul className="m-0 flex flex-1 list-none flex-col gap-3 p-0">
                   {tier.features.map((feature) => (
                     <li
                       key={feature}
+                      className="flex items-start gap-2"
                       style={{
-                        display: 'flex',
-                        alignItems: 'flex-start',
-                        gap: 'var(--spacing-2)',
                         fontSize: 'var(--text-sm)',
                         color: 'var(--color-foreground)',
                       }}

--- a/frontend/src/pages/admin/UserManagementPage.tsx
+++ b/frontend/src/pages/admin/UserManagementPage.tsx
@@ -75,9 +75,9 @@ export default function UserManagementPage() {
 
   return (
     <div>
-      <div style={{ marginBottom: '1rem' }}>
+      <div className="mb-4">
         <h2>User Management</h2>
-        <p style={{ fontSize: 'var(--text-sm)', color: 'var(--color-muted-foreground)' }}>
+        <p className="small-muted">
           Users and roles are managed by the user-service. Admin access requires
           the <code>admin</code> role on your user-service account.
         </p>
@@ -106,15 +106,12 @@ export default function UserManagementPage() {
                     <td>
                       <button
                         onClick={() => setDetailUserId(u.id)}
+                        className="cursor-pointer border-none p-0 underline"
                         style={{
                           background: 'none',
-                          border: 'none',
-                          cursor: 'pointer',
                           color: 'var(--color-primary)',
-                          textDecoration: 'underline',
                           fontFamily: 'inherit',
                           fontSize: 'inherit',
-                          padding: 0,
                         }}
                       >
                         {u.display_name ?? u.email}
@@ -128,7 +125,7 @@ export default function UserManagementPage() {
                     </td>
                     <td>
                       <select
-                        className="form-input"
+                        className="form-input w-[130px] p-1"
                         value={deriveHighestRole(currentRoles)}
                         onChange={(e) =>
                           roleMutation.mutate({
@@ -139,7 +136,6 @@ export default function UserManagementPage() {
                         }
                         disabled={roleMutation.isPending || !roles}
                         aria-label={`Role for ${u.display_name ?? u.email}`}
-                        style={{ width: 130, padding: '0.25rem' }}
                       >
                         {roleOptions.map((r) => (
                           <option key={r} value={r}>
@@ -174,32 +170,22 @@ export default function UserManagementPage() {
 
       {detailUserId && userDetail && (
         <div
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0,0,0,0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 100,
-          }}
+          className="fixed inset-0 z-[100] flex items-center justify-center"
+          style={{ background: 'rgba(0,0,0,0.5)' }}
           onClick={() => setDetailUserId(null)}
         >
           <div
+            className="rounded-lg p-6 min-w-[400px] max-w-[600px]"
             style={{
               background: 'var(--color-card)',
-              borderRadius: 'var(--radius-lg)',
-              padding: 'var(--spacing-6)',
-              minWidth: 400,
-              maxWidth: 600,
               boxShadow: 'var(--shadow-lg)',
             }}
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 style={{ marginBottom: 'var(--spacing-4)', fontFamily: 'var(--font-heading)' }}>
+            <h3 className="mb-4" style={{ fontFamily: 'var(--font-heading)' }}>
               User Detail
             </h3>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--spacing-3)' }}>
+            <div className="grid gap-3" style={{ gridTemplateColumns: '1fr 1fr' }}>
               <DetailField label="Name" value={userDetail.display_name ?? '—'} />
               <DetailField label="Email" value={userDetail.email} />
               <DetailField
@@ -218,9 +204,8 @@ export default function UserManagementPage() {
               />
             </div>
             <button
-              className="btn"
+              className="btn mt-4"
               onClick={() => setDetailUserId(null)}
-              style={{ marginTop: 'var(--spacing-4)' }}
             >
               Close
             </button>
@@ -237,7 +222,7 @@ function DetailField({ label, value }: { label: string; value: string }) {
       <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>
         {label}
       </div>
-      <div style={{ fontWeight: 500 }}>{value}</div>
+      <div className="font-medium">{value}</div>
     </div>
   )
 }

--- a/frontend/src/pages/admin/UserManagementPage.tsx
+++ b/frontend/src/pages/admin/UserManagementPage.tsx
@@ -106,10 +106,9 @@ export default function UserManagementPage() {
                     <td>
                       <button
                         onClick={() => setDetailUserId(u.id)}
-                        className="cursor-pointer border-none p-0 underline"
+                        className="cursor-pointer border-none p-0 text-primary underline"
                         style={{
                           background: 'none',
-                          color: 'var(--color-primary)',
                           fontFamily: 'inherit',
                           fontSize: 'inherit',
                         }}
@@ -175,9 +174,8 @@ export default function UserManagementPage() {
           onClick={() => setDetailUserId(null)}
         >
           <div
-            className="rounded-lg p-6 min-w-[400px] max-w-[600px]"
+            className="rounded-lg bg-card p-6 min-w-[400px] max-w-[600px]"
             style={{
-              background: 'var(--color-card)',
               boxShadow: 'var(--shadow-lg)',
             }}
             onClick={(e) => e.stopPropagation()}
@@ -219,7 +217,7 @@ export default function UserManagementPage() {
 function DetailField({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <div style={{ fontSize: 'var(--text-xs)', color: 'var(--color-muted-foreground)' }}>
+      <div className="text-muted-foreground" style={{ fontSize: 'var(--text-xs)' }}>
         {label}
       </div>
       <div className="font-medium">{value}</div>


### PR DESCRIPTION
Closes #981 — the full inline-style migration of the three heaviest files, off the merged #1000 `@theme` color bridge (f3fffb4). Single PR carrying the complete #967 bucket D work. (Supersedes the earlier conservative draft, now closed.)

## What migrated → DS / Tailwind utilities
- **Color / background / border-color → atomic DS utilities** (the bridge makes them resolve):
  - `color: var(--color-X)` → `text-X` (`text-foreground`/`text-muted-foreground`/`text-primary`/`text-primary-foreground`/`text-warning-foreground`)
  - `background: var(--color-X)` → `bg-X` (`bg-card`/`bg-background`/`bg-accent`/`bg-primary`/`bg-warning`)
  - `border: 1px solid var(--color-border)` → `border border-border` (plus `border-2 border-primary`, `border-t/b/l border-border`)
- **Layout / spacing / radius / display / flex / font-weight** → Tailwind-native utilities (1:1 verified; DS spacing scale == Tailwind scale; radius → `var(--radius-*)`; font-weight tokens == numerics).
- **Whole elements → DS component classes** where the rule matches property-for-property (`.muted-text`, `.small-muted`).
- Net **~−290 lines** across the 3 files.

## Kept inline (intentional)
- **Conditional / state-dependent** values: active-tab `background`/`color`, popular-tier `border`, depth/layout active state.
- **Genuinely-dynamic** graph-overlay positions (tooltip/legend/zoom coords, `right: detailOpen ? 340 : 12`).
- **font-size** (Tailwind `text-*` forces a paired line-height the inline value didn't set), **box-shadow / font-family** (Tailwind maps to its own scales), letter-spacing, transition.
- **SVG `fill`/`stroke` presentation attributes** (legend swatches, check icon) — not inline `style={{}}` objects.

After this, the only remaining `var(--color-*)` in these files are conditionals and SVG presentation attributes (verified).

## Files
- `frontend/src/pages/GraphExplorerPage.tsx`
- `frontend/src/pages/PricingPage.tsx`
- `frontend/src/pages/admin/UserManagementPage.tsx`

## Verification (real, light + dark)
- **CSS-level:** every introduced utility (17 distinct color utilities + the layout set) generates a real rule in the built bundle — none a silent no-op.
- **Headless browser (Playwright Chromium), `/pricing`, light AND dark** — computed styles match the DS token values exactly:
  | element / class | light | dark |
  |---|---|---|
  | `h1.text-foreground` | `oklch(0.25 0.02 260)` | `oklch(0.92 0.01 85)` |
  | tier card `.bg-card` | bg `oklch(0.99 0.005 85)`, border `oklch(0.85 0.01 85)` | bg `oklch(0.25 0.015 260)`, border `oklch(0.35 0.01 260)` |
  | badge `.bg-primary.text-primary-foreground` | `oklch(0.55 0.14 45)` / white | `oklch(0.65 0.14 45)` / dark |
  | back-link `.text-primary` | `oklch(0.55 0.14 45)` | `oklch(0.65 0.14 45)` |
- `npm run build` (tsc+vite) green; `npm run lint` 0 errors (1 pre-existing `set-state-in-effect` warning, untouched); `npm run test` **186/186** pass.

## Reviewers
@Ravi Desai (DS-utility composition), @Junseo Park (code).
