### PR TITLE
Phase 5 Wave 2 → main (isnad-graph) — API light-up

### DIFF
--- a/frontend/src/api/__tests__/admin-client-refresh.test.ts
+++ b/frontend/src/api/__tests__/admin-client-refresh.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  fetchSystemHealth,
+  fetchAdminUser,
+  resetStage,
+  ResetError,
+} from '../admin-client'
+import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
+
+// Fetch-boundary regression tests for the #1021 fix: the admin clients must
+// mirror the #1016 data-client recovery — attempt a token refresh
+// (POST /auth/token/refresh, via the httpOnly refresh cookie) and retry the
+// original request ONCE on a 401 before declaring the session expired. Before
+// this fix every admin 401 (isnad-graph admin API via `fetchAdminJson`,
+// user-service admin API via `fetchUserServiceJson`, and the cross-service
+// pipeline reset via `postReset`) force-logged-out immediately, so a mid-session
+// access-token expiry bounced admins despite a valid refresh cookie. These drive
+// the REAL clients against a stubbed `fetch`, asserting the actual request
+// sequence the mocked component tests can't see.
+
+const REFRESH_URL = '/auth/token/refresh'
+// In the test env (no window.RUNTIME_CONFIG / VITE_USER_SERVICE_ORIGIN) the
+// origin resolves to '' (same-origin), so the user-service + admin URLs are bare.
+const HEALTH_URL = '/api/v1/admin/health/ready'
+const USERS_URL = '/api/v1/users'
+const RESET_STAGE_URL = '/admin/reset/stage'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+function callsTo(substr: string): Array<{ url: string; init: RequestInit | undefined }> {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: c[1] as RequestInit | undefined }))
+    .filter((c) => c.url.includes(substr))
+}
+
+function authHeader(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.Authorization
+}
+
+let onExpired: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'expired-token')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  onExpired = vi.fn()
+  window.addEventListener(SESSION_EXPIRED_EVENT, onExpired)
+})
+
+afterEach(() => {
+  window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired)
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('admin client (isnad-graph admin API) 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ status: 'ok' }),
+      )
+    })
+
+    const result = await fetchSystemHealth()
+
+    expect(result).toEqual({ status: 'ok' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(REFRESH_URL)[0]?.init?.method).toBe('POST')
+    const data = callsTo(HEALTH_URL)
+    expect(data).toHaveLength(2)
+    expect(authHeader(data[0]?.init)).toBe('Bearer expired-token')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and does not retry', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ detail: 'refresh expired' }, 401))
+      }
+      return Promise.resolve(jsonResponse({ detail: 'token expired' }, 401))
+    })
+
+    await expect(fetchSystemHealth()).rejects.toThrow(/admin access required/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(HEALTH_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+})
+
+describe('admin client (user-service admin API) 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ id: 'u1', email: 'a@b.c' }),
+      )
+    })
+
+    const result = await fetchAdminUser('u1')
+
+    expect(result).toMatchObject({ id: 'u1' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    const data = callsTo(USERS_URL)
+    expect(data).toHaveLength(2)
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(fetchAdminUser('u1')).rejects.toThrow(/admin access required/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(USERS_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+})
+
+describe('admin client (cross-service pipeline reset) 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ ok: true, dry_run: true, deleted: {} }),
+      )
+    })
+
+    const result = await resetStage('raw', true)
+
+    expect(result).toMatchObject({ ok: true })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(RESET_STAGE_URL)).toHaveLength(2)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and throws ResetError(401)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(resetStage('raw', true)).rejects.toMatchObject({
+      name: 'ResetError',
+      status: 401,
+    })
+    // Sanity: the rejection is the typed ResetError, not a generic throw.
+    await expect(resetStage('raw', true)).rejects.toBeInstanceOf(ResetError)
+
+    expect(onExpired).toHaveBeenCalled()
+  })
+})
+
+describe('admin clients: a 200 response never triggers a refresh (#1021)', () => {
+  it('fetchSystemHealth', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: 'ok' }))
+
+    await fetchSystemHealth()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/__tests__/profile-client-refresh.test.ts
+++ b/frontend/src/api/__tests__/profile-client-refresh.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchProfile, revokeSession } from '../profile-client'
+import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
+
+// Fetch-boundary regression tests for the #1021 fix: the profile client must
+// mirror the #1016 data-client recovery — attempt a token refresh
+// (POST /auth/token/refresh, via the httpOnly refresh cookie) and retry the
+// original request ONCE on a 401 before declaring the session expired. Before
+// this fix a 401 on any /api/v1/users/me call (`fetchProfileJson`) or the
+// `revokeSession` DELETE force-logged-out immediately, so a mid-session
+// access-token expiry bounced the user out of their own profile despite a valid
+// refresh cookie. These drive the REAL client against a stubbed `fetch`.
+
+const REFRESH_URL = '/auth/token/refresh'
+// Origin resolves to '' (same-origin) in the test env, so the profile URLs are bare.
+const PROFILE_URL = '/api/v1/users/me/profile'
+const SESSIONS_URL = '/api/v1/users/me/sessions'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+function callsTo(substr: string): Array<{ url: string; init: RequestInit | undefined }> {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: c[1] as RequestInit | undefined }))
+    .filter((c) => c.url.includes(substr))
+}
+
+function authHeader(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.Authorization
+}
+
+let onExpired: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'expired-token')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  onExpired = vi.fn()
+  window.addEventListener(SESSION_EXPIRED_EVENT, onExpired)
+})
+
+afterEach(() => {
+  window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired)
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('profile client 401 → refresh → retry (#1021)', () => {
+  it('on 401, refreshes once and retries fetchProfile — no session-expired', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ id: 'u1', email: 'a@b.c', name: 'A' }),
+      )
+    })
+
+    const result = await fetchProfile()
+
+    expect(result).toMatchObject({ id: 'u1' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(REFRESH_URL)[0]?.init?.method).toBe('POST')
+    const data = callsTo(PROFILE_URL)
+    expect(data).toHaveLength(2)
+    expect(authHeader(data[0]?.init)).toBe('Bearer expired-token')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('on 401 with a failed refresh, emits session-expired and does not retry', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ detail: 'refresh expired' }, 401))
+      }
+      return Promise.resolve(jsonResponse({ detail: 'token expired' }, 401))
+    })
+
+    await expect(fetchProfile()).rejects.toThrow(/Unauthorized/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(PROFILE_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+
+  it('revokeSession refreshes once and retries the DELETE on a 401', async () => {
+    let dataCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      dataCalls += 1
+      return Promise.resolve(
+        dataCalls === 1 ? jsonResponse({ detail: 'token expired' }, 401) : jsonResponse({}, 204),
+      )
+    })
+
+    await expect(revokeSession('s1')).resolves.toBeUndefined()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    const data = callsTo(SESSIONS_URL)
+    expect(data).toHaveLength(2)
+    expect(data[1]?.init?.method).toBe('DELETE')
+    expect(authHeader(data[1]?.init)).toBe('Bearer fresh-token')
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+
+  it('revokeSession emits session-expired when the refresh fails', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(revokeSession('s1')).rejects.toThrow(/Unauthorized/)
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    expect(callsTo(SESSIONS_URL)).toHaveLength(1)
+    expect(onExpired).toHaveBeenCalledOnce()
+  })
+
+  it('a 200 response never triggers a refresh', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'u1', email: 'a@b.c', name: 'A' }))
+
+    await fetchProfile()
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+    expect(onExpired).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/__tests__/search-limits.test.ts
+++ b/frontend/src/api/__tests__/search-limits.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  searchAll,
+  searchSemantic,
+  SEARCH_MAX_LIMIT,
+  SEMANTIC_SEARCH_MAX_LIMIT,
+} from '../client'
+
+// The backend caps each search endpoint's ``limit`` query param (FastAPI
+// ``Query(..., le=N)`` in ``src/api/routes/search.py``). Requesting more than
+// the cap is rejected with a 422 before the query runs, which broke the full
+// results page when it asked for limit=200 (#1025). These caps mirror the
+// server bounds; if the server bounds change, update both sides together.
+const SERVER_SEARCH_CAP = 100 // /search        -> Query(20, ge=1, le=100)
+const SERVER_SEMANTIC_CAP = 50 // /search/semantic -> Query(10, ge=1, le=50)
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(jsonResponse({ results: [], total: 0 }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('search limit contract (#1025)', () => {
+  it('the keyword-search results-page limit is within the server cap', () => {
+    expect(SEARCH_MAX_LIMIT).toBeLessThanOrEqual(SERVER_SEARCH_CAP)
+  })
+
+  it('the semantic-search results-page limit is within the server cap', () => {
+    expect(SEMANTIC_SEARCH_MAX_LIMIT).toBeLessThanOrEqual(SERVER_SEMANTIC_CAP)
+  })
+
+  it('searchAll sends the requested limit in the query string', async () => {
+    await searchAll('prayer', SEARCH_MAX_LIMIT)
+    const url = fetchMock.mock.calls[0]?.[0] as string
+    expect(url).toContain('/api/v1/search?')
+    expect(url).toContain(`limit=${SEARCH_MAX_LIMIT}`)
+  })
+
+  it('searchSemantic sends the requested limit in the query string', async () => {
+    await searchSemantic('prayer', SEMANTIC_SEARCH_MAX_LIMIT)
+    const url = fetchMock.mock.calls[0]?.[0] as string
+    expect(url).toContain('/api/v1/search/semantic?')
+    expect(url).toContain(`limit=${SEMANTIC_SEARCH_MAX_LIMIT}`)
+  })
+})

--- a/frontend/src/api/__tests__/subscription-client.test.ts
+++ b/frontend/src/api/__tests__/subscription-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Regression test for #1026: `fetchSubscriptionOrNull` must target the
+// USER-SERVICE origin (`window.RUNTIME_CONFIG.USER_SERVICE_ORIGIN`), not the
+// same-origin isnad-graph API. Subscriptions live in user-service; hitting the
+// isnad-graph origin (`/api/v1/subscriptions/me`) 404'd on every authenticated
+// page and silently treated every user as un-subscribed.
+//
+// The origin is baked into a module-level constant at import time, so each test
+// sets `window.RUNTIME_CONFIG` and then imports the client via `vi.resetModules`
+// + dynamic import to pick up that value.
+
+const ORIGIN = 'https://users.example'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 404 ? 'Not Found' : 'OK',
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'jwt')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  vi.resetModules()
+  ;(window as unknown as { RUNTIME_CONFIG?: { USER_SERVICE_ORIGIN?: string } }).RUNTIME_CONFIG =
+    { USER_SERVICE_ORIGIN: ORIGIN }
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+  delete (window as unknown as { RUNTIME_CONFIG?: unknown }).RUNTIME_CONFIG
+})
+
+describe('fetchSubscriptionOrNull origin (#1026)', () => {
+  it('targets the user-service origin, not the same-origin isnad-graph API', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ tier: 'trial', status: 'trial', days_remaining: 5 }))
+    const { fetchSubscriptionOrNull } = await import('../client')
+
+    await fetchSubscriptionOrNull()
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(`${ORIGIN}/api/v1/subscriptions/me`)
+  })
+
+  it('resolves a 404 (no subscription) to null without throwing', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'No subscription found' }, 404))
+    const { fetchSubscriptionOrNull } = await import('../client')
+
+    await expect(fetchSubscriptionOrNull()).resolves.toBeNull()
+  })
+
+  it('returns the parsed subscription body on 200', async () => {
+    const body = { tier: 'active', status: 'active', days_remaining: 30 }
+    fetchMock.mockResolvedValue(jsonResponse(body))
+    const { fetchSubscriptionOrNull } = await import('../client')
+
+    await expect(fetchSubscriptionOrNull()).resolves.toEqual(body)
+  })
+})

