### PR TITLE
fix(frontend): parse /auth/providers object shape so Google/GitHub sign-in buttons render (Closes #1007)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -92,8 +92,12 @@ export default function LoginPage() {
 
   useEffect(() => {
     fetch(`${AUTH_BASE}/providers`)
-      .then((res) => (res.ok ? readJsonResponse<string[]>(res) : Promise.reject(res)))
-      .then((data) => setProviders(data))
+      .then((res) =>
+        res.ok
+          ? readJsonResponse<{ providers: { id: string; enabled: boolean }[] }>(res)
+          : Promise.reject(res),
+      )
+      .then((data) => setProviders(data.providers.filter((p) => p.enabled).map((p) => p.id)))
       .catch(() => setProviders(['google', 'github']))
   }, [])
 

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -12,6 +12,19 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
+// Real providers response shape returned by GET /auth/providers.
+function providersResponse(
+  overrides: { id: string; type: string; enabled: boolean }[] = [
+    { id: 'email', type: 'password', enabled: true },
+    { id: 'google', type: 'oauth', enabled: true },
+    { id: 'github', type: 'oauth', enabled: true },
+    { id: 'apple', type: 'oauth', enabled: false },
+    { id: 'facebook', type: 'oauth', enabled: false },
+  ],
+): Response {
+  return jsonResponse({ providers: overrides })
+}
+
 // A reverse-proxy fallback / stale-runtime-config misroute: the SPA's own
 // index.html served with HTTP 200 and a text/html content-type instead of the
 // auth JSON. This is the deploy#420 failure class.
@@ -30,6 +43,66 @@ function renderLogin() {
   )
 }
 
+describe('LoginPage — /auth/providers object-shape parsing (#1007)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders Google and GitHub buttons and hides apple/facebook (enabled:false)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(providersResponse())),
+    )
+
+    renderLogin()
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in with Google')).toBeInTheDocument()
+      expect(screen.getByText('Sign in with GitHub')).toBeInTheDocument()
+    })
+    // apple and facebook are disabled — no button for them
+    expect(screen.queryByText(/apple/i)).toBeNull()
+    expect(screen.queryByText(/facebook/i)).toBeNull()
+  })
+
+  it('filters only enabled providers from the object response', async () => {
+    // Feed the exact real-shape with only google enabled
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          providersResponse([
+            { id: 'google', type: 'oauth', enabled: true },
+            { id: 'github', type: 'oauth', enabled: false },
+            { id: 'apple', type: 'oauth', enabled: false },
+          ]),
+        ),
+      ),
+    )
+
+    renderLogin()
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in with Google')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Sign in with GitHub')).toBeNull()
+  })
+
+  it('falls back to google+github when the endpoint fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('network error'))),
+    )
+
+    renderLogin()
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in with Google')).toBeInTheDocument()
+      expect(screen.getByText('Sign in with GitHub')).toBeInTheDocument()
+    })
+  })
+})
+
 describe('LoginPage — non-JSON auth response guard (#977)', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -42,7 +115,7 @@ describe('LoginPage — non-JSON auth response guard (#977)', () => {
   it('surfaces a clean error (not a raw parse throw) when email login is misrouted to HTML', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
-      if (url.endsWith('/auth/providers')) return Promise.resolve(jsonResponse(['google']))
+      if (url.endsWith('/auth/providers')) return Promise.resolve(providersResponse())
       if (url.endsWith('/auth/login/email')) return Promise.resolve(htmlResponse())
       return Promise.reject(new Error(`unexpected fetch: ${url}`))
     })
@@ -71,7 +144,7 @@ describe('LoginPage — non-JSON auth response guard (#977)', () => {
   it('still completes a genuine JSON login', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
-      if (url.endsWith('/auth/providers')) return Promise.resolve(jsonResponse(['google']))
+      if (url.endsWith('/auth/providers')) return Promise.resolve(providersResponse())
       if (url.endsWith('/auth/login/email'))
         return Promise.resolve(jsonResponse({ access_token: 'real-token' }))
       return Promise.reject(new Error(`unexpected fetch: ${url}`))


### PR DESCRIPTION
## Root cause

`GET /auth/providers` returns an **object**:
```json
{"providers":[{"id":"email","type":"password","enabled":true},{"id":"google","type":"oauth","enabled":true},{"id":"github","type":"oauth","enabled":true},{"id":"apple","type":"oauth","enabled":false},{"id":"facebook","type":"oauth","enabled":false}]}
```

`LoginPage` called `readJsonResponse<string[]>(res)` — a compile-time cast only. At runtime `providers` became the raw object `{providers:[...]}`. The render gate `providers.length > 0` evaluated as `undefined > 0` → `false`, so the OAuth button block rendered `null`. The `.catch` fallback never fired because the fetch succeeded with valid JSON.

## Fix

- Widen the generic to `readJsonResponse<{ providers: { id: string; enabled: boolean }[] }>(res)`
- Map through `.filter(p => p.enabled).map(p => p.id)` before calling `setProviders`

Restores Google + GitHub buttons (enabled). Auto-hides apple/facebook (enabled:false). The `.catch` fallback is kept as-is.

No generated type exists for `/auth/providers` in `src/types/user-service.d.ts` (newer endpoint, not yet in OpenAPI snapshot) — inline type used.

## Files changed

- `frontend/src/pages/LoginPage.tsx` — fix providers useEffect parse
- `frontend/src/pages/__tests__/LoginPage.test.tsx` — add `#1007` suite (3 tests); update existing `#977` mocks from flat `string[]` to correct object shape

## Test plan

- [ ] `npm run test` (vitest) — 189/189 pass, including new `LoginPage — /auth/providers object-shape parsing (#1007)` suite:
  - renders Google + GitHub buttons, hides apple/facebook (enabled:false)
  - filters only enabled providers from object response
  - falls back to google+github on network error
- [ ] `npm run lint` (eslint) — 0 errors (11 pre-existing warnings in unrelated files)
- [ ] `tsc --noEmit` — passes clean

---
TechDebt: none