### PR TITLE
tech-debt(frontend): type /auth/providers via generated OpenAPI type (#1010)

### DIFF
--- a/frontend/docs/openapi-snapshot.README.md
+++ b/frontend/docs/openapi-snapshot.README.md
@@ -38,6 +38,18 @@ sibling follow-up (filed once user-service publishes its first stable snapshot).
 > that commit and `npm run gen:types` re-run in the same change. The CI drift
 > gate enforces consistency between the snapshot and the generated `.d.ts`.
 
+### Surgical additions (not from a full re-sync)
+
+The baseline row above is the last *full* snapshot. Individual paths/schemas
+that the frontend started consuming before the next full re-sync are added
+surgically (only the relevant `paths` + `components/schemas` entries, modelled
+to match the user-service contract), then `npm run gen:types` is re-run. They
+will be subsumed by the next full re-sync.
+
+| Added | From user-service | Issue |
+|---|---|---|
+| `GET /auth/providers` (`ProvidersResponse`, `AuthProviderInfo`) | [`4587935`](https://github.com/noorinalabs/noorinalabs-user-service/commit/4587935) — `feat(auth): email login/register/providers endpoints (#43)` | [isnad-graph#1010](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1010) |
+
 ## How to re-sync
 
 When user-service publishes a new release (or whenever the consumer side needs

--- a/frontend/docs/openapi-snapshot.json
+++ b/frontend/docs/openapi-snapshot.json
@@ -1,6 +1,30 @@
 {
   "components": {
     "schemas": {
+      "AuthProviderInfo": {
+        "description": "A single available authentication method for `GET /auth/providers`.",
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "enabled"
+        ],
+        "title": "AuthProviderInfo",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -92,6 +116,23 @@
           "code_verifier"
         ],
         "title": "OAuthLoginResponse",
+        "type": "object"
+      },
+      "ProvidersResponse": {
+        "description": "List of authentication methods the service supports + their enabled state.",
+        "properties": {
+          "providers": {
+            "items": {
+              "$ref": "#/components/schemas/AuthProviderInfo"
+            },
+            "title": "Providers",
+            "type": "array"
+          }
+        },
+        "required": [
+          "providers"
+        ],
+        "title": "ProvidersResponse",
         "type": "object"
       },
       "RefreshRequest": {
@@ -2310,6 +2351,28 @@
           }
         },
         "summary": "Oauth Login",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/providers": {
+      "get": {
+        "description": "List the auth methods this service supports and whether each is enabled.\n\nEmail/password is always available; each OAuth provider is `enabled` only\nwhen its credentials are configured. The frontend uses this to render the\ncorrect set of login buttons.",
+        "operationId": "list_providers_auth_providers_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvidersResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Providers",
         "tags": [
           "auth"
         ]

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,6 +4,13 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/Tabs'
 import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
 import { readJsonResponse } from '../lib/authJson'
+import type { components } from '../types/user-service'
+
+// Generated from the user-service OpenAPI snapshot (see frontend/docs/
+// openapi-snapshot.json → `npm run gen:types`). Using the generated type means a
+// contract drift on `GET /auth/providers` fails typecheck rather than silently
+// at runtime — the exact class of bug #1007 fixed (string[] vs object). #1010.
+type ProvidersResponse = components['schemas']['ProvidersResponse']
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
 // useAuth.ts for the full BASE-constant set and the runtime-vs-build-time
@@ -93,9 +100,7 @@ export default function LoginPage() {
   useEffect(() => {
     fetch(`${AUTH_BASE}/providers`)
       .then((res) =>
-        res.ok
-          ? readJsonResponse<{ providers: { id: string; enabled: boolean }[] }>(res)
-          : Promise.reject(res),
+        res.ok ? readJsonResponse<ProvidersResponse>(res) : Promise.reject(res),
       )
       .then((data) => setProviders(data.providers.filter((p) => p.enabled).map((p) => p.id)))
       .catch(() => setProviders(['google', 'github']))

--- a/frontend/src/types/user-service.d.ts
+++ b/frontend/src/types/user-service.d.ts
@@ -484,6 +484,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Providers
+         * @description List the auth methods this service supports and whether each is enabled.
+         *
+         *     Email/password is always available; each OAuth provider is `enabled` only
+         *     when its credentials are configured. The frontend uses this to render the
+         *     correct set of login buttons.
+         */
+        get: operations["list_providers_auth_providers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/token": {
         parameters: {
             query?: never;
@@ -588,6 +612,18 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * AuthProviderInfo
+         * @description A single available authentication method for `GET /auth/providers`.
+         */
+        AuthProviderInfo: {
+            /** Enabled */
+            enabled: boolean;
+            /** Id */
+            id: string;
+            /** Type */
+            type: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -634,6 +670,14 @@ export interface components {
             code_verifier: string;
             /** State */
             state: string;
+        };
+        /**
+         * ProvidersResponse
+         * @description List of authentication methods the service supports + their enabled state.
+         */
+        ProvidersResponse: {
+            /** Providers */
+            providers: components["schemas"]["AuthProviderInfo"][];
         };
         /**
          * RefreshRequest
@@ -1955,6 +1999,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_providers_auth_providers_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProvidersResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Tech-debt follow-up to #1007 / #1009. Makes the `GET /auth/providers` contract compile-time-checked in `LoginPage.tsx` by using a generated OpenAPI type instead of the hand-maintained inline shape.

- **Snapshot:** add `GET /auth/providers` + `ProvidersResponse` / `AuthProviderInfo` schemas to the committed `frontend/docs/openapi-snapshot.json`. This is a *surgical* add modelled on the user-service `main` route (commit `4587935`, PR noorinalabs/noorinalabs-user-service#43) — not a full re-sync (a full re-sync would pull unrelated surface drift, out of scope for #1010). README provenance note added to document the surgical addition.
- **Generated types:** regenerate `frontend/src/types/user-service.d.ts` via `npm run gen:types` in the same commit so `frontend-typegen-drift` stays green.
- **LoginPage:** replace `readJsonResponse<{ providers: { id: string; enabled: boolean }[] }>` with the generated `ProvidersResponse` type. The `['google','github']` fallback and the `enabled`-filter → `id`-map behavior are unchanged.

Note: the real user-service schema carries a `type` field (`"password" | "oauth"`) that the interim inline type omitted — now reflected in the generated `AuthProviderInfo`. A contract drift on `/auth/providers` will now fail typecheck rather than silently at runtime (the exact class of bug #1007 fixed: `string[]` vs object).

## Test Plan

- `npm run gen:types` — **idempotent** (re-running produces no diff; snapshot ⇄ `.d.ts` in lockstep, so `frontend-typegen-drift` passes).
- `npx tsc --noEmit` — clean.
- `npx eslint src/` — 0 errors (pre-existing warnings only, none in `LoginPage.tsx`).
- `npx vitest run` — 193/193 pass, including the 5 `LoginPage.test.tsx` tests that assert both Google + GitHub buttons render, that `enabled:false` providers are hidden, and the fetch-failure fallback. These tests already mock the real `{ id, type, enabled }` shape, which the generated type now enforces.

## Reviewers

@ requesting **Jun-Seo Park** (primary) and **Mateo Salazar** (2nd) per charter — both approvals required.

Closes #1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
