### PR TITLE
tech-debt(i18n): extend translation to feature page-BODY strings (#998)

### DIFF
--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "منصة تحليل الحديث",
     "returnHome": "العودة إلى الصفحة الرئيسية",
-    "loading": "جارٍ التحميل…"
+    "loading": "جارٍ التحميل…",
+    "search": "بحث",
+    "previous": "السابق",
+    "next": "التالي",
+    "first": "الأول",
+    "last": "الأخير",
+    "go": "انتقل",
+    "error": "خطأ: {{message}}",
+    "pageOf": "الصفحة {{current}} من {{total}}",
+    "colNameArabic": "الاسم (بالعربية)",
+    "colNameEnglish": "الاسم (بالإنجليزية)"
   },
   "nav": {
     "ariaLabel": "التنقل الرئيسي",
@@ -47,5 +57,42 @@
     "apiRateLimited": "طلبات كثيرة جدًا — يرجى الانتظار لحظة والمحاولة مرة أخرى.",
     "apiServer": "حدث خطأ من جانبنا. يرجى المحاولة مرة أخرى بعد قليل.",
     "apiGeneric": "حدث خطأ ما. يرجى المحاولة مرة أخرى."
+  },
+  "narrators": {
+    "heading": "الرواة",
+    "searchPlaceholder": "ابحث عن الرواة…",
+    "searchLabel": "ابحث عن الرواة",
+    "emptyHeading": "لم يتم العثور على رواة",
+    "emptyBody": "حاول تعديل كلمات البحث أو مسح عامل التصفية.",
+    "colGeneration": "الطبقة",
+    "colTrustworthiness": "التوثيق",
+    "colCommunity": "المجتمع"
+  },
+  "collections": {
+    "heading": "المجموعات",
+    "colCompiler": "المؤلف",
+    "colSect": "المذهب",
+    "colHadiths": "الأحاديث"
+  },
+  "hadiths": {
+    "heading": "الأحاديث",
+    "searchPlaceholder": "ابحث في نص الحديث…",
+    "allCollections": "جميع المجموعات",
+    "allSources": "جميع المصادر",
+    "loadingSources": "جارٍ تحميل المصادر…",
+    "allGrades": "جميع الدرجات",
+    "clearFilters": "مسح عوامل التصفية",
+    "resultsFound_one": "تم العثور على حديث واحد",
+    "resultsFound_two": "تم العثور على حديثين",
+    "resultsFound_few": "تم العثور على {{count}} أحاديث",
+    "resultsFound_many": "تم العثور على {{count}} حديثًا",
+    "resultsFound_other": "تم العثور على {{count}} حديث",
+    "filteredSuffix": " (مُصفّى)",
+    "colTitle": "العنوان",
+    "colSource": "المصدر",
+    "colGrade": "الدرجة",
+    "colTopics": "المواضيع",
+    "jumpPlaceholder": "رقم الصفحة",
+    "show": "إظهار:"
   }
 }

--- a/frontend/src/i18n/locales/bs.json
+++ b/frontend/src/i18n/locales/bs.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Platforma za analizu hadisa",
     "returnHome": "Povratak na početnu",
