### PR TITLE
fix(frontend/auth): refresh access token on 401 in data API client before logout (#1016)

### DIFF
--- a/frontend/src/api/__tests__/client-refresh.test.ts
+++ b/frontend/src/api/__tests__/client-refresh.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchNarrators } from '../client'
+import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
+
+// Fetch-boundary regression tests for the #1016 fix: the data API client must
+// attempt a token refresh (POST /auth/token/refresh, via the httpOnly refresh
+// cookie) and retry the original request ONCE on a 401 before declaring the
+// session expired. Only a failed refresh — a genuinely expired/revoked refresh
+// cookie — may emit `session-expired`. These drive the REAL fetchJson against a
+// stubbed `fetch`, so they assert the actual request sequence the mocked
+// component tests can't see.
+
+const REFRESH_URL = '/auth/token/refresh'
+const NARRATORS_URL = '/api/v1/narrators'
+
+// Origin resolution falls back to '' (same-origin) in the test env (no
+// window.RUNTIME_CONFIG, no VITE_USER_SERVICE_ORIGIN), so the refresh POST
+// targets a bare `/auth/token/refresh`.
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+function callsTo(substr: string): Array<{ url: string; init: RequestInit | undefined }> {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: c[1] as RequestInit | undefined }))
+    .filter((c) => c.url.includes(substr))
+}
+
+function authHeader(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.Authorization
+}
+
+let onExpired: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'expired-token')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  onExpired = vi.fn()
+  window.addEventListener(SESSION_EXPIRED_EVENT, onExpired)
+})
+
+afterEach(() => {
+  window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired)
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('data client 401 → refresh → retry (#1016)', () => {
+  it('on 401, refreshes once and retries the request — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      // First data call: the expired access token → 401. Retry: 200.
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ items: [], total: 0, page: 1, limit: 20 }),
+      )
+    })
+
+    const result = await fetchNarrators()
+
+    expect(result).toEqual({ items: [], total: 0, page: 1, limit: 20 })
+    // Exactly one refresh POST.
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(REFRESH_URL)[0]?.init?.method).toBe('POST')
+    // Two data calls: the original (401) and the retry.
+    const data = callsTo(NARRATORS_URL)
+    expect(data).toHaveLength(2)
+    // The retry carried the refreshed token (getAuthHeaders re-read localStorage).
+    expect(authHeader(data[0]?.init)).toBe('Bearer expired-token')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    // The user was NOT bounced to the login wall.
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and does not retry', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        // Refresh cookie genuinely expired/revoked → non-OK.
+        return Promise.resolve(jsonResponse({ detail: 'refresh expired' }, 401))
+      }
+      return Promise.resolve(jsonResponse({ detail: 'token expired' }, 401))
+    })
+
+    await expect(fetchNarrators()).rejects.toThrow(/401/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    // No retry — the single data call stays at one (refresh failed).
+    expect(callsTo(NARRATORS_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+
+  it('single-flight: concurrent 401s share ONE refresh', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      // The first two (concurrent) data calls 401; their retries succeed.
+      return Promise.resolve(
+        dataCalls <= 2
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ items: [], total: 0, page: 1, limit: 20 }),
+      )
+    })
+
+    const [a, b] = await Promise.all([fetchNarrators(), fetchNarrators()])
+
+    expect(a).toEqual({ items: [], total: 0, page: 1, limit: 20 })
+    expect(b).toEqual({ items: [], total: 0, page: 1, limit: 20 })
+    // Both 401s collapsed into a single refresh POST.
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    // Four data calls total: two originals (401) + two retries (200).
+    expect(callsTo(NARRATORS_URL)).toHaveLength(4)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('a 200 response never triggers a refresh', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [], total: 0, page: 1, limit: 20 }))
+
+    await fetchNarrators()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,15 +18,27 @@ import type {
 
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
+import { refreshAccessToken } from './token-refresh'
 
 const API_BASE = '/api/v1'
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })
-  if (!res.ok) {
+  let res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })
+  if (res.status === 401) {
+    // The access token has likely expired mid-session. Try a single refresh
+    // (shared across concurrent 401s) and retry the request ONCE with the new
+    // token before giving up — only a genuinely expired/revoked refresh cookie
+    // forces the session-expired modal. getAuthHeaders() re-reads the freshly
+    // persisted token. (#1016)
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })
+    }
     if (res.status === 401) {
       emitSessionExpired()
     }