--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -12,6 +12,7 @@ import type {
 import type { PaginatedResponse } from '../types/api'
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
+import { refreshAccessToken } from './token-refresh'
 import { apiError } from './api-error'
 
 // --- isnad-graph admin API (system / content / analytics panels — #806) ---
@@ -40,12 +41,29 @@ export type AdminUser = components['schemas']['UserRead']
 export type AdminUserList = components['schemas']['UserListResponse']
 export type Role = components['schemas']['RoleRead']
 
+// Issue an authenticated request; on a 401 attempt ONE shared token refresh
+// (POST /auth/token/refresh via the httpOnly refresh cookie) and retry the
+// request once before the caller surfaces session-expired. Only a genuinely
+// expired/revoked refresh cookie (a failed refresh) leaves the response at 401
+// for the caller's session-expired branch — a mid-session access-token expiry
+// no longer bounces an admin to the login wall. getAuthHeaders() re-reads the
+// freshly persisted token on the retry. Mirrors client.ts `fetchJson` (#1016);
+// shared by every admin 401 path so the recovery never diverges (#1021).
+async function fetchWithRefresh(url: string, init?: RequestInit): Promise<Response> {
+  const send = () =>
+    fetch(url, { ...init, headers: { ...getAuthHeaders(), ...init?.headers } })
+  let res = await send()
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await send()
+    }
+  }
+  return res
+}
+
 async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    credentials: 'include',
-    headers: { ...getAuthHeaders(), ...init?.headers },
-  })
+  const res = await fetchWithRefresh(url, { ...init, credentials: 'include' })
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized: admin access required')
@@ -64,10 +82,7 @@ async function fetchAdminJson<T>(url: string, init?: RequestInit): Promise<T> {
 // `credentials: 'include'` (matches profile-client.ts, avoids a cross-origin
 // credentialed-CORS requirement on the user-service vhost).
 async function fetchUserServiceJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { ...getAuthHeaders(), ...init?.headers },
-  })
+  const res = await fetchWithRefresh(url, init)
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized: admin access required')
@@ -84,10 +99,7 @@ async function fetchUserServiceJson<T>(url: string, init?: RequestInit): Promise
 // 204 No Content variant (role removal, soft-delete) — same auth/error handling
 // as fetchUserServiceJson but no body to parse.
 async function sendUserServiceRequest(url: string, init: RequestInit): Promise<void> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { ...getAuthHeaders(), ...init.headers },