-    "loading": "Učitavanje…"
+    "loading": "Učitavanje…",
+    "search": "Pretraži",
+    "previous": "Prethodno",
+    "next": "Sljedeće",
+    "first": "Prvo",
+    "last": "Posljednje",
+    "go": "Idi",
+    "error": "Greška: {{message}}",
+    "pageOf": "Stranica {{current}} od {{total}}",
+    "colNameArabic": "Ime (arapski)",
+    "colNameEnglish": "Ime (engleski)"
   },
   "nav": {
     "ariaLabel": "Glavna navigacija",
@@ -45,5 +55,40 @@
     "apiRateLimited": "Previše zahtjeva — molimo pričekajte trenutak i pokušajte ponovo.",
     "apiServer": "Nešto je pošlo po zlu na našoj strani. Molimo pokušajte ponovo uskoro.",
     "apiGeneric": "Nešto je pošlo po zlu. Molimo pokušajte ponovo."
+  },
+  "narrators": {
+    "heading": "Prenosioci",
+    "searchPlaceholder": "Pretraži prenosioce…",
+    "searchLabel": "Pretraži prenosioce",
+    "emptyHeading": "Nije pronađen nijedan prenosilac",
+    "emptyBody": "Pokušajte prilagoditi pojmove pretrage ili poništiti filter.",
+    "colGeneration": "Generacija",
+    "colTrustworthiness": "Pouzdanost",
+    "colCommunity": "Zajednica"
+  },
+  "collections": {
+    "heading": "Zbirke",
+    "colCompiler": "Sastavljač",
+    "colSect": "Pravac",
+    "colHadiths": "Hadisi"
+  },
+  "hadiths": {
+    "heading": "Hadisi",
+    "searchPlaceholder": "Pretraži tekst hadisa…",
+    "allCollections": "Sve zbirke",
+    "allSources": "Svi izvori",
+    "loadingSources": "Učitavanje izvora…",
+    "allGrades": "Sve ocjene",
+    "clearFilters": "Poništi filtere",
+    "resultsFound_one": "Pronađen {{count}} hadis",
+    "resultsFound_few": "Pronađena {{count}} hadisa",
+    "resultsFound_other": "Pronađeno {{count}} hadisa",
+    "filteredSuffix": " (filtrirano)",
+    "colTitle": "Naslov",
+    "colSource": "Izvor",
+    "colGrade": "Ocjena",
+    "colTopics": "Teme",
+    "jumpPlaceholder": "Stranica #",
+    "show": "Prikaži:"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Hadith Analysis Platform",
     "returnHome": "Return home",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "search": "Search",
+    "previous": "Previous",
+    "next": "Next",
+    "first": "First",
+    "last": "Last",
+    "go": "Go",
+    "error": "Error: {{message}}",
+    "pageOf": "Page {{current}} of {{total}}",
+    "colNameArabic": "Name (Arabic)",
+    "colNameEnglish": "Name (English)"
   },
   "nav": {
     "ariaLabel": "Main navigation",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Too many requests — please wait a moment and try again.",
     "apiServer": "Something went wrong on our end. Please try again shortly.",
     "apiGeneric": "Something went wrong. Please try again."
+  },
+  "narrators": {
+    "heading": "Narrators",
+    "searchPlaceholder": "Search narrators…",
+    "searchLabel": "Search narrators",
+    "emptyHeading": "No narrators found",
+    "emptyBody": "Try adjusting your search terms or clearing the filter.",
+    "colGeneration": "Generation",
+    "colTrustworthiness": "Trustworthiness",
+    "colCommunity": "Community"
+  },
+  "collections": {
+    "heading": "Collections",
+    "colCompiler": "Compiler",
+    "colSect": "Sect",
+    "colHadiths": "Hadiths"
+  },
+  "hadiths": {
+    "heading": "Hadiths",
+    "searchPlaceholder": "Search hadith text…",
+    "allCollections": "All Collections",
+    "allSources": "All Sources",
+    "loadingSources": "Loading sources…",
+    "allGrades": "All Grades",
+    "clearFilters": "Clear filters",
+    "resultsFound_one": "{{count}} hadith found",
+    "resultsFound_other": "{{count}} hadiths found",
+    "filteredSuffix": " (filtered)",
+    "colTitle": "Title",
+    "colSource": "Source",
+    "colGrade": "Grade",
+    "colTopics": "Topics",
+    "jumpPlaceholder": "Page #",
+    "show": "Show:"
   }
 }

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Platform Analisis Hadis",
     "returnHome": "Kembali ke beranda",
