### PR TITLE
fix(frontend): subscriptions/me → user-service origin + derive search collection facet (#1026)

### DIFF
--- a/frontend/src/api/__tests__/subscription-client.test.ts
+++ b/frontend/src/api/__tests__/subscription-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Regression test for #1026: `fetchSubscriptionOrNull` must target the
+// USER-SERVICE origin (`window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN`), not the
+// same-origin isnad-graph API. Subscriptions live in user-service; hitting the
+// isnad-graph origin (`/api/v1/subscriptions/me`) 404'd on every authenticated
+// page and silently treated every user as un-subscribed.
+//
+// The origin is baked into a module-level constant at import time, so each test
+// sets `window.RUNTIME_CONFIG` and then imports the client via `vi.resetModules`
+// + dynamic import to pick up that value.
+
+const ORIGIN = 'https://users.example'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 404 ? 'Not Found' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'jwt')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  vi.resetModules()
+  ;(window as unknown as { RUNTIME_CONFIG?: { USER_SERVICE_ORIGIN?: string } }).RUNTIME_CONFIG =
+    { USER_SERVICE_ORIGIN: ORIGIN }
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+  delete (window as unknown as { RUNTIME_CONFIG?: unknown }).RUNTIME_CONFIG
+})
+
+describe('fetchSubscriptionOrNull origin (#1026)', () => {
+  it('targets the user-service origin, not the same-origin isnad-graph API', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ tier: 'trial', status: 'trial', days_remaining: 5 }))
+    const { fetchSubscriptionOrNull } = await import('../client')
+
+    await fetchSubscriptionOrNull()
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(`${ORIGIN}/api/v1/subscriptions/me`)
+  })
+
+  it('resolves a 404 (no subscription) to null without throwing', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'No subscription found' }, 404))
+    const { fetchSubscriptionOrNull } = await import('../client')
+
+    await expect(fetchSubscriptionOrNull()).resolves.toBeNull()
+  })
+
+  it('returns the parsed subscription body on 200', async () => {
+    const body = { tier: 'active', status: 'active', days_remaining: 30 }
+    fetchMock.mockResolvedValue(jsonResponse(body))
+    const { fetchSubscriptionOrNull } = await import('../client')
+
+    await expect(fetchSubscriptionOrNull()).resolves.toEqual(body)
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,6 +23,19 @@ import { apiError } from './api-error'
 
 const API_BASE = '/api/v1'
 
+// Subscriptions live in the user-service, not the isnad-graph API. Resolve its
+// origin at runtime from `window.RUNTIME_CONFIG` (injected by the container
+// entrypoint), falling back to the build-time `VITE_USER_SERVICE_ORIGIN`, then
+// to same-origin. This mirrors useAuth.ts / profile-client.ts / admin-client.ts.
+// Without this, `/subscriptions/me` hit the isnad-graph origin — which has no
+// such route — and 404'd on every authenticated page, silently treating every
+// user (including real subscribers) as un-subscribed. (#1026)
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
+const SUBSCRIPTIONS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/subscriptions`
+
 async function fetchJson<T>(url: string): Promise<T> {
   let res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })
   if (res.status === 401) {
@@ -213,7 +226,7 @@ export async function flagContent(
 // (free tier / admin), not an error. Resolve it to null and let callers
 // branch on `subscription === null`. Other non-OK statuses throw as usual.
 export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | null> {
-  let res = await fetch(`${API_BASE}/subscriptions/me`, {
+  let res = await fetch(`${SUBSCRIPTIONS_BASE}/me`, {
     headers: getAuthHeaders(),
     credentials: 'include',
   })
@@ -223,7 +236,7 @@ export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | 
   if (res.status === 401) {
     const refreshed = await refreshAccessToken()
     if (refreshed) {
-      res = await fetch(`${API_BASE}/subscriptions/me`, {
+      res = await fetch(`${SUBSCRIPTIONS_BASE}/me`, {
         headers: getAuthHeaders(),
         credentials: 'include',
       })

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { searchAll, searchSemantic } from '../api/client'
+import { searchAll, searchSemantic, fetchCollections } from '../api/client'
 import { Card, CardContent } from '../components/ui/Card'
 import { Badge } from '../components/ui/Badge'
 import { Input } from '../components/ui/Input'
@@ -33,16 +33,10 @@ interface SearchFilters {
   topics: string[]
 }
 
-const COLLECTIONS = [
-  'Bukhari',
-  'Muslim',
-  'Abu Dawud',
-  'Tirmidhi',
-  "Nasa'i",
-  'Ibn Majah',
-  'al-Kafi',
-  'Bihar al-Anwar',
-]
+// Collection facet options are derived from the live `/collections` response
+// (see the useQuery below), not hardcoded — the previous static list showed
+// unloaded Shia collections (al-Kafi, Bihar al-Anwar) and omitted loaded ones
+// (e.g. riyadussalihin). (#1026)
 
 const GRADINGS = ['Sahih', 'Hasan', "Da'if", "Mawdu'"]
 const CENTURIES = [1, 2, 3, 4, 5]
@@ -131,6 +125,18 @@ export default function SearchPage() {
     enabled: query.length >= 2,
     retry: 1,
   })
+
+  // Collection facet options, derived from the live `/collections` response so
+  // the filter only ever offers actually-loaded collections (mirrors the
+  // Hadiths page dropdown). (#1026)
+  const { data: collectionsData } = useQuery({
+    queryKey: ['collections-all'],
+    queryFn: () => fetchCollections(1, 100),
+    staleTime: 5 * 60 * 1000,
+  })
+  const collectionOptions = (collectionsData?.items ?? [])
+    .map((c) => c.name_en)
+    .sort((a, b) => a.localeCompare(b))
 
   // Close typeahead on outside click
   useEffect(() => {
@@ -294,17 +300,21 @@ export default function SearchPage() {
         <h4 id="filter-collection" className="text-sm font-semibold mb-2 uppercase tracking-wide text-muted-foreground">
           Collection
         </h4>
-        {COLLECTIONS.map((c) => (
-          <label key={c} className="flex items-center gap-2 py-1 cursor-pointer text-sm">
-            <input
-              type="checkbox"
-              checked={filters.collections.includes(c)}
-              onChange={() => toggleFilter('collections', c)}
-              className="rounded"
-            />
-            {c}
-          </label>
-        ))}
+        {collectionOptions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No collections available</p>
+        ) : (
+          collectionOptions.map((c) => (
+            <label key={c} className="flex items-center gap-2 py-1 cursor-pointer text-sm">
+              <input
+                type="checkbox"
+                checked={filters.collections.includes(c)}
+                onChange={() => toggleFilter('collections', c)}
+                className="rounded"
+              />
+              {c}
+            </label>
+          ))
+        )}
       </div>
 
       {/* Grading filter */}


### PR DESCRIPTION
## Summary

Fixes both defects in #1026 (found in the isnad-graph#1018 live bug-bash).

### 1. `GET /api/v1/subscriptions/me` 404 on every authenticated page

**Root cause:** `fetchSubscriptionOrNull` (frontend/src/api/client.ts) built its URL from the same-origin isnad-graph `API_BASE` (`/api/v1`). But subscriptions are served by **user-service** — `user-service` exposes `GET /api/v1/subscriptions/me` (`src/app/routers/subscriptions.py`, returns 404 only for genuinely subscription-less users). The isnad-graph backend has no such route (`src/api/routes/auth.py` only stubs `/auth/subscription` → 410), so every call hit the wrong origin and 404'd. The hook treats 404 as "no subscription" (#830), so this silently treated **every** user — including real subscribers — as un-subscribed, and fired a failed request on every navigation.

Every other user-service client (`useAuth`, `profile-client`, `admin-client`, `token-refresh`) already resolves `USER_SERVICE_ORIGIN` from `window.RUNTIME_CONFIG`; the subscription fetch was the lone exception.

**Fix:** resolve `USER_SERVICE_ORIGIN` (runtime `window.RUNTIME_CONFIG` → build-time `VITE_USER_SERVICE_ORIGIN` → same-origin) and target `${USER_SERVICE_ORIGIN}/api/v1/subscriptions/me`, mirroring the existing clients. The 401→refresh→retry recovery (#1016) and 404→null handling are preserved.

### 2. Search-page collection facet hardcoded (showed unloaded Shia collections)

**Root cause:** `SearchPage.tsx` had a static `COLLECTIONS` array listing `al-Kafi` and `Bihar al-Anwar` (Shia, not loaded — staging is sunni-only) and omitting the loaded `riyadussalihin`.

**Fix:** derive the facet from the live `/collections` response via `fetchCollections(1, 100)` (`name_en`, sorted), mirroring how the Hadiths page builds its dropdown. Renders "No collections available" if the list is empty.

## Scope / coordination

Coordinated the search-client boundary with **Jun-Seo Park** (#1025): this PR does **not** touch `searchAll`/`searchSemantic` or the `limit=200` calls — those are Jun-Seo's. The two PRs edit different regions of `SearchPage.tsx`/`client.ts`.

## Out of scope (follow-up note)

The collection/grading/century/topic facets are currently tracked in state but `filteredResults` only applies `entityTypes` to results — the collection filter is not wired to actually filter results (server- or client-side). This PR only corrects the facet **list** per the issue; wiring collection filtering is a separate gap.

## Verification

- New `src/api/__tests__/subscription-client.test.ts`: asserts the fetch URL targets the user-service origin (sets `window.RUNTIME_CONFIG` before a dynamic import, since the same-origin fallback masks the bug), plus 404→null and 200 paths.
- Full frontend suite green: **206 tests passed**.
- `tsc --noEmit` clean; ESLint clean on changed files.

Closes #1026

TechDebt: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