-  })
+  const res = await fetchWithRefresh(url, init)
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized: admin access required')
@@ -259,10 +271,10 @@ export class ResetError extends Error {
 }
 
 async function postReset(path: string, body: unknown): Promise<ResetResponse> {
-  const res = await fetch(`${RESET_BASE}${path}`, {
+  const res = await fetchWithRefresh(`${RESET_BASE}${path}`, {
     method: 'POST',
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
   if (res.ok) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,6 +23,19 @@ import { apiError } from './api-error'
 
 const API_BASE = '/api/v1'
 
+// Subscriptions live in the user-service, not the isnad-graph API. Resolve its
+// origin at runtime from `window.RUNTIME_CONFIG` (injected by the container
+// entrypoint), falling back to the build-time `VITE_USER_SERVICE_ORIGIN`, then
+// to same-origin. This mirrors useAuth.ts / profile-client.ts / admin-client.ts.
+// Without this, `/subscriptions/me` hit the isnad-graph origin — which has no
+// such route — and 404'd on every authenticated page, silently treating every
+// user (including real subscribers) as un-subscribed. (#1026)
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
+const SUBSCRIPTIONS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/subscriptions`
+
 async function fetchJson<T>(url: string): Promise<T> {
   let res = await fetch(url, { headers: getAuthHeaders(), credentials: 'include' })
   if (res.status === 401) {
@@ -213,7 +226,7 @@ export async function flagContent(
 // (free tier / admin), not an error. Resolve it to null and let callers
 // branch on `subscription === null`. Other non-OK statuses throw as usual.
 export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | null> {
-  let res = await fetch(`${API_BASE}/subscriptions/me`, {
+  let res = await fetch(`${SUBSCRIPTIONS_BASE}/me`, {
     headers: getAuthHeaders(),
     credentials: 'include',
   })
@@ -223,7 +236,7 @@ export async function fetchSubscriptionOrNull(): Promise<SubscriptionResponse | 
   if (res.status === 401) {
     const refreshed = await refreshAccessToken()
     if (refreshed) {
-      res = await fetch(`${API_BASE}/subscriptions/me`, {
+      res = await fetch(`${SUBSCRIPTIONS_BASE}/me`, {
         headers: getAuthHeaders(),
         credentials: 'include',
       })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -156,6 +156,14 @@ export async function fetchGraphNetwork(
   )
 }
 
+// Maximum result counts the backend will accept for each search endpoint.
+// These MUST stay in sync with the ``limit`` ``le=`` bounds in
+// ``src/api/routes/search.py`` — requesting more triggers a 422 request
+// validation failure (#1025). The full results page requests the cap so it
+// shows as many matches as the endpoint allows in a single page.
+export const SEARCH_MAX_LIMIT = 100
+export const SEMANTIC_SEARCH_MAX_LIMIT = 50
+
 export async function searchAll(
   query: string,
   limit = 20,

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -1,5 +1,6 @@
 import { emitSessionExpired } from '../hooks/useAuth'
 import { getAuthHeaders } from './auth-headers'
+import { refreshAccessToken } from './token-refresh'
 import { apiError } from './api-error'
 
 // Absolute URL targeting the user-service vhost (`users.{base}`). See
@@ -12,11 +13,29 @@ const USER_SERVICE_ORIGIN =
   ''
 const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
 
+// Issue an authenticated request; on a 401 attempt ONE shared token refresh
+// (POST /auth/token/refresh via the httpOnly refresh cookie) and retry the
+// request once before the caller surfaces session-expired. Only a genuinely
+// expired/revoked refresh cookie (a failed refresh) leaves the response at 401
+// — a mid-session access-token expiry no longer logs the user out of their
+// profile. getAuthHeaders() re-reads the freshly persisted token on the retry.
+// Mirrors client.ts `fetchJson` (#1016); shared by every profile 401 path so a
+// 401 from one client no longer diverges from the others (#1021).
+async function fetchWithRefresh(url: string, init?: RequestInit): Promise<Response> {
+  const send = () =>
+    fetch(url, { ...init, headers: { ...getAuthHeaders(), ...init?.headers } })
+  let res = await send()
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await send()
+    }
+  }
+  return res
+}
+
 async function fetchProfileJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { ...getAuthHeaders(), ...init?.headers },
-  })
+  const res = await fetchWithRefresh(url, init)
   if (res.status === 401) {
     emitSessionExpired()
     throw new Error('Unauthorized')
@@ -74,9 +93,8 @@ export async function fetchSessions(): Promise<SessionInfo[]> {
 }
 
 export async function revokeSession(sessionId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+  const res = await fetchWithRefresh(`${API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
     method: 'DELETE',
-    headers: getAuthHeaders(),
   })
   if (res.status === 401) {
     emitSessionExpired()

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "منصة تحليل الحديث",
     "returnHome": "العودة إلى الصفحة الرئيسية",
-    "loading": "جارٍ التحميل…"
+    "loading": "جارٍ التحميل…",
+    "search": "بحث",
+    "previous": "السابق",
+    "next": "التالي",
+    "first": "الأول",
+    "last": "الأخير",
+    "go": "انتقل",
+    "error": "خطأ: {{message}}",
+    "pageOf": "الصفحة {{current}} من {{total}}",
+    "colNameArabic": "الاسم (بالعربية)",
+    "colNameEnglish": "الاسم (بالإنجليزية)"
   },
   "nav": {
     "ariaLabel": "التنقل الرئيسي",
@@ -47,5 +57,42 @@
     "apiRateLimited": "طلبات كثيرة جدًا — يرجى الانتظار لحظة والمحاولة مرة أخرى.",
     "apiServer": "حدث خطأ من جانبنا. يرجى المحاولة مرة أخرى بعد قليل.",
     "apiGeneric": "حدث خطأ ما. يرجى المحاولة مرة أخرى."
+  },
+  "narrators": {
+    "heading": "الرواة",
+    "searchPlaceholder": "ابحث عن الرواة…",
+    "searchLabel": "ابحث عن الرواة",
+    "emptyHeading": "لم يتم العثور على رواة",
+    "emptyBody": "حاول تعديل كلمات البحث أو مسح عامل التصفية.",
+    "colGeneration": "الطبقة",
+    "colTrustworthiness": "التوثيق",
+    "colCommunity": "المجتمع"
+  },
+  "collections": {
+    "heading": "المجموعات",
+    "colCompiler": "المؤلف",
+    "colSect": "المذهب",
+    "colHadiths": "الأحاديث"
+  },
+  "hadiths": {
+    "heading": "الأحاديث",
+    "searchPlaceholder": "ابحث في نص الحديث…",
+    "allCollections": "جميع المجموعات",
+    "allSources": "جميع المصادر",
+    "loadingSources": "جارٍ تحميل المصادر…",
+    "allGrades": "جميع الدرجات",
+    "clearFilters": "مسح عوامل التصفية",
+    "resultsFound_one": "تم العثور على حديث واحد",
+    "resultsFound_two": "تم العثور على حديثين",
+    "resultsFound_few": "تم العثور على {{count}} أحاديث",
+    "resultsFound_many": "تم العثور على {{count}} حديثًا",
+    "resultsFound_other": "تم العثور على {{count}} حديث",
+    "filteredSuffix": " (مُصفّى)",
+    "colTitle": "العنوان",
+    "colSource": "المصدر",
+    "colGrade": "الدرجة",
+    "colTopics": "المواضيع",
+    "jumpPlaceholder": "رقم الصفحة",
+    "show": "إظهار:"
   }
 }

--- a/frontend/src/i18n/locales/bs.json
+++ b/frontend/src/i18n/locales/bs.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Platforma za analizu hadisa",
     "returnHome": "Povratak na početnu",
-    "loading": "Učitavanje…"
+    "loading": "Učitavanje…",
+    "search": "Pretraži",
+    "previous": "Prethodno",
+    "next": "Sljedeće",
+    "first": "Prvo",
+    "last": "Posljednje",
+    "go": "Idi",
+    "error": "Greška: {{message}}",
+    "pageOf": "Stranica {{current}} od {{total}}",
+    "colNameArabic": "Ime (arapski)",
+    "colNameEnglish": "Ime (engleski)"
   },
   "nav": {
     "ariaLabel": "Glavna navigacija",
@@ -45,5 +55,40 @@
     "apiRateLimited": "Previše zahtjeva — molimo pričekajte trenutak i pokušajte ponovo.",
     "apiServer": "Nešto je pošlo po zlu na našoj strani. Molimo pokušajte ponovo uskoro.",
     "apiGeneric": "Nešto je pošlo po zlu. Molimo pokušajte ponovo."
+  },
+  "narrators": {
+    "heading": "Prenosioci",
+    "searchPlaceholder": "Pretraži prenosioce…",
+    "searchLabel": "Pretraži prenosioce",
+    "emptyHeading": "Nije pronađen nijedan prenosilac",
+    "emptyBody": "Pokušajte prilagoditi pojmove pretrage ili poništiti filter.",
+    "colGeneration": "Generacija",
+    "colTrustworthiness": "Pouzdanost",
+    "colCommunity": "Zajednica"
+  },
+  "collections": {
+    "heading": "Zbirke",
+    "colCompiler": "Sastavljač",
+    "colSect": "Pravac",
+    "colHadiths": "Hadisi"
+  },
+  "hadiths": {
+    "heading": "Hadisi",
+    "searchPlaceholder": "Pretraži tekst hadisa…",
+    "allCollections": "Sve zbirke",
+    "allSources": "Svi izvori",
+    "loadingSources": "Učitavanje izvora…",
+    "allGrades": "Sve ocjene",
+    "clearFilters": "Poništi filtere",
+    "resultsFound_one": "Pronađen {{count}} hadis",
+    "resultsFound_few": "Pronađena {{count}} hadisa",
+    "resultsFound_other": "Pronađeno {{count}} hadisa",
+    "filteredSuffix": " (filtrirano)",
+    "colTitle": "Naslov",
+    "colSource": "Izvor",
+    "colGrade": "Ocjena",
+    "colTopics": "Teme",
+    "jumpPlaceholder": "Stranica #",
+    "show": "Prikaži:"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Hadith Analysis Platform",
     "returnHome": "Return home",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "search": "Search",
+    "previous": "Previous",
+    "next": "Next",
+    "first": "First",
+    "last": "Last",
+    "go": "Go",
+    "error": "Error: {{message}}",
+    "pageOf": "Page {{current}} of {{total}}",
+    "colNameArabic": "Name (Arabic)",
+    "colNameEnglish": "Name (English)"
   },
   "nav": {
     "ariaLabel": "Main navigation",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Too many requests — please wait a moment and try again.",
     "apiServer": "Something went wrong on our end. Please try again shortly.",
     "apiGeneric": "Something went wrong. Please try again."
+  },
+  "narrators": {
+    "heading": "Narrators",
+    "searchPlaceholder": "Search narrators…",
+    "searchLabel": "Search narrators",
+    "emptyHeading": "No narrators found",
+    "emptyBody": "Try adjusting your search terms or clearing the filter.",
+    "colGeneration": "Generation",
+    "colTrustworthiness": "Trustworthiness",
+    "colCommunity": "Community"
+  },
+  "collections": {
+    "heading": "Collections",
+    "colCompiler": "Compiler",
+    "colSect": "Sect",
+    "colHadiths": "Hadiths"
+  },
+  "hadiths": {
+    "heading": "Hadiths",
+    "searchPlaceholder": "Search hadith text…",
+    "allCollections": "All Collections",
+    "allSources": "All Sources",
+    "loadingSources": "Loading sources…",
+    "allGrades": "All Grades",
+    "clearFilters": "Clear filters",
+    "resultsFound_one": "{{count}} hadith found",
+    "resultsFound_other": "{{count}} hadiths found",
+    "filteredSuffix": " (filtered)",
+    "colTitle": "Title",
+    "colSource": "Source",
+    "colGrade": "Grade",
+    "colTopics": "Topics",
+    "jumpPlaceholder": "Page #",
+    "show": "Show:"
   }
 }

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Platform Analisis Hadis",
     "returnHome": "Kembali ke beranda",
-    "loading": "Memuat…"
+    "loading": "Memuat…",
+    "search": "Cari",
+    "previous": "Sebelumnya",
+    "next": "Berikutnya",
+    "first": "Pertama",
+    "last": "Terakhir",
+    "go": "Buka",
+    "error": "Kesalahan: {{message}}",
+    "pageOf": "Halaman {{current}} dari {{total}}",
+    "colNameArabic": "Nama (Arab)",
+    "colNameEnglish": "Nama (Inggris)"
   },
   "nav": {
     "ariaLabel": "Navigasi utama",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Terlalu banyak permintaan — harap tunggu sebentar dan coba lagi.",
     "apiServer": "Terjadi kesalahan di pihak kami. Silakan coba lagi sebentar lagi.",
     "apiGeneric": "Terjadi kesalahan. Silakan coba lagi."
+  },
+  "narrators": {
+    "heading": "Perawi",
+    "searchPlaceholder": "Cari perawi…",
+    "searchLabel": "Cari perawi",
+    "emptyHeading": "Tidak ada perawi ditemukan",
+    "emptyBody": "Coba sesuaikan kata kunci pencarian Anda atau hapus filter.",
+    "colGeneration": "Generasi",
+    "colTrustworthiness": "Kredibilitas",
+    "colCommunity": "Komunitas"
+  },
+  "collections": {
+    "heading": "Koleksi",
+    "colCompiler": "Penyusun",
+    "colSect": "Mazhab",
+    "colHadiths": "Hadis"
+  },
+  "hadiths": {
+    "heading": "Hadis",
+    "searchPlaceholder": "Cari teks hadis…",
+    "allCollections": "Semua Koleksi",
+    "allSources": "Semua Sumber",
+    "loadingSources": "Memuat sumber…",
+    "allGrades": "Semua Derajat",
+    "clearFilters": "Hapus filter",
+    "resultsFound_one": "{{count}} hadis ditemukan",
+    "resultsFound_other": "{{count}} hadis ditemukan",
+    "filteredSuffix": " (difilter)",
+    "colTitle": "Judul",
+    "colSource": "Sumber",
+    "colGrade": "Derajat",
+    "colTopics": "Topik",
+    "jumpPlaceholder": "Halaman #",
+    "show": "Tampilkan:"
   }
 }