-    "loading": "Memuat…"
+    "loading": "Memuat…",
+    "search": "Cari",
+    "previous": "Sebelumnya",
+    "next": "Berikutnya",
+    "first": "Pertama",
+    "last": "Terakhir",
+    "go": "Buka",
+    "error": "Kesalahan: {{message}}",
+    "pageOf": "Halaman {{current}} dari {{total}}",
+    "colNameArabic": "Nama (Arab)",
+    "colNameEnglish": "Nama (Inggris)"
   },
   "nav": {
     "ariaLabel": "Navigasi utama",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Terlalu banyak permintaan — harap tunggu sebentar dan coba lagi.",
     "apiServer": "Terjadi kesalahan di pihak kami. Silakan coba lagi sebentar lagi.",
     "apiGeneric": "Terjadi kesalahan. Silakan coba lagi."
+  },
+  "narrators": {
+    "heading": "Perawi",
+    "searchPlaceholder": "Cari perawi…",
+    "searchLabel": "Cari perawi",
+    "emptyHeading": "Tidak ada perawi ditemukan",
+    "emptyBody": "Coba sesuaikan kata kunci pencarian Anda atau hapus filter.",
+    "colGeneration": "Generasi",
+    "colTrustworthiness": "Kredibilitas",
+    "colCommunity": "Komunitas"
+  },
+  "collections": {
+    "heading": "Koleksi",
+    "colCompiler": "Penyusun",
+    "colSect": "Mazhab",
+    "colHadiths": "Hadis"
+  },
+  "hadiths": {
+    "heading": "Hadis",
+    "searchPlaceholder": "Cari teks hadis…",
+    "allCollections": "Semua Koleksi",
+    "allSources": "Semua Sumber",
+    "loadingSources": "Memuat sumber…",
+    "allGrades": "Semua Derajat",
+    "clearFilters": "Hapus filter",
+    "resultsFound_one": "{{count}} hadis ditemukan",
+    "resultsFound_other": "{{count}} hadis ditemukan",
+    "filteredSuffix": " (difilter)",
+    "colTitle": "Judul",
+    "colSource": "Sumber",
+    "colGrade": "Derajat",
+    "colTopics": "Topik",
+    "jumpPlaceholder": "Halaman #",
+    "show": "Tampilkan:"
   }
 }

--- a/frontend/src/i18n/locales/ms.json
+++ b/frontend/src/i18n/locales/ms.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Platform Analisis Hadis",
     "returnHome": "Kembali ke laman utama",
-    "loading": "Memuatkan…"
+    "loading": "Memuatkan…",
+    "search": "Cari",
+    "previous": "Sebelumnya",
+    "next": "Seterusnya",
+    "first": "Pertama",
+    "last": "Terakhir",
+    "go": "Pergi",
+    "error": "Ralat: {{message}}",
+    "pageOf": "Halaman {{current}} daripada {{total}}",
+    "colNameArabic": "Nama (Arab)",
+    "colNameEnglish": "Nama (Inggeris)"
   },
   "nav": {
     "ariaLabel": "Navigasi utama",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Terlalu banyak permintaan — sila tunggu sebentar dan cuba lagi.",
     "apiServer": "Sesuatu tidak kena di pihak kami. Sila cuba lagi sebentar lagi.",
     "apiGeneric": "Sesuatu tidak kena. Sila cuba lagi."
+  },
+  "narrators": {
+    "heading": "Perawi",
+    "searchPlaceholder": "Cari perawi…",
+    "searchLabel": "Cari perawi",
+    "emptyHeading": "Tiada perawi dijumpai",
+    "emptyBody": "Cuba laraskan istilah carian anda atau kosongkan penapis.",
+    "colGeneration": "Generasi",
+    "colTrustworthiness": "Kebolehpercayaan",
+    "colCommunity": "Komuniti"
+  },
+  "collections": {
+    "heading": "Koleksi",
+    "colCompiler": "Penyusun",
+    "colSect": "Mazhab",
+    "colHadiths": "Hadis"
+  },
+  "hadiths": {
+    "heading": "Hadis",
+    "searchPlaceholder": "Cari teks hadis…",
+    "allCollections": "Semua Koleksi",
+    "allSources": "Semua Sumber",
+    "loadingSources": "Memuatkan sumber…",
+    "allGrades": "Semua Gred",
+    "clearFilters": "Kosongkan penapis",
+    "resultsFound_one": "{{count}} hadis dijumpai",
+    "resultsFound_other": "{{count}} hadis dijumpai",
+    "filteredSuffix": " (ditapis)",
+    "colTitle": "Tajuk",
+    "colSource": "Sumber",
+    "colGrade": "Gred",
+    "colTopics": "Topik",
+    "jumpPlaceholder": "Halaman #",
+    "show": "Papar:"
   }
 }

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Hadis Analiz Platformu",
     "returnHome": "Ana sayfaya dön",