+  }
+  if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`)
   }
   return res.json() as Promise<T>
@@ -200,15 +212,27 @@ export async function flagContent(
 // (free tier / admin), not an error. Resolve it to null and let callers
 // branch on `subscription === null`. Other non-OK statuses throw as usual.
 export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | null> {
-  const res = await fetch(`${API_BASE}/subscriptions/me`, {
+  let res = await fetch(`${API_BASE}/subscriptions/me`, {
     headers: getAuthHeaders(),
     credentials: 'include',
   })
-  if (res.status === 404) return null
-  if (!res.ok) {
+  // Same refresh-then-retry-once recovery as fetchJson: a mid-session access
+  // token expiry must not force a logout while the refresh cookie is still
+  // valid. (#1016)
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await fetch(`${API_BASE}/subscriptions/me`, {
+        headers: getAuthHeaders(),
+        credentials: 'include',
+      })
+    }
     if (res.status === 401) {
       emitSessionExpired()
     }
+  }
+  if (res.status === 404) return null
+  if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`)
   }
   return res.json() as Promise<SubscriptionResponse>

--- a/frontend/src/api/token-refresh.ts
+++ b/frontend/src/api/token-refresh.ts
@@ -1,0 +1,76 @@
+// Shared access-token refresh machinery (#1016).
+//
+// The user-service issues short-lived access tokens (held in localStorage) plus
+// a long-lived refresh token in an httpOnly, SameSite cookie. When an access
+// token expires mid-session every API client gets a 401; the cure is a single
+// `POST /auth/token/refresh` (the browser sends the refresh cookie), which mints
+// a fresh access token. Previously only `useAuth.loadUser` knew how to do this,
+// so the data clients force-logged-out on any 401. This module is the single
+// source of truth for that exchange so every client recovers identically and the
+// endpoint logic never diverges.
+
+// Absolute URL targeting the user-service vhost (`users.{base}`). Resolved at
+// runtime from `window.RUNTIME_CONFIG` (injected by the container entrypoint via
+// /runtime-config.js) so a single image digest targets env-specific origins,
+// falling back to the build-time `VITE_USER_SERVICE_ORIGIN` for local
+// `npm run dev`, then '' (same-origin). Mirrors useAuth.ts (isnad-graph#932).
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
+const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
+
+// Double-submit CSRF: the refresh cookie pairs with a readable `csrf_token`
+// cookie echoed back in the `X-CSRF-Token` header. Absent → empty string (the
+// server rejects, refresh fails closed).
+function getCsrfToken(): string {
+  const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/)
+  return match?.[1] ?? ''
+}
+
+// Single-flight guard. Concurrent 401s (e.g. a page firing several data calls
+// at once) MUST share ONE in-flight refresh rather than each POSTing its own:
+// the refresh cookie rotates on use, so parallel refreshes would race and
+// invalidate each other, defeating the recovery they're meant to provide. The
+// promise is cached for the duration of the request and cleared once it settles
+// so the next genuine expiry triggers a fresh exchange.
+let inFlight: Promise<string | null> | null = null
+
+async function doRefresh(): Promise<string | null> {
+  try {
+    const res = await fetch(`${AUTH_BASE}/token/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+    })
+
+    if (!res.ok) return null
+
+    const data = await res.json()
+    localStorage.setItem('access_token', data.access_token)
+    return data.access_token as string
+  } catch {
+    // Network failure / non-JSON body — treat as a failed refresh (caller logs out).
+    return null
+  }
+}
+
+/**
+ * Exchange the httpOnly refresh cookie for a fresh access token, persisting it
+ * to localStorage on success. Returns the new token, or `null` if the refresh
+ * token is genuinely expired/revoked (or the request failed) — in which case
+ * the caller should surface session-expired.
+ *
+ * Single-flight: concurrent callers share one in-flight request.
+ */
+export function refreshAccessToken(): Promise<string | null> {
+  if (!inFlight) {
+    inFlight = doRefresh().finally(() => {
+      inFlight = null
+    })
+  }
+  return inFlight
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react'
 import { createElement } from 'react'
 import type { components } from '../types/user-service'
+import { refreshAccessToken } from '../api/token-refresh'
 
 export type UserRole = 'trial' | 'reader' | 'researcher' | 'admin'
 
@@ -78,41 +79,18 @@ export function deriveHighestRole(roleNames: string[]): UserRole {
 // Vite can bake only one VITE_* value into the bundle (Contract v6, #815).
 // Falls back to the build-time `VITE_USER_SERVICE_ORIGIN` for local `npm run dev`
 // (no entrypoint), then to '' (same-origin). See isnad-graph#932 / deploy#245 step 5.
+//
+// The `/auth/token/refresh` exchange itself now lives in `api/token-refresh.ts`
+// (single source of truth, shared with the data clients per #1016) — hence no
+// AUTH_BASE / getCsrfToken here anymore.
 const USER_SERVICE_ORIGIN =
   (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
   import.meta.env.VITE_USER_SERVICE_ORIGIN ||
   ''
-const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
 const USER_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users`
 const SESSIONS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/sessions`
 
 const AuthContext = createContext<AuthContextValue | null>(null)
-
-function getCsrfToken(): string {
-  const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/)
-  return match?.[1] ?? ''
-}
-
-async function refreshAccessToken(): Promise<string | null> {
-  try {
-    const res = await fetch(`${AUTH_BASE}/token/refresh`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': getCsrfToken(),
-      },
-    })
-
-    if (!res.ok) return null
-
-    const data = await res.json()
-    localStorage.setItem('access_token', data.access_token)
-    return data.access_token as string
-  } catch {
-    return null
-  }
-}
 
 /**
  * Event emitted when an API call receives a 401 mid-session.


### PR DESCRIPTION
## What & why

On a `401` from any data API call, the frontend **immediately declared the session expired and logged the user out — it never attempted a refresh-token exchange first**, even though a valid refresh token is held in an httpOnly cookie and the refresh machinery already existed. Every authenticated user was bounced to the login wall the instant their short-lived access token expired mid-session (live repro on staging, #1016).

The refresh path existed but was wired only into `useAuth.loadUser` (the `/me` loader), so `/me` silently recovered while every other endpoint (Narrators, Hadiths, …) force-logged-out.

Closes #1016

## Changes

- **New `frontend/src/api/token-refresh.ts`** — single source of truth for the `POST /auth/token/refresh` exchange (httpOnly refresh cookie + double-submit CSRF), with **single-flight** semantics: concurrent 401s share ONE in-flight refresh and the promise clears once it settles.
- **`useAuth.ts`** now imports `refreshAccessToken` from that helper instead of carrying its own private copy — no duplicated/divergent endpoint logic (the brief's explicit constraint). `AUTH_BASE`/`getCsrfToken` moved into the helper.
- **`client.ts`** — `fetchJson` and `fetchSubscriptionOrNull` now, on a 401, attempt a refresh and **retry the original request once** with the refreshed token before emitting `session-expired`. Only a genuinely failed refresh (expired/revoked cookie) forces logout. Single-retry guard prevents any loop.

## Security threat model (@Idris Yusuf)

- **Refresh endpoint unchanged** — same `POST /auth/token/refresh`, `credentials: 'include'`, `X-CSRF-Token` double-submit header. The fix reuses the existing exchange verbatim; it does not weaken CSRF or cookie handling.
- **Single-flight is a hardening, not a loosening** — the refresh cookie rotates on use, so N parallel refreshes would race and revoke each other; collapsing concurrent 401s into one exchange avoids that self-inflicted invalidation.
- **Fail-closed** — any non-OK refresh response, network error, or non-JSON body resolves to `null` → the caller emits `session-expired` exactly as before. No silent swallowing of a genuinely revoked session.
- **Bounded retry** — exactly one retry per request; a second 401 after refresh emits `session-expired` and throws. No infinite re-auth loop.
- **No token surface change** — access token still read from the URL fragment only (ig#955); the retry re-reads it from `localStorage` via `getAuthHeaders()`.

## Tests

`frontend/src/api/__tests__/client-refresh.test.ts` (real `fetchJson` against a stubbed `fetch`):
- 401 → refresh succeeds → retry succeeds → **no** session-expired; retry carries the refreshed `Bearer` token.
- 401 → refresh fails → session-expired emitted once, **no** retry.
- Single-flight: two concurrent 401s collapse to ONE refresh POST.
- A 200 never triggers a refresh.

Full frontend suite green locally: **197 passed**; `tsc --noEmit` clean; eslint clean on changed files (one pre-existing unrelated warning on the `is_new_user` effect).

## Scope / follow-up

Diff kept tight to the 401/refresh path to coexist with #1017 (error-message handling on the same file). `admin-client.ts` / `profile-client.ts` have the same force-logout-on-401 gap; the new `refreshAccessToken` helper makes wiring them a one-line change — recommend a fast follow-up rather than widening this PR.