--- a/frontend/src/i18n/locales/ms.json
+++ b/frontend/src/i18n/locales/ms.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Platform Analisis Hadis",
     "returnHome": "Kembali ke laman utama",
-    "loading": "Memuatkan…"
+    "loading": "Memuatkan…",
+    "search": "Cari",
+    "previous": "Sebelumnya",
+    "next": "Seterusnya",
+    "first": "Pertama",
+    "last": "Terakhir",
+    "go": "Pergi",
+    "error": "Ralat: {{message}}",
+    "pageOf": "Halaman {{current}} daripada {{total}}",
+    "colNameArabic": "Nama (Arab)",
+    "colNameEnglish": "Nama (Inggeris)"
   },
   "nav": {
     "ariaLabel": "Navigasi utama",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Terlalu banyak permintaan — sila tunggu sebentar dan cuba lagi.",
     "apiServer": "Sesuatu tidak kena di pihak kami. Sila cuba lagi sebentar lagi.",
     "apiGeneric": "Sesuatu tidak kena. Sila cuba lagi."
+  },
+  "narrators": {
+    "heading": "Perawi",
+    "searchPlaceholder": "Cari perawi…",
+    "searchLabel": "Cari perawi",
+    "emptyHeading": "Tiada perawi dijumpai",
+    "emptyBody": "Cuba laraskan istilah carian anda atau kosongkan penapis.",
+    "colGeneration": "Generasi",
+    "colTrustworthiness": "Kebolehpercayaan",
+    "colCommunity": "Komuniti"
+  },
+  "collections": {
+    "heading": "Koleksi",
+    "colCompiler": "Penyusun",
+    "colSect": "Mazhab",
+    "colHadiths": "Hadis"
+  },
+  "hadiths": {
+    "heading": "Hadis",
+    "searchPlaceholder": "Cari teks hadis…",
+    "allCollections": "Semua Koleksi",
+    "allSources": "Semua Sumber",
+    "loadingSources": "Memuatkan sumber…",
+    "allGrades": "Semua Gred",
+    "clearFilters": "Kosongkan penapis",
+    "resultsFound_one": "{{count}} hadis dijumpai",
+    "resultsFound_other": "{{count}} hadis dijumpai",
+    "filteredSuffix": " (ditapis)",
+    "colTitle": "Tajuk",
+    "colSource": "Sumber",
+    "colGrade": "Gred",
+    "colTopics": "Topik",
+    "jumpPlaceholder": "Halaman #",
+    "show": "Papar:"
   }
 }

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "Hadis Analiz Platformu",
     "returnHome": "Ana sayfaya dön",