-    "loading": "Yükleniyor…"
+    "loading": "Yükleniyor…",
+    "search": "Ara",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "first": "İlk",
+    "last": "Son",
+    "go": "Git",
+    "error": "Hata: {{message}}",
+    "pageOf": "Sayfa {{current}} / {{total}}",
+    "colNameArabic": "Ad (Arapça)",
+    "colNameEnglish": "Ad (İngilizce)"
   },
   "nav": {
     "ariaLabel": "Ana gezinme",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Çok fazla istek — lütfen biraz bekleyip tekrar deneyin.",
     "apiServer": "Tarafımızda bir şeyler ters gitti. Lütfen birazdan tekrar deneyin.",
     "apiGeneric": "Bir şeyler ters gitti. Lütfen tekrar deneyin."
+  },
+  "narrators": {
+    "heading": "Raviler",
+    "searchPlaceholder": "Ravilerde ara…",
+    "searchLabel": "Ravilerde ara",
+    "emptyHeading": "Ravi bulunamadı",
+    "emptyBody": "Arama terimlerinizi değiştirmeyi veya filtreyi temizlemeyi deneyin.",
+    "colGeneration": "Nesil",
+    "colTrustworthiness": "Güvenilirlik",
+    "colCommunity": "Topluluk"
+  },
+  "collections": {
+    "heading": "Koleksiyonlar",
+    "colCompiler": "Derleyen",
+    "colSect": "Mezhep",
+    "colHadiths": "Hadisler"
+  },
+  "hadiths": {
+    "heading": "Hadisler",
+    "searchPlaceholder": "Hadis metninde ara…",
+    "allCollections": "Tüm Koleksiyonlar",
+    "allSources": "Tüm Kaynaklar",
+    "loadingSources": "Kaynaklar yükleniyor…",
+    "allGrades": "Tüm Dereceler",
+    "clearFilters": "Filtreleri temizle",
+    "resultsFound_one": "{{count}} hadis bulundu",
+    "resultsFound_other": "{{count}} hadis bulundu",
+    "filteredSuffix": " (filtrelenmiş)",
+    "colTitle": "Başlık",
+    "colSource": "Kaynak",
+    "colGrade": "Derece",
+    "colTopics": "Konular",
+    "jumpPlaceholder": "Sayfa #",
+    "show": "Göster:"
   }
 }

--- a/frontend/src/i18n/locales/ur.json
+++ b/frontend/src/i18n/locales/ur.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "حدیث تجزیہ پلیٹ فارم",
     "returnHome": "ہوم پیج پر واپس جائیں",
