### PR TITLE
fix(frontend/auth): admin + profile clients refresh-on-401 before logout (#1021)

### DIFF
--- a/frontend/src/api/__tests__/admin-client-refresh.test.ts
+++ b/frontend/src/api/__tests__/admin-client-refresh.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  fetchSystemHealth,
+  fetchAdminUser,
+  resetStage,
+  ResetError,
+} from '../admin-client'
+import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
+
+// Fetch-boundary regression tests for the #1021 fix: the admin clients must
+// mirror the #1016 data-client recovery — attempt a token refresh
+// (POST /auth/token/refresh, via the httpOnly refresh cookie) and retry the
+// original request ONCE on a 401 before declaring the session expired. Before
+// this fix every admin 401 (isnad-graph admin API via `fetchAdminJson`,
+// user-service admin API via `fetchUserServiceJson`, and the cross-service
+// pipeline reset via `postReset`) force-logged-out immediately, so a mid-session
+// access-token expiry bounced admins despite a valid refresh cookie. These drive
+// the REAL clients against a stubbed `fetch`, asserting the actual request
+// sequence the mocked component tests can't see.
+
+const REFRESH_URL = '/auth/token/refresh'
+// In the test env (no window.RUNTIME_CONFIG / VITE_USER_SERVICE_ORIGIN) the
+// origin resolves to '' (same-origin), so the user-service + admin URLs are bare.
+const HEALTH_URL = '/api/v1/admin/health/ready'
+const USERS_URL = '/api/v1/users'
+const RESET_STAGE_URL = '/admin/reset/stage'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+function callsTo(substr: string): Array<{ url: string; init: RequestInit | undefined }> {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: c[1] as RequestInit | undefined }))
+    .filter((c) => c.url.includes(substr))
+}
+
+function authHeader(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.Authorization
+}
+
+let onExpired: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'expired-token')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  onExpired = vi.fn()
+  window.addEventListener(SESSION_EXPIRED_EVENT, onExpired)
+})
+
+afterEach(() => {
+  window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired)
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('admin client (isnad-graph admin API) 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ status: 'ok' }),
+      )
+    })
+
+    const result = await fetchSystemHealth()
+
+    expect(result).toEqual({ status: 'ok' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(REFRESH_URL)[0]?.init?.method).toBe('POST')
+    const data = callsTo(HEALTH_URL)
+    expect(data).toHaveLength(2)
+    expect(authHeader(data[0]?.init)).toBe('Bearer expired-token')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and does not retry', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ detail: 'refresh expired' }, 401))
+      }
+      return Promise.resolve(jsonResponse({ detail: 'token expired' }, 401))
+    })
+
+    await expect(fetchSystemHealth()).rejects.toThrow(/admin access required/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(HEALTH_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+})
+
+describe('admin client (user-service admin API) 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ id: 'u1', email: 'a@b.c' }),
+      )
+    })
+
+    const result = await fetchAdminUser('u1')
+
+    expect(result).toMatchObject({ id: 'u1' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    const data = callsTo(USERS_URL)
+    expect(data).toHaveLength(2)
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(fetchAdminUser('u1')).rejects.toThrow(/admin access required/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(USERS_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+})
+
+describe('admin client (cross-service pipeline reset) 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ ok: true, dry_run: true, deleted: {} }),
+      )
+    })
+
+    const result = await resetStage('raw', true)
+
+    expect(result).toMatchObject({ ok: true })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(RESET_STAGE_URL)).toHaveLength(2)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and throws ResetError(401)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(resetStage('raw', true)).rejects.toMatchObject({
+      name: 'ResetError',
+      status: 401,
+    })
+    // Sanity: the rejection is the typed ResetError, not a generic throw.
+    await expect(resetStage('raw', true)).rejects.toBeInstanceOf(ResetError)
+
+    expect(onExpired).toHaveBeenCalled()
+  })
+})
+
+describe('admin clients: a 200 response never triggers a refresh (#1021)', () => {
+  it('fetchSystemHealth', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: 'ok' }))
+
+    await fetchSystemHealth()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/__tests__/profile-client-refresh.test.ts
+++ b/frontend/src/api/__tests__/profile-client-refresh.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchProfile, revokeSession } from '../profile-client'
+import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
+
+// Fetch-boundary regression tests for the #1021 fix: the profile client must
+// mirror the #1016 data-client recovery — attempt a token refresh
+// (POST /auth/token/refresh, via the httpOnly refresh cookie) and retry the
+// original request ONCE on a 401 before declaring the session expired. Before
+// this fix a 401 on any /api/v1/users/me call (`fetchProfileJson`) or the
+// `revokeSession` DELETE force-logged-out immediately, so a mid-session
+// access-token expiry bounced the user out of their own profile despite a valid
+// refresh cookie. These drive the REAL client against a stubbed `fetch`.
+
+const REFRESH_URL = '/auth/token/refresh'
+// Origin resolves to '' (same-origin) in the test env, so the profile URLs are bare.
+const PROFILE_URL = '/api/v1/users/me/profile'
+const SESSIONS_URL = '/api/v1/users/me/sessions'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+function callsTo(substr: string): Array<{ url: string; init: RequestInit | undefined }> {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: c[1] as RequestInit | undefined }))
+    .filter((c) => c.url.includes(substr))
+}
+
+function authHeader(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.Authorization
+}
+
+let onExpired: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'expired-token')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  onExpired = vi.fn()
+  window.addEventListener(SESSION_EXPIRED_EVENT, onExpired)
+})
+
+afterEach(() => {
+  window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired)
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('profile client 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries fetchProfile — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ id: 'u1', email: 'a@b.c', name: 'A' }),
+      )
+    })
+
+    const result = await fetchProfile()
+
+    expect(result).toMatchObject({ id: 'u1' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(REFRESH_URL)[0]?.init?.method).toBe('POST')
+    const data = callsTo(PROFILE_URL)
+    expect(data).toHaveLength(2)
+    expect(authHeader(data[0]?.init)).toBe('Bearer expired-token')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and does not retry', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ detail: 'refresh expired' }, 401))
+      }
+      return Promise.resolve(jsonResponse({ detail: 'token expired' }, 401))
+    })
+
+    await expect(fetchProfile()).rejects.toThrow(/Unauthorized/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(PROFILE_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+
+  it('revokeSession refreshes once and retries the DELETE on a 401', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1 ? jsonResponse({ detail: 'token expired' }, 401) : jsonResponse({}, 204),
+      )
+    })
+
+    await expect(revokeSession('s1')).resolves.toBeUndefined()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    const data = callsTo(SESSIONS_URL)
+    expect(data).toHaveLength(2)
+    expect(data[1]?.init?.method).toBe('DELETE')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('revokeSession emits session-expired when the refresh fails', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(revokeSession('s1')).rejects.toThrow(/Unauthorized/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(SESSIONS_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+
+  it('a 200 response never triggers a refresh', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'u1', email: 'a@b.c', name: 'A' }))
+
+    await fetchProfile()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -12,6 +12,7 @@ import type {
 import type { PaginatedResponse } from '../types/api'
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
+import { refreshAccessToken } from './token-refresh'
 import { apiError } from './api-error'
 
 // --- isnad-graph admin API (system / content / analytics panels — #806) ---
@@ -40,12 +41,29 @@ export type AdminUser = components['schemas']['UserRead']
 export type AdminUserList = components['schemas']['UserListResponse']
 export type Role = components['schemas']['RoleRead']
 
+// Issue an authenticated request; on a 401 attempt ONE shared token refresh
+// (POST /auth/token/refresh via the httpOnly refresh cookie) and retry the
+// request once before the caller surfaces session-expired. Only a genuinely
+// expired/revoked refresh cookie (a failed refresh) leaves the response at 401
+// for the caller's session-expired branch — a mid-session access-token expiry
+// no longer bounces an admin to the login wall. getAuthHeaders() re-reads the
+// freshly persisted token on the retry. Mirrors client.ts `fetchJson` (#1016);
+// shared by every admin 401 path so the recovery never diverges (#1021).
+async function fetchWithRefresh(url: string, init?: RequestInit): Promise<Response> {
+  const send = () =>
+    fetch(url, { ...init, headers: { ...getAuthHeaders(), ...init?.headers } })
+  let res = await send()
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await send()
+    }
+  }
+  return res
+}
+
 async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    credentials: 'include',
