### PR TITLE
fix(frontend): re-pin nginx base digest to clear openssl CVE-2026-45447 (Closes #1005)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,7 +22,7 @@ RUN npm run build
 # the starting layer; the upgrade step keeps OS packages current within the
 # alpine 3.23 patch lifecycle. Re-pin to a newer digest on each minor nginx
 # bump (or alpine 3.24+ when nginx publishes it).
-FROM nginx:stable-alpine3.23@sha256:0272e4604ed93c1792f03695a033a6e8546840f86e0de20a884bb17d2c924883
+FROM nginx:stable-alpine3.23@sha256:5f979dcfed4ce6461873f087e8c980d6e29b084b9e8776d9704a7e989b5f4898
 # gettext provides `envsubst`, used by entrypoint.sh to render runtime-config.js
 # from its template at container start (isnad-graph#932).
 RUN apk upgrade --no-cache && apk add --no-cache gettext


### PR DESCRIPTION
## What
Re-pin the frontend runtime base `nginx:stable-alpine3.23` digest `0272e46` → `5f979dc` (still stable-alpine3.23, current latest).

## Why
The P4W4→main merge's `Publish to GHCR` went RED: Trivy flagged **CVE-2026-45447** (HIGH, openssl `libcrypto3`/`libssl3` 3.5.6-r0, fixed in 3.5.7-r0). Root cause is **a stale cached `apk upgrade --no-cache` layer** in CI buildx — built when 3.5.6-r0 was latest. Verified locally: a fresh `apk upgrade` on BOTH the old and new alpine-3.23 digest yields the patched **3.5.7-r0**, so the alpine 3.23 repo already carries the fix; the image just needs the cached layer busted. Bumping the `FROM` digest invalidates that layer → `apk upgrade` re-runs → patched openssl ships.

## Verification
```
docker run --rm nginx:stable-alpine3.23@sha256:5f979dc sh -c 'apk upgrade --no-cache; apk info -v | grep -E "^libcrypto3|^libssl3"'
# → libcrypto3-3.5.7-r0 / libssl3-3.5.7-r0
```

## Blast radius
Frontend image only. The api (`python:3.14-slim`) and user-service (`python:3.12-slim`) are Debian-based — not affected by this Alpine openssl CVE.

## Test Plan (post-merge)
- `Publish to GHCR` on main goes green (Trivy clean), `deploy-stg.yml` dispatches, and staging serves the P4W4 frontend (the DS color system + i18n that are currently merged but not yet on staging).

Closes #1005