-    "loading": "لوڈ ہو رہا ہے…"
+    "loading": "لوڈ ہو رہا ہے…",
+    "search": "تلاش کریں",
+    "previous": "پچھلا",
+    "next": "اگلا",
+    "first": "پہلا",
+    "last": "آخری",
+    "go": "جائیں",
+    "error": "خرابی: {{message}}",
+    "pageOf": "صفحہ {{current}} از {{total}}",
+    "colNameArabic": "نام (عربی)",
+    "colNameEnglish": "نام (انگریزی)"
   },
   "nav": {
     "ariaLabel": "مرکزی نیویگیشن",
@@ -44,5 +54,39 @@
     "apiRateLimited": "بہت زیادہ درخواستیں — براہ کرم تھوڑی دیر انتظار کریں اور دوبارہ کوشش کریں۔",
     "apiServer": "ہماری طرف سے کچھ غلط ہو گیا۔ براہ کرم تھوڑی دیر بعد دوبارہ کوشش کریں۔",
     "apiGeneric": "کچھ غلط ہو گیا۔ براہ کرم دوبارہ کوشش کریں۔"
+  },
+  "narrators": {
+    "heading": "راوی",
+    "searchPlaceholder": "راویوں کو تلاش کریں…",
+    "searchLabel": "راویوں کو تلاش کریں",
+    "emptyHeading": "کوئی راوی نہیں ملا",
+    "emptyBody": "اپنے تلاش کے الفاظ کو تبدیل کریں یا فلٹر صاف کریں۔",
+    "colGeneration": "طبقہ",
+    "colTrustworthiness": "وثاقت",
+    "colCommunity": "برادری"
+  },
+  "collections": {
+    "heading": "مجموعے",
+    "colCompiler": "مؤلف",
+    "colSect": "مسلک",
+    "colHadiths": "احادیث"
+  },
+  "hadiths": {
+    "heading": "احادیث",
+    "searchPlaceholder": "حدیث کے متن میں تلاش کریں…",
+    "allCollections": "تمام مجموعے",
+    "allSources": "تمام ذرائع",
+    "loadingSources": "ذرائع لوڈ ہو رہے ہیں…",
+    "allGrades": "تمام درجات",
+    "clearFilters": "فلٹرز صاف کریں",
+    "resultsFound_one": "{{count}} حدیث ملی",
+    "resultsFound_other": "{{count}} احادیث ملیں",
+    "filteredSuffix": " (فلٹر شدہ)",
+    "colTitle": "عنوان",
+    "colSource": "ماخذ",
+    "colGrade": "درجہ",
+    "colTopics": "موضوعات",
+    "jumpPlaceholder": "صفحہ #",
+    "show": "دکھائیں:"
   }
 }

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
 import { fetchCollections } from '../api/client'
 
 export default function CollectionsPage() {
+  const { t } = useTranslation()
   const navigate = useNavigate()
 
   const { data, isLoading, error } = useQuery({
@@ -12,7 +14,7 @@ export default function CollectionsPage() {
 
   return (
     <div>
-      <h2 className="page-heading">Collections</h2>
+      <h2 className="page-heading">{t('collections.heading')}</h2>
 
       {isLoading && (
         <div>
@@ -21,17 +23,17 @@ export default function CollectionsPage() {
           ))}
         </div>
       )}
-      {error && <p className="error-text">Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">{t('common.error', { message: (error as Error).message })}</p>}
 
       {data && (
         <table className="data-table">
           <thead>
             <tr>
-              <th>Name (Arabic)</th>
-              <th>Name (English)</th>
-              <th>Compiler</th>
-              <th>Sect</th>
-              <th style={{ textAlign: 'right' }}>Hadiths</th>
+              <th>{t('common.colNameArabic')}</th>
+              <th>{t('common.colNameEnglish')}</th>
+              <th>{t('collections.colCompiler')}</th>
+              <th>{t('collections.colSect')}</th>
+              <th style={{ textAlign: 'right' }}>{t('collections.colHadiths')}</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -1,11 +1,13 @@
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { fetchHadiths, fetchCollections, fetchHadithFacets } from '../api/client'
 
 const PAGE_SIZES = [25, 50, 100] as const
 
 export default function HadithsPage() {
+  const { t } = useTranslation()
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState<number>(25)
   const [searchInput, setSearchInput] = useState('')
@@ -85,7 +87,7 @@ export default function HadithsPage() {
 
   return (
     <div>
-      <h2 className="page-heading">Hadiths</h2>
+      <h2 className="page-heading">{t('hadiths.heading')}</h2>
 
       {/* Filter controls */}
       <div className="mb-4" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', alignItems: 'flex-end' }}>
@@ -93,7 +95,7 @@ export default function HadithsPage() {
         <form onSubmit={handleSearch} style={{ display: 'flex', gap: '0.5rem' }}>
           <input
             type="text"
-            placeholder="Search hadith text..."
+            placeholder={t('hadiths.searchPlaceholder')}
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             className="filter-input"
@@ -118,7 +120,7 @@ export default function HadithsPage() {
               cursor: 'pointer',
             }}
           >
-            Search
+            {t('common.search')}
           </button>
         </form>
 
@@ -134,7 +136,7 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">All Collections</option>
+          <option value="">{t('hadiths.allCollections')}</option>
           {collectionsData?.items.map((c) => (
             <option key={c.id} value={c.name_en}>
               {c.name_en}
@@ -155,7 +157,7 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">{facetsLoading ? 'Loading sources...' : 'All Sources'}</option>
+          <option value="">{facetsLoading ? t('hadiths.loadingSources') : t('hadiths.allSources')}</option>
           {facetsData?.source_corpus.map((s) => (
             <option key={s} value={s}>
               {s}
@@ -175,7 +177,10 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">All Grades</option>
+          <option value="">{t('hadiths.allGrades')}</option>
+          {/* Grade names are scholarly classification terms that mirror the
+              untransformed API grade values shown in result badges, so per the
+              i18n scope policy (#703/#998) they are intentionally left as-is. */}
           <option value="sahih">Sahih</option>
           <option value="hasan">Hasan</option>
           <option value="da'if">Da'if</option>
@@ -194,7 +199,7 @@ export default function HadithsPage() {
               cursor: 'pointer',
             }}
           >
-            Clear filters
+            {t('hadiths.clearFilters')}
           </button>
         )}
       </div>
@@ -206,23 +211,23 @@ export default function HadithsPage() {
           ))}
         </div>
       )}
-      {error && <p className="error-text">Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">{t('common.error', { message: (error as Error).message })}</p>}
 
       {data && (
         <>
           {/* Results summary */}
           <p className="text-sm mb-2" style={{ color: 'var(--color-muted-foreground)' }}>
-            {data.total.toLocaleString()} hadith{data.total !== 1 ? 's' : ''} found
-            {hasActiveFilters ? ' (filtered)' : ''}
+            {t('hadiths.resultsFound', { count: data.total })}
+            {hasActiveFilters ? t('hadiths.filteredSuffix') : ''}
           </p>
 
           <table className="data-table">
             <thead>
               <tr>
-                <th>Title</th>
-                <th>Source</th>
-                {hasGrades && <th>Grade</th>}
-                {hasTopics && <th>Topics</th>}
+                <th>{t('hadiths.colTitle')}</th>
+                <th>{t('hadiths.colSource')}</th>
+                {hasGrades && <th>{t('hadiths.colGrade')}</th>}
+                {hasTopics && <th>{t('hadiths.colTopics')}</th>}
               </tr>
             </thead>
             <tbody>
@@ -268,19 +273,19 @@ export default function HadithsPage() {
           <div className="pagination" style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap', marginTop: '1rem' }}>
             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
               <button disabled={page <= 1} onClick={() => setPage(1)}>
-                First
+                {t('common.first')}
               </button>
               <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-                Previous
+                {t('common.previous')}
               </button>
               <span>
-                Page {data.page} of {totalPages.toLocaleString()}
+                {t('common.pageOf', { current: data.page, total: totalPages.toLocaleString() })}
               </span>
               <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
-                Next
+                {t('common.next')}
               </button>
               <button disabled={page >= totalPages} onClick={() => setPage(totalPages)}>
-                Last
+                {t('common.last')}
               </button>
             </div>
 
@@ -292,7 +297,7 @@ export default function HadithsPage() {
                 max={totalPages}
                 value={jumpPage}
                 onChange={(e) => setJumpPage(e.target.value)}
-                placeholder="Page #"
+                placeholder={t('hadiths.jumpPlaceholder')}
                 style={{
                   width: '5rem',
                   padding: '0.25rem 0.5rem',
@@ -302,12 +307,12 @@ export default function HadithsPage() {
                   color: 'var(--color-foreground)',
                 }}
               />
-              <button type="submit">Go</button>
+              <button type="submit">{t('common.go')}</button>
             </form>
 
             {/* Page size selector */}
             <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
-              <span style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>Show:</span>
+              <span style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>{t('hadiths.show')}</span>
               {PAGE_SIZES.map((size) => (
                 <button
                   key={size}

--- a/frontend/src/pages/NarratorsPage.tsx
+++ b/frontend/src/pages/NarratorsPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { fetchNarrators } from '../api/client'
 
 export default function NarratorsPage() {
+  const { t } = useTranslation()
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState('')
   const [inputValue, setInputValue] = useState('')
@@ -23,13 +25,13 @@ export default function NarratorsPage() {
 
   return (
     <div>
-      <h2 className="page-heading">Narrators</h2>
+      <h2 className="page-heading">{t('narrators.heading')}</h2>
 
       <div className="flex-row" style={{ marginBottom: 'var(--spacing-4)' }}>
         <input
           type="text"
-          placeholder="Search narrators..."
-          aria-label="Search narrators"
+          placeholder={t('narrators.searchPlaceholder')}
+          aria-label={t('narrators.searchLabel')}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
@@ -37,7 +39,7 @@ export default function NarratorsPage() {
           style={{ flex: 1, maxWidth: 400 }}
         />
         <button onClick={handleSearch} className="btn-primary">
-          Search
+          {t('common.search')}
         </button>
       </div>
 
@@ -48,7 +50,7 @@ export default function NarratorsPage() {
           ))}
         </div>
       )}
-      {error && <p className="error-text">Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">{t('common.error', { message: (error as Error).message })}</p>}
 
       {data && data.items.length === 0 && (
         <div className="empty-state">
@@ -58,9 +60,9 @@ export default function NarratorsPage() {
               <path d="m21 21-4.3-4.3" />
             </svg>
           </div>
-          <div className="empty-state-heading">No narrators found</div>
+          <div className="empty-state-heading">{t('narrators.emptyHeading')}</div>
           <div className="empty-state-body">
-            Try adjusting your search terms or clearing the filter.
+            {t('narrators.emptyBody')}
           </div>
         </div>
       )}
@@ -70,11 +72,11 @@ export default function NarratorsPage() {
           <table className="data-table">
             <thead>
               <tr>
-                <th>Name (Arabic)</th>
-                <th>Name (English)</th>
-                <th>Generation</th>
-                <th>Trustworthiness</th>
-                <th>Community</th>
+                <th>{t('common.colNameArabic')}</th>
+                <th>{t('common.colNameEnglish')}</th>
+                <th>{t('narrators.colGeneration')}</th>
+                <th>{t('narrators.colTrustworthiness')}</th>
+                <th>{t('narrators.colCommunity')}</th>
               </tr>
             </thead>
             <tbody>
@@ -99,13 +101,13 @@ export default function NarratorsPage() {
 
           <div className="pagination">
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-              Previous
+              {t('common.previous')}
             </button>
             <span>
-              Page {data.page} of {totalPages}
+              {t('common.pageOf', { current: data.page, total: totalPages })}
             </span>
             <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
-              Next
+              {t('common.next')}
             </button>
           </div>
         </>


### PR DESCRIPTION
## Summary

Closes #998 — extends i18next coverage from UI **chrome** (nav/header/user-menu/404/switcher, shipped in #703) to the page-**BODY** strings on the three highest-traffic public browse pages.

Tech-debt intake item for P5W2.

## Pages in scope
- **NarratorsPage** — heading, search placeholder + aria-label, empty state (heading + body), table headers (Name Arabic/English, Generation, Trustworthiness, Community), pagination.
- **CollectionsPage** — heading, table headers (Name Arabic/English, Compiler, Sect, Hadiths), error text.
- **HadithsPage** — heading, search placeholder, filter labels (All Collections / All Sources / loading sources / All Grades / Clear filters), pluralized results count + "(filtered)" suffix, table headers (Title, Source, Grade, Topics), full pagination block (First/Previous/Page X of Y/Next/Last), jump-to-page placeholder, page-size "Show:" label.

## Keys
Added to the existing single `translation` namespace across **all 7 locales** (en, tr, id, ms, ar, bs, ur):
- `common.*` — reusable: search, previous, next, first, last, go, `error` (interpolated), `pageOf` (interpolated), `colNameArabic`, `colNameEnglish`
- `narrators.*`, `collections.*`, `hadiths.*` — page-specific body strings
- `hadiths.resultsFound` uses i18next plural forms (CLDR categories per locale — Arabic one/two/few/many/other, Bosnian one/few/other).

## Scope policy (i18n = UI only)
Per #703 / #998 and org policy: **source/API data is never routed through i18next.** Untouched: narrator names (`name_ar`/`name_en`), hadith titles, collection names, sect/grade **badge values**, topic tags — all rendered as-is from the API.

One deliberate call: the **grade FILTER option labels** (Sahih / Hasan / Da'if / Mawdu') are intentionally **left untranslated**, because they mirror the untransformed API grade values displayed in the result badges — translating the dropdown but not the badge would desync them. Documented with an inline comment. Happy to revisit if reviewers prefer otherwise.

## Verification
- `locales.test.ts` (base-key parity across all 7 locales + no-empty-strings): **21 passed**
- Full frontend suite: **203 passed / 32 files**
- `tsc --noEmit`: clean
- ESLint: **0 errors** (11 pre-existing warnings in unrelated files: TimelinePage, admin/ConfigPage)
- `npm run build`: success
- Key-resolution check: every `t('…')` key used in the three pages resolves against `en.json` (no silent key-as-text fallthrough).

## Follow-up (not in scope — smaller-PR preference)
SearchPage, ComparativePage, TimelinePage, GraphExplorerPage, the detail pages, and all `admin/*` pages still hold inline English body copy. Recommend a follow-up tech-debt issue to continue the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