-    "loading": "Yükleniyor…"
+    "loading": "Yükleniyor…",
+    "search": "Ara",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "first": "İlk",
+    "last": "Son",
+    "go": "Git",
+    "error": "Hata: {{message}}",
+    "pageOf": "Sayfa {{current}} / {{total}}",
+    "colNameArabic": "Ad (Arapça)",
+    "colNameEnglish": "Ad (İngilizce)"
   },
   "nav": {
     "ariaLabel": "Ana gezinme",
@@ -44,5 +54,39 @@
     "apiRateLimited": "Çok fazla istek — lütfen biraz bekleyip tekrar deneyin.",
     "apiServer": "Tarafımızda bir şeyler ters gitti. Lütfen birazdan tekrar deneyin.",
     "apiGeneric": "Bir şeyler ters gitti. Lütfen tekrar deneyin."
+  },
+  "narrators": {
+    "heading": "Raviler",
+    "searchPlaceholder": "Ravilerde ara…",
+    "searchLabel": "Ravilerde ara",
+    "emptyHeading": "Ravi bulunamadı",
+    "emptyBody": "Arama terimlerinizi değiştirmeyi veya filtreyi temizlemeyi deneyin.",
+    "colGeneration": "Nesil",
+    "colTrustworthiness": "Güvenilirlik",
+    "colCommunity": "Topluluk"
+  },
+  "collections": {
+    "heading": "Koleksiyonlar",
+    "colCompiler": "Derleyen",
+    "colSect": "Mezhep",
+    "colHadiths": "Hadisler"
+  },
+  "hadiths": {
+    "heading": "Hadisler",
+    "searchPlaceholder": "Hadis metninde ara…",
+    "allCollections": "Tüm Koleksiyonlar",
+    "allSources": "Tüm Kaynaklar",
+    "loadingSources": "Kaynaklar yükleniyor…",
+    "allGrades": "Tüm Dereceler",
+    "clearFilters": "Filtreleri temizle",
+    "resultsFound_one": "{{count}} hadis bulundu",
+    "resultsFound_other": "{{count}} hadis bulundu",
+    "filteredSuffix": " (filtrelenmiş)",
+    "colTitle": "Başlık",
+    "colSource": "Kaynak",
+    "colGrade": "Derece",
+    "colTopics": "Konular",
+    "jumpPlaceholder": "Sayfa #",
+    "show": "Göster:"
   }
 }

