### PR TITLE
fix(api): GET /narrators returns 500 on sparse narrator data (#1024)

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -51,16 +51,21 @@ class NarratorResponse(BaseModel):
 
     id: str
     name_ar: str
-    name_en: str
+    # name_en and the structured biographical fields below are sparse on real
+    # loaded data (most narrators lack an English transliteration, generation,
+    # gender, sect, or a trustworthiness grade). They are optional so a node
+    # missing them serializes cleanly instead of raising a Pydantic
+    # ValidationError → HTTP 500 on GET /narrators (#1024).
+    name_en: str | None = None
     kunya: str | None = None
     nisba: str | None = None
     laqab: str | None = None
     birth_year_ah: int | None = None
     death_year_ah: int | None = None
-    generation: str
-    gender: str
-    sect_affiliation: str
-    trustworthiness_consensus: str
+    generation: str | None = None
+    gender: str | None = None
+    sect_affiliation: str | None = None
+    trustworthiness_consensus: str | None = None
     aliases: list[str] = []
     betweenness_centrality: float | None = None
     in_degree: int | None = None

--- a/tests/test_api/test_narrators.py
+++ b/tests/test_api/test_narrators.py
@@ -16,6 +16,14 @@ SAMPLE_NARRATOR = {
     "trustworthiness_consensus": "thiqah",
 }
 
+# A narrator node carrying only the always-present fields — most real loaded
+# narrators lack name_en / generation / gender / sect / trustworthiness. Before
+# #1024 these absent required fields raised a Pydantic ValidationError → 500.
+SPARSE_NARRATOR = {
+    "id": "nar-sparse",
+    "name_ar": "فلان بن فلان",
+}
+
 
 def test_list_narrators_empty(client: TestClient) -> None:
     """GET /api/v1/narrators returns empty paginated response when no data."""
@@ -41,6 +49,26 @@ def test_list_narrators_with_data(client: TestClient, mock_neo4j: MagicMock) -> 
     assert len(body["items"]) == 1
     assert body["items"][0]["id"] == "nar-001"
     assert body["items"][0]["name_en"] == "Abu Hurayra"
+
+
+def test_list_narrators_sparse_node(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """A narrator missing the sparse biographical fields serializes as 200, not 500 (#1024)."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 1}],
+        [{"props": SPARSE_NARRATOR}],
+    ]
+    resp = client.get("/api/v1/narrators")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    item = body["items"][0]
+    assert item["id"] == "nar-sparse"
+    # The absent fields come back as null rather than raising a validation error.
+    assert item["name_en"] is None
+    assert item["generation"] is None
+    assert item["gender"] is None
+    assert item["sect_affiliation"] is None
+    assert item["trustworthiness_consensus"] is None
 
 
 def test_list_narrators_pagination(client: TestClient, mock_neo4j: MagicMock) -> None:


### PR DESCRIPTION
## Summary
`GET /api/v1/narrators` 500s because `NarratorResponse` (src/api/models.py) declares `name_en`, `generation`, `gender`, `sect_affiliation`, `trustworthiness_consensus` as **required** `str`, but `narrators.py` constructs the response via `NarratorResponse(**node_props)` and most loaded narrators lack those fields → Pydantic `ValidationError` → HTTP 500 on the whole list endpoint.

## Fix
- Make those five fields `str | None = None` — they are **genuinely sparse** on real loaded data (most narrators have no English transliteration, generation, gender, sect, or trustworthiness grade). `id` and `name_ar` remain required.
- Add a regression test (`test_list_narrators_sparse_node`) with a bare `{id, name_ar}` node. The existing `SAMPLE_NARRATOR` fixture was fully-populated and masked this (fixture-masks-bug class, cf. #671).

## Why it matters
This is the seed-path unblock for **both** `/graph` (narrator search seeding) and narrator search/browse.

## Verification
- `NarratorResponse` constructs cleanly from a sparse `{id, name_ar}` dict (all five fields → `None`); full node still validates.
- `ruff check` + `ruff format --check` clean; `mypy` passes on the changed model.
- Full pytest suite deferred to CI (the `client` fixture's app startup blocks on DB connections unavailable in the sandbox).

Closes #1024