-    headers: { ...getAuthHeaders(), ...init?.headers },
-  })
+  const res = await fetchWithRefresh(url, { ...init, credentials: 'include' })
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized: admin access required')
@@ -64,10 +82,7 @@ async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
 // `credentials: 'include'` (matches profile-client.ts, avoids a cross-origin
 // credentialed-CORS requirement on the user-service vhost).
 async function fetchUserServiceJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { ...getAuthHeaders(), ...init?.headers },
-  })
+  const res = await fetchWithRefresh(url, init)
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized: admin access required')
@@ -84,10 +99,7 @@ async function fetchUserServiceJson<T>(url: string, init?: RequestInit): Promise
 // 204 No Content variant (role removal, soft-delete) — same auth/error handling
 // as fetchUserServiceJson but no body to parse.
 async function sendUserServiceRequest(url: string, init: RequestInit): Promise<void> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { ...getAuthHeaders(), ...init.headers },
-  })
+  const res = await fetchWithRefresh(url, init)
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized: admin access required')
@@ -259,10 +271,10 @@ export class ResetError extends Error {
 }
 
 async function postReset(path: string, body: unknown): Promise<ResetResponse> {
-  const res = await fetch(`${RESET_BASE}${path}`, {
+  const res = await fetchWithRefresh(`${RESET_BASE}${path}`, {
     method: 'POST',
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
   if (res.ok) {

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -1,5 +1,6 @@
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
+import { refreshAccessToken } from './token-refresh'
 import { apiError } from './api-error'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
@@ -12,11 +13,29 @@ const USER_SERVICE_ORIGIN =
   ''
 const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
 
+// Issue an authenticated request; on a 401 attempt ONE shared token refresh
+// (POST /auth/token/refresh via the httpOnly refresh cookie) and retry the
+// request once before the caller surfaces session-expired. Only a genuinely
+// expired/revoked refresh cookie (a failed refresh) leaves the response at 401
+// — a mid-session access-token expiry no longer logs the user out of their
+// profile. getAuthHeaders() re-reads the freshly persisted token on the retry.
+// Mirrors client.ts `fetchJson` (#1016); shared by every profile 401 path so a
+// 401 from one client no longer diverges from the others (#1021).
+async function fetchWithRefresh(url: string, init?: RequestInit): Promise<Response> {
+  const send = () =>
+    fetch(url, { ...init, headers: { ...getAuthHeaders(), ...init?.headers } })
+  let res = await send()
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await send()
+    }
+  }
+  return res
+}
+
 async function fetchProfileJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { ...getAuthHeaders(), ...init?.headers },
-  })
+  const res = await fetchWithRefresh(url, init)
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized')
@@ -74,9 +93,8 @@ export async function fetchSessions(): Promise<SessionInfo[]> {
 }
 
 export async function revokeSession(sessionId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+  const res = await fetchWithRefresh(`${API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
     method: 'DELETE',
-    headers: getAuthHeaders(),
   })
   if (res.status === 401) {
     emitSessionExpired()


### PR DESCRIPTION
Closes #1021

## Root cause
`admin-client.ts` and `profile-client.ts` carried the **same** force-logout-on-401 gap that ig#1016 (PR #1019) fixed in `client.ts`: every 401 path called `emitSessionExpired()` immediately, with **no** token-refresh attempt. So a mid-session access-token expiry bounced an admin/user to the login wall even though their long-lived httpOnly refresh cookie was still valid. #1016 deliberately scoped its fix to the data API client and factored the single-flight refresh exchange into `frontend/src/api/token-refresh.ts`; this is the follow-up that wires the remaining two clients into that helper (depends on #1019, now merged).

## Fix
Each client gets a small local `fetchWithRefresh(url, init)` helper that:
1. issues the request,
2. on a `401`, calls the shared single-flight `refreshAccessToken()` (`token-refresh.ts`),
3. retries the request **once** with the freshly persisted token (`getAuthHeaders()` re-reads `localStorage`),
4. returns the response — the caller's existing `401 → emitSessionExpired()` branch now only fires when the refresh genuinely fails (expired/revoked cookie).

All 401 paths route through it, so the recovery can't diverge per call site:
- **admin-client.ts** — `fetchAdminJson` (isnad-graph admin API, `credentials: include`), `fetchUserServiceJson` + `sendUserServiceRequest` (user-service admin API, Bearer-only), and `postReset` (cross-service pipeline reset, `ResetError(401)` path).
- **profile-client.ts** — `fetchProfileJson` and the `revokeSession` DELETE.

No behavior change on 403 / 404 / 422 / 503 / network errors, and a 200 never triggers a refresh.

## Verification
- New `admin-client-refresh.test.ts` (7 tests) + `profile-client-refresh.test.ts` (5 tests) drive the **real** clients against a stubbed `fetch` (parallel to `client-refresh.test.ts`). They assert, per client/path:
  - **401 → refresh → retry-once → success**, with the retry carrying `Bearer fresh-token` and **no** `session-expired` event;
  - **401 + failed refresh → exactly one refresh POST, no retry, `session-expired` emitted once** (and `ResetError(401)` for the reset path);
  - **200 never triggers a refresh.**
- Pre-existing `admin-client.test.ts` 401 test still passes (failed-refresh path preserves the original force-logout).
- `npx tsc --noEmit` clean; ESLint clean on changed files.
- **Full frontend suite green: 215 tests, 34 files.**

## Scenarios now handled correctly
- Admin viewing the dashboard / user list / pipeline-reset panel when the access token expires mid-session → silent refresh + retry, stays signed in.
- User on their profile / sessions page when the access token expires → silent refresh + retry.
- Genuinely expired/revoked refresh cookie → single clean force-logout (unchanged).

## Follow-ups
- The `fetchWithRefresh` helper is now duplicated across `client.ts` (inlined), `admin-client.ts`, and `profile-client.ts`. A future cleanup could export one shared `fetchWithRefresh` from `token-refresh.ts` and adopt it in all three; kept per-file here to keep the diff tight and reviewable, matching the #1016 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