--- a/frontend/src/i18n/locales/ur.json
+++ b/frontend/src/i18n/locales/ur.json
@@ -2,7 +2,17 @@
   "common": {
     "platformTagline": "حدیث تجزیہ پلیٹ فارم",
     "returnHome": "ہوم پیج پر واپس جائیں",
-    "loading": "لوڈ ہو رہا ہے…"
+    "loading": "لوڈ ہو رہا ہے…",
+    "search": "تلاش کریں",
+    "previous": "پچھلا",
+    "next": "اگلا",
+    "first": "پہلا",
+    "last": "آخری",
+    "go": "جائیں",
+    "error": "خرابی: {{message}}",
+    "pageOf": "صفحہ {{current}} از {{total}}",
+    "colNameArabic": "نام (عربی)",
+    "colNameEnglish": "نام (انگریزی)"
   },
   "nav": {
     "ariaLabel": "مرکزی نیویگیشن",
@@ -44,5 +54,39 @@
     "apiRateLimited": "بہت زیادہ درخواستیں — براہ کرم تھوڑی دیر انتظار کریں اور دوبارہ کوشش کریں۔",
     "apiServer": "ہماری طرف سے کچھ غلط ہو گیا۔ براہ کرم تھوڑی دیر بعد دوبارہ کوشش کریں۔",
     "apiGeneric": "کچھ غلط ہو گیا۔ براہ کرم دوبارہ کوشش کریں۔"
+  },
+  "narrators": {
+    "heading": "راوی",
+    "searchPlaceholder": "راویوں کو تلاش کریں…",
+    "searchLabel": "راویوں کو تلاش کریں",
+    "emptyHeading": "کوئی راوی نہیں ملا",
+    "emptyBody": "اپنے تلاش کے الفاظ کو تبدیل کریں یا فلٹر صاف کریں۔",
+    "colGeneration": "طبقہ",
+    "colTrustworthiness": "وثاقت",
+    "colCommunity": "برادری"
+  },
+  "collections": {
+    "heading": "مجموعے",
+    "colCompiler": "مؤلف",
+    "colSect": "مسلک",
+    "colHadiths": "احادیث"
+  },
+  "hadiths": {
+    "heading": "احادیث",
+    "searchPlaceholder": "حدیث کے متن میں تلاش کریں…",
+    "allCollections": "تمام مجموعے",
+    "allSources": "تمام ذرائع",
+    "loadingSources": "ذرائع لوڈ ہو رہے ہیں…",
+    "allGrades": "تمام درجات",
+    "clearFilters": "فلٹرز صاف کریں",
+    "resultsFound_one": "{{count}} حدیث ملی",
+    "resultsFound_other": "{{count}} احادیث ملیں",
+    "filteredSuffix": " (فلٹر شدہ)",
+    "colTitle": "عنوان",
+    "colSource": "ماخذ",
+    "colGrade": "درجہ",
+    "colTopics": "موضوعات",
+    "jumpPlaceholder": "صفحہ #",
+    "show": "دکھائیں:"
   }
 }

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
 import { fetchCollections } from '../api/client'
 
 export default function CollectionsPage() {
+  const { t } = useTranslation()
   const navigate = useNavigate()
 
   const { data, isLoading, error } = useQuery({
@@ -12,7 +14,7 @@ export default function CollectionsPage() {
 
   return (
     <div>
-      <h2 className="page-heading">Collections</h2>
+      <h2 className="page-heading">{t('collections.heading')}</h2>
 
       {isLoading && (
         <div>
@@ -21,17 +23,17 @@ export default function CollectionsPage() {
           ))}
         </div>
       )}
-      {error && <p className="error-text">Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">{t('common.error', { message: (error as Error).message })}</p>}
 
       {data && (
         <table className="data-table">
           <thead>
             <tr>
-              <th>Name (Arabic)</th>
-              <th>Name (English)</th>
-              <th>Compiler</th>
-              <th>Sect</th>
-              <th style={{ textAlign: 'right' }}>Hadiths</th>
+              <th>{t('common.colNameArabic')}</th>
+              <th>{t('common.colNameEnglish')}</th>
+              <th>{t('collections.colCompiler')}</th>
+              <th>{t('collections.colSect')}</th>
+              <th style={{ textAlign: 'right' }}>{t('collections.colHadiths')}</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -1,11 +1,13 @@
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { fetchHadiths, fetchCollections, fetchHadithFacets } from '../api/client'
 
 const PAGE_SIZES = [25, 50, 100] as const
 
 export default function HadithsPage() {
+  const { t } = useTranslation()
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState<number>(25)
   const [searchInput, setSearchInput] = useState('')
@@ -85,7 +87,7 @@ export default function HadithsPage() {
 
   return (
     <div>
-      <h2 className="page-heading">Hadiths</h2>
+      <h2 className="page-heading">{t('hadiths.heading')}</h2>
 
       {/* Filter controls */}
       <div className="mb-4" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', alignItems: 'flex-end' }}>
@@ -93,7 +95,7 @@ export default function HadithsPage() {
         <form onSubmit={handleSearch} style={{ display: 'flex', gap: '0.5rem' }}>
           <input
             type="text"
-            placeholder="Search hadith text..."
+            placeholder={t('hadiths.searchPlaceholder')}
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             className="filter-input"
@@ -118,7 +120,7 @@ export default function HadithsPage() {
               cursor: 'pointer',
             }}
           >
-            Search
+            {t('common.search')}
           </button>
         </form>
 
@@ -134,7 +136,7 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">All Collections</option>
+          <option value="">{t('hadiths.allCollections')}</option>
           {collectionsData?.items.map((c) => (
             <option key={c.id} value={c.name_en}>
               {c.name_en}
@@ -155,7 +157,7 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">{facetsLoading ? 'Loading sources...' : 'All Sources'}</option>
+          <option value="">{facetsLoading ? t('hadiths.loadingSources') : t('hadiths.allSources')}</option>
           {facetsData?.source_corpus.map((s) => (
             <option key={s} value={s}>
               {s}
@@ -175,7 +177,10 @@ export default function HadithsPage() {
             color: 'var(--color-foreground)',
           }}
         >
-          <option value="">All Grades</option>
+          <option value="">{t('hadiths.allGrades')}</option>
+          {/* Grade names are scholarly classification terms that mirror the
+              untransformed API grade values shown in result badges, so per the
+              i18n scope policy (#703/#998) they are intentionally left as-is. */}
           <option value="sahih">Sahih</option>
           <option value="hasan">Hasan</option>
           <option value="da'if">Da'if</option>
@@ -194,7 +199,7 @@ export default function HadithsPage() {
               cursor: 'pointer',
             }}
           >
-            Clear filters
+            {t('hadiths.clearFilters')}
           </button>
         )}
       </div>
@@ -206,23 +211,23 @@ export default function HadithsPage() {
           ))}
         </div>
       )}
-      {error && <p className="error-text">Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">{t('common.error', { message: (error as Error).message })}</p>}
 
       {data && (
         <>
           {/* Results summary */}
           <p className="text-sm mb-2" style={{ color: 'var(--color-muted-foreground)' }}>
-            {data.total.toLocaleString()} hadith{data.total !== 1 ? 's' : ''} found
-            {hasActiveFilters ? ' (filtered)' : ''}
+            {t('hadiths.resultsFound', { count: data.total })}
+            {hasActiveFilters ? t('hadiths.filteredSuffix') : ''}
           </p>
 
           <table className="data-table">
             <thead>
               <tr>
-                <th>Title</th>
-                <th>Source</th>
-                {hasGrades && <th>Grade</th>}
-                {hasTopics && <th>Topics</th>}
+                <th>{t('hadiths.colTitle')}</th>
+                <th>{t('hadiths.colSource')}</th>
+                {hasGrades && <th>{t('hadiths.colGrade')}</th>}
+                {hasTopics && <th>{t('hadiths.colTopics')}</th>}
               </tr>
             </thead>
             <tbody>
@@ -268,19 +273,19 @@ export default function HadithsPage() {
           <div className="pagination" style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap', marginTop: '1rem' }}>
             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
               <button disabled={page <= 1} onClick={() => setPage(1)}>
-                First
+                {t('common.first')}
               </button>
               <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-                Previous
+                {t('common.previous')}
               </button>
               <span>
-                Page {data.page} of {totalPages.toLocaleString()}
+                {t('common.pageOf', { current: data.page, total: totalPages.toLocaleString() })}
               </span>
               <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
-                Next
+                {t('common.next')}
               </button>
               <button disabled={page >= totalPages} onClick={() => setPage(totalPages)}>
-                Last
+                {t('common.last')}
               </button>
             </div>
 
@@ -292,7 +297,7 @@ export default function HadithsPage() {
                 max={totalPages}
                 value={jumpPage}
                 onChange={(e) => setJumpPage(e.target.value)}
-                placeholder="Page #"
+                placeholder={t('hadiths.jumpPlaceholder')}
                 style={{
                   width: '5rem',
                   padding: '0.25rem 0.5rem',
@@ -302,12 +307,12 @@ export default function HadithsPage() {
                   color: 'var(--color-foreground)',
                 }}
               />
-              <button type="submit">Go</button>
+              <button type="submit">{t('common.go')}</button>
             </form>
 
             {/* Page size selector */}
             <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
-              <span style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>Show:</span>
+              <span style={{ color: 'var(--color-muted-foreground)', fontSize: '0.875rem' }}>{t('hadiths.show')}</span>
               {PAGE_SIZES.map((size) => (
                 <button
                   key={size}

--- a/frontend/src/pages/NarratorsPage.tsx
+++ b/frontend/src/pages/NarratorsPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { fetchNarrators } from '../api/client'
 
 export default function NarratorsPage() {
+  const { t } = useTranslation()
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState('')
   const [inputValue, setInputValue] = useState('')
@@ -23,13 +25,13 @@ export default function NarratorsPage() {
 
   return (
     <div>
-      <h2 className="page-heading">Narrators</h2>
+      <h2 className="page-heading">{t('narrators.heading')}</h2>
 
       <div className="flex-row" style={{ marginBottom: 'var(--spacing-4)' }}>
         <input
           type="text"
-          placeholder="Search narrators..."
-          aria-label="Search narrators"
+          placeholder={t('narrators.searchPlaceholder')}
+          aria-label={t('narrators.searchLabel')}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
@@ -37,7 +39,7 @@ export default function NarratorsPage() {
           style={{ flex: 1, maxWidth: 400 }}
         />
         <button onClick={handleSearch} className="btn-primary">
-          Search
+          {t('common.search')}
         </button>
       </div>
 
@@ -48,7 +50,7 @@ export default function NarratorsPage() {
           ))}
         </div>
       )}
-      {error && <p className="error-text">Error: {(error as Error).message}</p>}
+      {error && <p className="error-text">{t('common.error', { message: (error as Error).message })}</p>}
 
       {data && data.items.length === 0 && (
         <div className="empty-state">
@@ -58,9 +60,9 @@ export default function NarratorsPage() {
               <path d="m21 21-4.3-4.3" />
             </svg>
           </div>
-          <div className="empty-state-heading">No narrators found</div>
+          <div className="empty-state-heading">{t('narrators.emptyHeading')}</div>
           <div className="empty-state-body">
-            Try adjusting your search terms or clearing the filter.
+            {t('narrators.emptyBody')}
           </div>
         </div>
       )}
@@ -70,11 +72,11 @@ export default function NarratorsPage() {
           <table className="data-table">
             <thead>
               <tr>
-                <th>Name (Arabic)</th>
-                <th>Name (English)</th>
-                <th>Generation</th>
-                <th>Trustworthiness</th>
-                <th>Community</th>
+                <th>{t('common.colNameArabic')}</th>
+                <th>{t('common.colNameEnglish')}</th>
+                <th>{t('narrators.colGeneration')}</th>
+                <th>{t('narrators.colTrustworthiness')}</th>
+                <th>{t('narrators.colCommunity')}</th>
               </tr>
             </thead>
             <tbody>
@@ -99,13 +101,13 @@ export default function NarratorsPage() {
 
           <div className="pagination">
             <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-              Previous
+              {t('common.previous')}
             </button>
             <span>
-              Page {data.page} of {totalPages}
+              {t('common.pageOf', { current: data.page, total: totalPages })}
             </span>
             <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
-              Next
+              {t('common.next')}
             </button>
           </div>
         </>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { searchAll, searchSemantic } from '../api/client'
+import { searchAll, searchSemantic, fetchCollections } from '../api/client'
 import { Card, CardContent } from '../components/ui/Card'
 import { Badge } from '../components/ui/Badge'
 import { Input } from '../components/ui/Input'
@@ -33,16 +33,10 @@ interface SearchFilters {
   topics: string[]
 }
 
-const COLLECTIONS = [
-  'Bukhari',
-  'Muslim',
-  'Abu Dawud',
-  'Tirmidhi',
-  "Nasa'i",
-  'Ibn Majah',
-  'al-Kafi',
-  'Bihar al-Anwar',
-]
+// Collection facet options are derived from the live `/collections` response
+// (see the useQuery below), not hardcoded — the previous static list showed
+// unloaded Shia collections (al-Kafi, Bihar al-Anwar) and omitted loaded ones
+// (e.g. riyadussalihin). (#1026)
 
 const GRADINGS = ['Sahih', 'Hasan', "Da'if", "Mawdu'"]
 const CENTURIES = [1, 2, 3, 4, 5]
@@ -131,6 +125,18 @@ export default function SearchPage() {
     enabled: query.length >= 2,
     retry: 1,
   })
+
+  // Collection facet options, derived from the live `/collections` response so
+  // the filter only ever offers actually-loaded collections (mirrors the
+  // Hadiths page dropdown). (#1026)
+  const { data: collectionsData } = useQuery({
+    queryKey: ['collections-all'],
+    queryFn: () => fetchCollections(1, 100),
+    staleTime: 5 * 60 * 1000,
+  })
+  const collectionOptions = (collectionsData?.items ?? [])
+    .map((c) => c.name_en)
+    .sort((a, b) => a.localeCompare(b))
 
   // Close typeahead on outside click
   useEffect(() => {
@@ -294,17 +300,21 @@ export default function SearchPage() {
         <h4 id="filter-collection" className="text-sm font-semibold mb-2 uppercase tracking-wide text-muted-foreground">
           Collection
         </h4>
-        {COLLECTIONS.map((c) => (
-          <label key={c} className="flex items-center gap-2 py-1 cursor-pointer text-sm">
-            <input
-              type="checkbox"
-              checked={filters.collections.includes(c)}
-              onChange={() => toggleFilter('collections', c)}
-              className="rounded"
-            />
-            {c}
-          </label>
-        ))}
+        {collectionOptions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No collections available</p>
+        ) : (
+          collectionOptions.map((c) => (
+            <label key={c} className="flex items-center gap-2 py-1 cursor-pointer text-sm">
+              <input
+                type="checkbox"
+                checked={filters.collections.includes(c)}
+                onChange={() => toggleFilter('collections', c)}
+                className="rounded"
+              />
+              {c}
+            </label>
+          ))
+        )}
       </div>
 
       {/* Grading filter */}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,7 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { searchAll, searchSemantic, fetchCollections } from '../api/client'
+import {
+  searchAll,
+  searchSemantic,
+  fetchCollections,
+  SEARCH_MAX_LIMIT,
+  SEMANTIC_SEARCH_MAX_LIMIT,
+} from '../api/client'
 import { Card, CardContent } from '../components/ui/Card'
 import { Badge } from '../components/ui/Badge'
 import { Input } from '../components/ui/Input'
@@ -121,7 +127,9 @@ export default function SearchPage() {
   const { data: searchData, isLoading, isError, error: searchError } = useQuery({
     queryKey: ['search', query, mode],
     queryFn: () =>
-      mode === 'semantic' ? searchSemantic(query, 200) : searchAll(query, 200),
+      mode === 'semantic'
+        ? searchSemantic(query, SEMANTIC_SEARCH_MAX_LIMIT)
+        : searchAll(query, SEARCH_MAX_LIMIT),
     enabled: query.length >= 2,
     retry: 1,
   })

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -51,16 +51,21 @@ class NarratorResponse(BaseModel):
 
     id: str
     name_ar: str
-    name_en: str
+    # name_en and the structured biographical fields below are sparse on real
+    # loaded data (most narrators lack an English transliteration, generation,
+    # gender, sect, or a trustworthiness grade). They are optional so a node
+    # missing them serializes cleanly instead of raising a Pydantic
+    # ValidationError → HTTP 500 on GET /narrators (#1024).
+    name_en: str | None = None
     kunya: str | None = None
     nisba: str | None = None
     laqab: str | None = None
     birth_year_ah: int | None = None
     death_year_ah: int | None = None
-    generation: str
-    gender: str
-    sect_affiliation: str
-    trustworthiness_consensus: str
+    generation: str | None = None
+    gender: str | None = None
+    sect_affiliation: str | None = None
+    trustworthiness_consensus: str | None = None
     aliases: list[str] = []
     betweenness_centrality: float | None = None
     in_degree: int | None = None

--- a/tests/test_api/test_narrators.py
+++ b/tests/test_api/test_narrators.py
@@ -16,6 +16,14 @@ SAMPLE_NARRATOR = {
     "trustworthiness_consensus": "thiqah",
 }
 
+# A narrator node carrying only the always-present fields — most real loaded
+# narrators lack name_en / generation / gender / sect / trustworthiness. Before
+# #1024 these absent required fields raised a Pydantic ValidationError → 500.
+SPARSE_NARRATOR = {
+    "id": "nar-sparse",
+    "name_ar": "فلان بن فلان",
+}
+
 
 def test_list_narrators_empty(client: TestClient) -> None:
     """GET /api/v1/narrators returns empty paginated response when no data."""
@@ -41,6 +49,26 @@ def test_list_narrators_with_data(client: TestClient, mock_neo4j: MagicMock) -> 
     assert len(body["items"]) == 1
     assert body["items"][0]["id"] == "nar-001"
     assert body["items"][0]["name_en"] == "Abu Hurayra"
+
+
+def test_list_narrators_sparse_node(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """A narrator missing the sparse biographical fields serializes as 200, not 500 (#1024)."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 1}],
+        [{"props": SPARSE_NARRATOR}],
+    ]
+    resp = client.get("/api/v1/narrators")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    item = body["items"][0]
+    assert item["id"] == "nar-sparse"
+    # The absent fields come back as null rather than raising a validation error.
+    assert item["name_en"] is None
+    assert item["generation"] is None
+    assert item["gender"] is None
+    assert item["sect_affiliation"] is None
+    assert item["trustworthiness_consensus"] is None
 
 
 def test_list_narrators_pagination(client: TestClient, mock_neo4j: MagicMock) -> None:

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -74,6 +74,21 @@ def test_search_total_exceeds_limit(client: TestClient, mock_neo4j: MagicMock) -
     assert body["total"] == 180
 
 
+def test_search_limit_at_cap_is_accepted(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """limit at the endpoint cap (100) is accepted — the frontend results page
+    requests this much, so the cap must cover it (#1025)."""
+    mock_neo4j.execute_read.return_value = []
+    resp = client.get("/api/v1/search?q=test&limit=100")
+    assert resp.status_code == 200
+
+
+def test_search_limit_over_cap_is_422(client: TestClient) -> None:
+    """limit above the cap is rejected with 422 before any query runs. This is
+    the failure the frontend hit when it asked for limit=200 (#1025)."""
+    resp = client.get("/api/v1/search?q=test&limit=101")
+    assert resp.status_code == 422
+
+
 def test_search_falls_back_to_contains(client: TestClient, mock_neo4j: MagicMock) -> None:
     """When full-text index is unavailable, falls back to CONTAINS."""
     # narrator: fulltext raises, CONTAINS fallback succeeds
@@ -198,4 +213,48 @@ def test_semantic_search_returns_results_when_pg_available(client: TestClient, a
     assert body["results"][0]["score"] == 0.92
 
     # Clean up override
+    del app.dependency_overrides[get_pg]
+
+
+def test_semantic_search_limit_over_cap_is_422(client: TestClient, app: object) -> None:
+    """semantic limit above its cap (50) is rejected with 422 — the frontend
+    results page must stay within this cap (#1025).
+
+    The pg dependency is overridden with a mock so the assertion isolates the
+    request-validation behaviour and never touches a real database (FastAPI
+    resolves dependencies while validating params)."""
+    mock_pg = MagicMock()
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test&limit=51")
+    assert resp.status_code == 422
+    # Validation rejects the request before the handler queries pgvector.
+    mock_pg.execute.assert_not_called()
+
+    del app.dependency_overrides[get_pg]
+
+
+def test_semantic_search_limit_at_cap_is_accepted(client: TestClient, app: object) -> None:
+    """semantic limit at its cap (50) is accepted (#1025)."""
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = [[], [{"total": 0}]]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test&limit=50")
+    assert resp.status_code == 200
+
     del app.dependency_overrides[get_pg]


### PR DESCRIPTION
P5W2 "API light-up" wave merge for noorinalabs-isnad-graph. All 5 PRs reviewed (2 charter verdicts each) and merged to the wave branch, CI green:

- #1045 — narrators API 500 fix (#1024, keystone)
- #1033 — search results 422 fix (#1025)
- #1030 — i18n page-body strings (#998, TD intake)
- #1029 — auth refresh-on-401 (#1021)
- #1028 — subscriptions/me origin + collection facet (#1026)

Wave branch retained post-merge per owner directive (no --delete-branch).