### PR TITLE
fix(frontend): substitute ${INGEST_PLATFORM_ORIGIN} in runtime-config + fail-fast guard (Closes #1008)

### DIFF
--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -4,10 +4,10 @@
 # final Dockerfile stage) substitutes only the variables we name explicitly so
 # stray `$`-sequences elsewhere are left untouched.
 #
-# USER_SERVICE_ORIGIN is supplied by the compose `environment:` block
-# (noorinalabs-deploy, templated per env via write-deploy-env). When unset it
-# substitutes to the empty string, preserving the same-origin fallback that the
-# transitional dual-bind relied on. See isnad-graph#932 / deploy#245 step 5.
+# USER_SERVICE_ORIGIN and INGEST_PLATFORM_ORIGIN are supplied by the compose
+# `environment:` block (noorinalabs-deploy, templated per env via
+# write-deploy-env). When unset they substitute to the empty string.
+# See isnad-graph#932 / deploy#245 step 5.
 set -eu
 
 TEMPLATE=/runtime-config.js.template
@@ -20,10 +20,19 @@ TEMPLATE=/runtime-config.js.template
 OUTPUT=/tmp/runtime-config.js
 
 # The single-quoted SHELL-FORMAT argument is deliberate: it is an envsubst
-# allowlist, not a shell expansion. Only ${USER_SERVICE_ORIGIN} is substituted;
+# allowlist, not a shell expansion. Only the listed variables are substituted;
 # every other `$`-sequence in the template is left verbatim. shellcheck SC2016
 # would have us double-quote it, which would break the intended behaviour.
 # shellcheck disable=SC2016
-envsubst '${USER_SERVICE_ORIGIN}' < "$TEMPLATE" > "$OUTPUT"
+envsubst '${USER_SERVICE_ORIGIN}${INGEST_PLATFORM_ORIGIN}' < "$TEMPLATE" > "$OUTPUT"
+
+# Fail fast if any ${…} placeholder survived substitution unchanged. A residual
+# placeholder means a variable was not listed in the allowlist above (or the
+# compose environment block is missing a binding). Shipping silently would serve
+# a malformed runtime-config to every client. See ig#1008.
+if grep -qF '${' "$OUTPUT"; then
+    printf 'entrypoint: ERROR: unsubstituted variable(s) remain in %s -- add missing var to envsubst allowlist\n' "$OUTPUT" >&2
+    exit 1
+fi
 
 exec "$@"

--- a/frontend/src/__tests__/entrypoint.test.ts
+++ b/frontend/src/__tests__/entrypoint.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+// Import the actual source files as raw strings via Vite's ?raw suffix so
+// the test runs against the committed text without needing @types/node.
+import entrypointSrc from '../../entrypoint.sh?raw'
+import templateSrc from '../../runtime-config.js.template?raw'
+
+/**
+ * Guards the envsubst allowlist in entrypoint.sh against template drift (#1008).
+ *
+ * Root cause: runtime-config.js.template added ${INGEST_PLATFORM_ORIGIN} but the
+ * envsubst allowlist was '${USER_SERVICE_ORIGIN}' only, so the placeholder shipped
+ * verbatim. This test catches the whole class by asserting that every ${VAR}
+ * reference in the template is present in the allowlist.
+ */
+
+/** Extract bare var names from every ${UPPER_CASE_VAR} occurrence in a string. */
+function extractVarRefs(text: string): string[] {
+  return [...text.matchAll(/\$\{([A-Z][A-Z0-9_]*)\}/g)]
+    .map((m) => m[1])
+    .filter((v): v is string => v !== undefined)
+}
+
+describe('entrypoint.sh — envsubst allowlist covers all template vars (#1008)', () => {
+  it('template vars ⊆ allowlist (no placeholder can ship as a literal)', () => {
+    const templateVars = extractVarRefs(templateSrc)
+    expect(templateVars.length, 'template should reference at least one variable').toBeGreaterThan(0)
+
+    // Extract the single-quoted allowlist argument: envsubst '${VAR1}${VAR2}' < "$TEMPLATE" > "$OUTPUT"
+    const allowlistMatch = entrypointSrc.match(/envsubst\s+'([^']+)'/)
+    expect(
+      allowlistMatch,
+      'entrypoint.sh must contain an envsubst call with a single-quoted allowlist',
+    ).toBeTruthy()
+    const allowlistVars = extractVarRefs(allowlistMatch![1] ?? '')
+
+    const missing = templateVars.filter((v) => !allowlistVars.includes(v))
+    expect(
+      missing,
+      `Template var(s) [${missing.join(', ')}] referenced in runtime-config.js.template ` +
+        `are absent from the envsubst allowlist in entrypoint.sh. ` +
+        `Add them to prevent the placeholder from shipping as a literal.`,
+    ).toHaveLength(0)
+  })
+
+  it('allowlist contains USER_SERVICE_ORIGIN', () => {
+    const allowlistMatch = entrypointSrc.match(/envsubst\s+'([^']+)'/)
+    expect(allowlistMatch).toBeTruthy()
+    expect(allowlistMatch![1]).toContain('${USER_SERVICE_ORIGIN}')
+  })
+
+  it('allowlist contains INGEST_PLATFORM_ORIGIN', () => {
+    const allowlistMatch = entrypointSrc.match(/envsubst\s+'([^']+)'/)
+    expect(allowlistMatch).toBeTruthy()
+    expect(allowlistMatch![1]).toContain('${INGEST_PLATFORM_ORIGIN}')
+  })
+
+  it('fail-fast guard is present after the envsubst call', () => {
+    // After substitution, entrypoint.sh must grep for residual '${' and exit 1.
+    // This prevents a missing-allowlist-entry from silently shipping a malformed config.
+    expect(entrypointSrc).toMatch(/grep.*\$\{/)
+    expect(entrypointSrc).toMatch(/exit 1/)
+  })
+})


### PR DESCRIPTION
## Root cause

`frontend/runtime-config.js.template` references `${INGEST_PLATFORM_ORIGIN}` on line 13, but `frontend/entrypoint.sh:27` had an envsubst allowlist of `'${USER_SERVICE_ORIGIN}'` only. `envsubst` left the placeholder verbatim. The literal string `"${INGEST_PLATFORM_ORIGIN}"` is truthy, so `admin-client.ts:243-247` skipped the `VITE_INGEST_PLATFORM_ORIGIN` / same-origin fallback chain and set `RESET_BASE = "${INGEST_PLATFORM_ORIGIN}/admin/reset"` (malformed URL) — admin-reset broken.

## Changes

1. **`frontend/entrypoint.sh`** — extend envsubst allowlist to `'${USER_SERVICE_ORIGIN}${INGEST_PLATFORM_ORIGIN}'`
2. **`frontend/entrypoint.sh`** — add POSIX-sh fail-fast guard after `envsubst`: `grep -qF '${' "$OUTPUT"` exits 1 with a diagnostic message if any placeholder survived substitution, so a future template var added without an allowlist entry can't ship silently
3. **`frontend/src/__tests__/entrypoint.test.ts`** — new vitest suite (4 tests) using Vite `?raw` imports to read both files and assert `template-vars ⊆ allowlist`; also asserts the fail-fast guard is present

## Test plan

- [ ] `vitest run` — 193/193 pass, including new `entrypoint.sh — envsubst allowlist covers all template vars (#1008)` suite (4 tests)
- [ ] `eslint src/` — 0 errors
- [ ] `tsc --noEmit` — clean

---
TechDebt: none