### PR TITLE
fix(search): align frontend results-page limit with endpoint cap (#1025)

### DIFF
--- a/frontend/src/api/__tests__/search-limits.test.ts
+++ b/frontend/src/api/__tests__/search-limits.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  searchAll,
+  searchSemantic,
+  SEARCH_MAX_LIMIT,
+  SEMANTIC_SEARCH_MAX_LIMIT,
+} from '../client'
+
+// The backend caps each search endpoint's ``limit`` query param (FastAPI
+// ``Query(..., le=N)`` in ``src/api/routes/search.py``). Requesting more than
+// the cap is rejected with a 422 before the query runs, which broke the full
+// results page when it asked for limit=200 (#1025). These caps mirror the
+// server bounds; if the server bounds change, update both sides together.
+const SERVER_SEARCH_CAP = 100 // /search        -> Query(20, ge=1, le=100)
+const SERVER_SEMANTIC_CAP = 50 // /search/semantic -> Query(10, ge=1, le=50)
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(jsonResponse({ results: [], total: 0 }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('search limit contract (#1025)', () => {
+  it('the keyword-search results-page limit is within the server cap', () => {
+    expect(SEARCH_MAX_LIMIT).toBeLessThanOrEqual(SERVER_SEARCH_CAP)
+  })
+
+  it('the semantic-search results-page limit is within the server cap', () => {
+    expect(SEMANTIC_SEARCH_MAX_LIMIT).toBeLessThanOrEqual(SERVER_SEMANTIC_CAP)
+  })
+
+  it('searchAll sends the requested limit in the query string', async () => {
+    await searchAll('prayer', SEARCH_MAX_LIMIT)
+    const url = fetchMock.mock.calls[0]?.[0] as string
+    expect(url).toContain('/api/v1/search?')
+    expect(url).toContain(`limit=${SEARCH_MAX_LIMIT}`)
+  })
+
+  it('searchSemantic sends the requested limit in the query string', async () => {
+    await searchSemantic('prayer', SEMANTIC_SEARCH_MAX_LIMIT)
+    const url = fetchMock.mock.calls[0]?.[0] as string
+    expect(url).toContain('/api/v1/search/semantic?')
+    expect(url).toContain(`limit=${SEMANTIC_SEARCH_MAX_LIMIT}`)
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -143,6 +143,14 @@ export async function fetchGraphNetwork(
   )
 }
 
+// Maximum result counts the backend will accept for each search endpoint.
+// These MUST stay in sync with the ``limit`` ``le=`` bounds in
+// ``src/api/routes/search.py`` — requesting more triggers a 422 request
+// validation failure (#1025). The full results page requests the cap so it
+// shows as many matches as the endpoint allows in a single page.
+export const SEARCH_MAX_LIMIT = 100
+export const SEMANTIC_SEARCH_MAX_LIMIT = 50
+
 export async function searchAll(
   query: string,
   limit = 20,

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { searchAll, searchSemantic } from '../api/client'
+import {
+  searchAll,
+  searchSemantic,
+  SEARCH_MAX_LIMIT,
+  SEMANTIC_SEARCH_MAX_LIMIT,
+} from '../api/client'
 import { Card, CardContent } from '../components/ui/Card'
 import { Badge } from '../components/ui/Badge'
 import { Input } from '../components/ui/Input'
@@ -127,7 +132,9 @@ export default function SearchPage() {
   const { data: searchData, isLoading, isError, error: searchError } = useQuery({
     queryKey: ['search', query, mode],
     queryFn: () =>
-      mode === 'semantic' ? searchSemantic(query, 200) : searchAll(query, 200),
+      mode === 'semantic'
+        ? searchSemantic(query, SEMANTIC_SEARCH_MAX_LIMIT)
+        : searchAll(query, SEARCH_MAX_LIMIT),
     enabled: query.length >= 2,
     retry: 1,
   })

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -74,6 +74,21 @@ def test_search_total_exceeds_limit(client: TestClient, mock_neo4j: MagicMock) -
     assert body["total"] == 180
 
 
+def test_search_limit_at_cap_is_accepted(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """limit at the endpoint cap (100) is accepted — the frontend results page
+    requests this much, so the cap must cover it (#1025)."""
+    mock_neo4j.execute_read.return_value = []
+    resp = client.get("/api/v1/search?q=test&limit=100")
+    assert resp.status_code == 200
+
+
+def test_search_limit_over_cap_is_422(client: TestClient) -> None:
+    """limit above the cap is rejected with 422 before any query runs. This is
+    the failure the frontend hit when it asked for limit=200 (#1025)."""
+    resp = client.get("/api/v1/search?q=test&limit=101")
+    assert resp.status_code == 422
+
+
 def test_search_falls_back_to_contains(client: TestClient, mock_neo4j: MagicMock) -> None:
     """When full-text index is unavailable, falls back to CONTAINS."""
     # narrator: fulltext raises, CONTAINS fallback succeeds
@@ -198,4 +213,48 @@ def test_semantic_search_returns_results_when_pg_available(client: TestClient, a
     assert body["results"][0]["score"] == 0.92
 
     # Clean up override
+    del app.dependency_overrides[get_pg]
+
+
+def test_semantic_search_limit_over_cap_is_422(client: TestClient, app: object) -> None:
+    """semantic limit above its cap (50) is rejected with 422 — the frontend
+    results page must stay within this cap (#1025).
+
+    The pg dependency is overridden with a mock so the assertion isolates the
+    request-validation behaviour and never touches a real database (FastAPI
+    resolves dependencies while validating params)."""
+    mock_pg = MagicMock()
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test&limit=51")
+    assert resp.status_code == 422
+    # Validation rejects the request before the handler queries pgvector.
+    mock_pg.execute.assert_not_called()
+
+    del app.dependency_overrides[get_pg]
+
+
+def test_semantic_search_limit_at_cap_is_accepted(client: TestClient, app: object) -> None:
+    """semantic limit at its cap (50) is accepted (#1025)."""
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = [[], [{"total": 0}]]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test&limit=50")
+    assert resp.status_code == 200
+
     del app.dependency_overrides[get_pg]


### PR DESCRIPTION
Closes #1025

## Root cause
The full-text **Search results page failed with HTTP 422**. `SearchPage.tsx` requested `limit=200` for the full-results query, but the search endpoints cap the `limit` query param:

- `GET /api/v1/search` → `Query(20, ge=1, le=100)`
- `GET /api/v1/search/semantic` → `Query(10, ge=1, le=50)`

FastAPI rejected `limit=200` with a request-validation 422 **before the query ran**, so the results page showed a "Retry" error and zero results. The autocomplete (`limit=9`) was within bounds, so the dropdown worked — which is why the bug only showed on submit.

## Fix
Align the two sides by lowering the frontend results-page limit to the endpoint cap (rather than raising the server cap, which would pull unbounded result sets):

- `frontend/src/api/client.ts`: export `SEARCH_MAX_LIMIT = 100` and `SEMANTIC_SEARCH_MAX_LIMIT = 50`, mirroring the server `le=` bounds (comment cross-references `src/api/routes/search.py`).
- `frontend/src/pages/SearchPage.tsx`: the full-results query now requests those constants instead of `200`.

No change to `searchAll` / `searchSemantic` signatures, the collection facet, or `subscriptions/me` — those are #1026 (coordinated with Mateo; our edits touch different regions of `SearchPage.tsx`).

## Verification
**Frontend** (`frontend/src/api/__tests__/search-limits.test.ts`, new — 4 tests):
- asserts each results-page limit is ≤ the documented server cap (the test the issue asked for);
- asserts `searchAll`/`searchSemantic` send the requested limit verbatim in the query string.
```
✓ src/api/__tests__/search-limits.test.ts (4 tests)
Test Files  1 passed (1)   Tests  4 passed (4)
```
`npx tsc --noEmit` and `npx eslint` on the changed files: clean.

**Backend** (`tests/test_api/test_search.py`, +4 tests) — cap boundary for both endpoints:
- `/search`: `limit=100` → 200, `limit=101` → 422
- `/search/semantic`: `limit=50` → 200, `limit=51` → 422 (pg dependency mocked so the assertions isolate request validation and don't touch a real DB)
```
13 passed in 14.53s
```
`ruff check` / `ruff format --check`: clean.

**Live trace** — the originating bug-bash trace (issue #1025) was `?q=prayer&limit=200 → 422`. With this change the results page requests `limit=100` (keyword) / `limit=50` (semantic), both within the server caps, so the request validates and returns 200. A post-merge staging re-trace on `/search` is listed below as a Test Plan item.

## Test Plan (post-merge / staging)
- [ ] On staging `/search`, submit a query and confirm `GET /api/v1/search?...&limit=100` returns 200 and the results render (no "Retry").
- [ ] Toggle to semantic mode and confirm `?...&limit=50` returns 200.

## Notes
- This bug is request-validation only; no data/loader involvement.
