### PR TITLE
fix(api): surface hadith grade via GRADED_BY + make grade filter real (#1048)

### DIFF
--- a/frontend/src/lib/__tests__/grades.test.ts
+++ b/frontend/src/lib/__tests__/grades.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { gradeLabel, gradeColor, gradeBarColor, gradeBarWidth } from '../grades'
+
+describe('grade helpers', () => {
+  it('maps canonical tokens to display labels', () => {
+    expect(gradeLabel('sahih')).toBe('Sahih')
+    expect(gradeLabel('hasan_sahih')).toBe('Hasan Sahih')
+    expect(gradeLabel('daif')).toBe("Da'if")
+    expect(gradeLabel('mawdu')).toBe("Mawdu'")
+  })
+
+  it('falls back to the raw token for unknown values', () => {
+    expect(gradeLabel('mysterious')).toBe('mysterious')
+  })
+
+  it('colours sahih and hasan_sahih as authentic', () => {
+    expect(gradeColor('sahih')).toContain('text-sahih')
+    expect(gradeColor('hasan_sahih')).toContain('text-sahih')
+    expect(gradeBarColor('sahih')).toBe('bg-sahih')
+    expect(gradeBarColor('hasan_sahih')).toBe('bg-sahih')
+  })
+
+  it('colours weak and fabricated grades distinctly', () => {
+    expect(gradeColor('daif')).toContain('text-daif')
+    expect(gradeBarColor('daif')).toBe('bg-warning')
+    expect(gradeBarColor('mawdu')).toBe('bg-destructive')
+  })
+
+  it('returns neutral classes for null/unknown tokens', () => {
+    expect(gradeColor(null)).toBe('')
+    expect(gradeColor('munkar')).toBe('')
+    expect(gradeBarColor(null)).toBe('bg-muted')
+  })
+
+  it('scales the bar width by soundness', () => {
+    expect(gradeBarWidth('sahih')).toBe('100%')
+    expect(gradeBarWidth('hasan_sahih')).toBe('100%')
+    expect(gradeBarWidth('hasan')).toBe('75%')
+    expect(gradeBarWidth('daif')).toBe('40%')
+    expect(gradeBarWidth(null)).toBe('40%')
+  })
+})

--- a/frontend/src/lib/grades.ts
+++ b/frontend/src/lib/grades.ts
@@ -1,0 +1,64 @@
+// Canonical hadith-grade tokens (produced by the API's grade_normalized field)
+// mapped to display labels and Tailwind colour classes. The raw scholar text is
+// shown verbatim; these helpers drive the badge/bar colour and the filter labels.
+
+export const GRADE_LABELS: Record<string, string> = {
+  sahih: 'Sahih',
+  hasan: 'Hasan',
+  hasan_sahih: 'Hasan Sahih',
+  daif: "Da'if",
+  mawdu: "Mawdu'",
+  munkar: 'Munkar',
+  shadh: 'Shadh',
+}
+
+export function gradeLabel(token: string): string {
+  return GRADE_LABELS[token] ?? token
+}
+
+// Badge background/text classes keyed on the normalized token.
+export function gradeColor(token: string | null): string {
+  switch (token) {
+    case 'sahih':
+    case 'hasan_sahih':
+      return 'bg-sahih-bg text-sahih'
+    case 'hasan':
+      return 'bg-hasan-bg text-hasan'
+    case 'daif':
+      return 'bg-daif-bg text-daif'
+    case 'mawdu':
+      return 'bg-mawdu-bg text-mawdu'
+    default:
+      return ''
+  }
+}
+
+// Solid bar colour for the grading strength indicator.
+export function gradeBarColor(token: string | null): string {
+  switch (token) {
+    case 'sahih':
+    case 'hasan_sahih':
+      return 'bg-sahih'
+    case 'hasan':
+      return 'bg-hasan'
+    case 'daif':
+      return 'bg-warning'
+    case 'mawdu':
+      return 'bg-destructive'
+    default:
+      return 'bg-muted'
+  }
+}
+
+// Relative fill width for the grading bar (sound grades read fuller).
+export function gradeBarWidth(token: string | null): string {
+  switch (token) {
+    case 'sahih':
+    case 'hasan_sahih':
+      return '100%'
+    case 'hasan':
+      return '75%'
+    default:
+      return '40%'
+  }
+}

--- a/frontend/src/pages/HadithDetailPage.tsx
+++ b/frontend/src/pages/HadithDetailPage.tsx
@@ -5,26 +5,7 @@ import { fetchHadith, fetchHadithParallels } from '../api/client'
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card'
 import { Badge } from '../components/ui/Badge'
 import { Button } from '../components/ui/Button'
-
-function gradeColor(grade: string | null): string {
-  if (!grade) return ''
-  const lower = grade.toLowerCase()
-  if (lower === 'sahih') return 'bg-sahih-bg text-sahih'
-  if (lower === 'hasan') return 'bg-hasan-bg text-hasan'
-  if (lower === "da'if" || lower === 'daif') return 'bg-daif-bg text-daif'
-  if (lower === "mawdu'" || lower === 'mawdu') return 'bg-mawdu-bg text-mawdu'
-  return ''
-}
-
-function gradeBarColor(grade: string | null): string {
-  if (!grade) return 'bg-muted'
-  const lower = grade.toLowerCase()
-  if (lower === 'sahih') return 'bg-sahih'
-  if (lower === 'hasan') return 'bg-hasan'
-  if (lower === "da'if" || lower === 'daif') return 'bg-warning'
-  if (lower === "mawdu'" || lower === 'mawdu') return 'bg-destructive'
-  return 'bg-muted'
-}
+import { gradeColor, gradeBarColor, gradeBarWidth } from '../lib/grades'
 
 function similarityLevel(score: number): string {
   if (score >= 0.9) return 'text-sahih'
@@ -135,7 +116,7 @@ export default function HadithDetailPage() {
             </h2>
             {hadith.grade_composite && (
               <span
-                className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${gradeColor(hadith.grade_composite)}`}
+                className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${gradeColor(hadith.grade_normalized)}`}
               >
                 {hadith.grade_composite}
               </span>
@@ -205,15 +186,8 @@ export default function HadithDetailPage() {
                 </div>
                 <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
                   <div
-                    className={`h-full rounded-full ${gradeBarColor(hadith.grade_composite)}`}
-                    style={{
-                      width:
-                        hadith.grade_composite.toLowerCase() === 'sahih'
-                          ? '100%'
-                          : hadith.grade_composite.toLowerCase() === 'hasan'
-                            ? '75%'
-                            : '40%',
-                    }}
+                    className={`h-full rounded-full ${gradeBarColor(hadith.grade_normalized)}`}
+                    style={{ width: gradeBarWidth(hadith.grade_normalized) }}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/HadithsPage.tsx
+++ b/frontend/src/pages/HadithsPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { fetchHadiths, fetchCollections, fetchHadithFacets } from '../api/client'
+import { gradeLabel } from '../lib/grades'
 
 const PAGE_SIZES = [25, 50, 100] as const
 
@@ -178,13 +179,16 @@ export default function HadithsPage() {
           }}
         >
           <option value="">{t('hadiths.allGrades')}</option>
-          {/* Grade names are scholarly classification terms that mirror the
-              untransformed API grade values shown in result badges, so per the
-              i18n scope policy (#703/#998) they are intentionally left as-is. */}
-          <option value="sahih">Sahih</option>
-          <option value="hasan">Hasan</option>
-          <option value="da'if">Da'if</option>
-          <option value="mawdu'">Mawdu'</option>
+          {/* Options come from the API facets (the normalized grades actually
+              present in the data). Grade names are scholarly classification terms
+              that mirror the untransformed API grade values shown in result
+              badges, so per the i18n scope policy (#703/#998) the labels are
+              intentionally left as-is. */}
+          {(facetsData?.grades ?? []).map((token) => (
+            <option key={token} value={token}>
+              {gradeLabel(token)}
+            </option>
+          ))}
         </select>
 
         {hasActiveFilters && (
@@ -248,7 +252,11 @@ export default function HadithsPage() {
                     <td>
                       {h.grade_composite && (
                         <span
-                          className={`badge ${h.grade_composite.toLowerCase() === 'sahih' ? 'badge-sahih' : 'badge-other-grade'}`}
+                          className={`badge ${
+                            h.grade_normalized === 'sahih' || h.grade_normalized === 'hasan_sahih'
+                              ? 'badge-sahih'
+                              : 'badge-other-grade'
+                          }`}
                         >
                           {h.grade_composite}
                         </span>

--- a/frontend/src/pages/__tests__/HadithDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/HadithDetailPage.test.tsx
@@ -18,7 +18,8 @@ function makeHadith(overrides: Partial<Hadith> = {}): Hadith {
     matn_en: "Actions are but by intentions",
     isnad_raw_ar: null,
     isnad_raw_en: null,
-    grade_composite: "Sahih",
+    grade_composite: "Sahih - Authentic",
+    grade_normalized: "sahih",
     topic_tags: ["intention", "worship"],
     source_corpus: "Sahih al-Bukhari",
     collection_name: "Bukhari",
@@ -104,9 +105,10 @@ describe("HadithDetailPage", () => {
       expect(
         screen.getByText("Actions are but by intentions"),
       ).toBeInTheDocument()
-      expect(
-        screen.getByText("Sahih", { selector: "span" }),
-      ).toBeInTheDocument()
+      // Raw free-text grade is shown verbatim, coloured from the normalized token.
+      const badge = screen.getByText("Sahih - Authentic", { selector: "span" })
+      expect(badge).toBeInTheDocument()
+      expect(badge).toHaveClass("text-sahih")
       // Metadata fields
       expect(screen.getByText("Collection")).toBeInTheDocument()
       expect(screen.getByText("Bukhari")).toBeInTheDocument()

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -33,6 +33,7 @@ export interface Hadith {
   isnad_raw_ar: string | null
   isnad_raw_en: string | null
   grade_composite: string | null
+  grade_normalized: string | null
   topic_tags: string[]
   source_corpus: string
   collection_name: string | null
@@ -43,6 +44,7 @@ export interface Hadith {
 
 export interface HadithFacetsResponse {
   source_corpus: string[]
+  grades: string[]
 }
 
 export interface Collection {

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -87,7 +87,8 @@ class HadithResponse(BaseModel):
                     "matn_en": "Actions are judged by intentions.",
                     "isnad_raw_ar": "حدثنا الحميدي...",
                     "isnad_raw_en": None,
-                    "grade_composite": "sahih",
+                    "grade_composite": "Sahih - Authentic",
+                    "grade_normalized": "sahih",
                     "topic_tags": ["intentions", "sincerity"],
                     "source_corpus": "bukhari",
                     "has_shia_parallel": True,
@@ -103,6 +104,7 @@ class HadithResponse(BaseModel):
     isnad_raw_ar: str | None = None
     isnad_raw_en: str | None = None
     grade_composite: str | None = None
+    grade_normalized: str | None = None
     topic_tags: list[str] = []
     source_corpus: str
     collection_name: str | None = None
@@ -117,6 +119,7 @@ class HadithFacetsResponse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     source_corpus: list[str]
+    grades: list[str] = []
 
 
 class CollectionResponse(BaseModel):

--- a/src/api/routes/hadiths.py
+++ b/src/api/routes/hadiths.py
@@ -8,7 +8,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
 from src.api.models import HadithFacetsResponse, HadithResponse, PaginatedResponse
+from src.utils.grades import grade_filter_clause, normalize_grade
 from src.utils.neo4j_client import Neo4jClient
+
+# Cypher expression for the effective raw grade: prefer the traversed Grading node,
+# fall back to any legacy flat property on the Hadith node.
+_GRADE_EXPR = "coalesce(g.grade, h.grade_composite, h.grade)"
 
 router = APIRouter()
 
@@ -67,11 +72,19 @@ def _format_display_title(hadith_id: str, collection_name: str | None) -> str:
     return display_name
 
 
-def _build_hadith_response(props: dict[str, Any]) -> HadithResponse:
-    """Convert Neo4j properties dict into a HadithResponse with display_title."""
+def _build_hadith_response(props: dict[str, Any], grade: str | None = None) -> HadithResponse:
+    """Convert Neo4j properties dict into a HadithResponse with display_title.
+
+    ``grade`` is the raw grade text resolved via the ``GRADED_BY`` traversal; it
+    falls back to a legacy flat ``grade_composite``/``grade`` property on the Hadith
+    node when no Grading node is connected. The raw text is surfaced for display and
+    its canonical form is exposed as ``grade_normalized`` for filtering/colouring.
+    """
     hadith_id = props.get("id", "")
     collection_name = props.get("collection_name")
     display_title = _format_display_title(hadith_id, collection_name)
+
+    raw_grade = grade or props.get("grade_composite") or props.get("grade")
 
     return HadithResponse(
         id=hadith_id,
@@ -79,7 +92,8 @@ def _build_hadith_response(props: dict[str, Any]) -> HadithResponse:
         matn_en=props.get("matn_en"),
         isnad_raw_ar=props.get("isnad_raw_ar"),
         isnad_raw_en=props.get("isnad_raw_en"),
-        grade_composite=props.get("grade_composite") or props.get("grade"),
+        grade_composite=raw_grade,
+        grade_normalized=normalize_grade(raw_grade),
         topic_tags=props.get("topic_tags", []),
         source_corpus=props.get("source_corpus", ""),
         collection_name=collection_name,
@@ -98,7 +112,19 @@ def get_hadith_facets(
         "MATCH (h:Hadith) WHERE h.source_corpus IS NOT NULL "
         "RETURN DISTINCT h.source_corpus AS corpus ORDER BY corpus"
     )
-    return HadithFacetsResponse(source_corpus=[row["corpus"] for row in rows])
+    # Distinct raw grades across all Grading nodes (bounded ~dozens of free-text
+    # values); normalize each to its canonical token and return the present set.
+    grade_rows = neo4j.execute_read(
+        "MATCH (:Hadith)-[:GRADED_BY]->(g:Grading) "
+        "WHERE g.grade IS NOT NULL RETURN DISTINCT g.grade AS grade"
+    )
+    grades = sorted(
+        {token for row in grade_rows if (token := normalize_grade(row["grade"])) is not None}
+    )
+    return HadithFacetsResponse(
+        source_corpus=[row["corpus"] for row in rows],
+        grades=grades,
+    )
 
 
 @router.get("/hadiths", response_model=PaginatedResponse[HadithResponse])
@@ -124,8 +150,11 @@ def list_hadiths(
         where_clauses.append("h.source_corpus = $source_corpus")
         params["source_corpus"] = source_corpus
     if grade:
-        where_clauses.append("(h.grade_composite = $grade OR h.grade = $grade)")
-        params["grade"] = grade
+        # Match the connected Grading node's (or legacy flat) grade against the
+        # requested canonical token, using the same rules as normalize_grade.
+        clause, grade_params = grade_filter_clause(grade, _GRADE_EXPR)
+        where_clauses.append(clause)
+        params.update(grade_params)
     if q:
         where_clauses.append(
             "(toLower(h.matn_ar) CONTAINS toLower($q) OR toLower(h.matn_en) CONTAINS toLower($q))"
@@ -134,16 +163,21 @@ def list_hadiths(
 
     where = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
-    count_query = f"MATCH (h:Hadith) {where} RETURN count(h) AS total"
+    # OPTIONAL MATCH so ungraded hadiths still list; when a grade filter is active
+    # its clause requires g, so the OPTIONAL MATCH then effectively inner-joins.
+    # Grading is 1:1 per hadith, so this does not duplicate rows.
+    base = f"MATCH (h:Hadith) OPTIONAL MATCH (h)-[:GRADED_BY]->(g:Grading) {where} "
+
+    count_query = f"{base}RETURN count(h) AS total"
     count_result = neo4j.execute_read(count_query, params)
     total = count_result[0]["total"] if count_result else 0
 
     data_query = (
-        f"MATCH (h:Hadith) {where} "
-        "RETURN properties(h) AS props ORDER BY h.id SKIP $skip LIMIT $limit"
+        f"{base}RETURN properties(h) AS props, {_GRADE_EXPR} AS grade "
+        "ORDER BY h.id SKIP $skip LIMIT $limit"
     )
     rows = neo4j.execute_read(data_query, params)
-    items = [_build_hadith_response(row["props"]) for row in rows]
+    items = [_build_hadith_response(row["props"], row.get("grade")) for row in rows]
     return PaginatedResponse(items=items, total=total, page=page, limit=limit)
 
 
@@ -154,9 +188,11 @@ def get_hadith(
 ) -> HadithResponse:
     """Return a single hadith by ID."""
     rows = neo4j.execute_read(
-        "MATCH (h:Hadith {id: $id}) RETURN properties(h) AS props",
+        "MATCH (h:Hadith {id: $id}) "
+        "OPTIONAL MATCH (h)-[:GRADED_BY]->(g:Grading) "
+        f"RETURN properties(h) AS props, {_GRADE_EXPR} AS grade",
         {"id": hadith_id},
     )
     if not rows:
         raise HTTPException(status_code=404, detail=f"Hadith '{hadith_id}' not found")
-    return _build_hadith_response(rows[0]["props"])
+    return _build_hadith_response(rows[0]["props"], rows[0].get("grade"))

--- a/src/utils/grades.py
+++ b/src/utils/grades.py
@@ -1,0 +1,108 @@
+"""Hadith grade normalization.
+
+The graph stores grades as free-text scholar strings on the
+``(Hadith)-[:GRADED_BY]->(Grading {grade})`` node, e.g. ``"Sahih - Authentic"``,
+``"Sahih-Authentic"``, ``"Hasan Sahih"``, ``"Da'if in chain"``, ``"Sahih Maqtu'"``,
+``"Munkar"``, ``"Shadh"`` or Arabic ``"صحيح الإسناد مقطوع"``.
+
+These raw values are kept for display, but they are useless for filtering and for
+the frontend colour mapping, which both need a small, canonical vocabulary. This
+module maps the free-text grade to one of a fixed set of canonical tokens and
+provides the matching Cypher predicate so the API can filter by a canonical token
+against the un-normalized graph (the long-term home for a stored
+``grade_normalized`` is the data layer — cf. da#153).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Keyword groups: a raw grade belongs to a group if its lower-cased text contains
+# any of the group's substrings. Transliterations + Arabic only — the English
+# glosses ("authentic"/"good"/"weak") always co-occur with the transliteration in
+# the source data, so listing them would only add false-positive risk.
+_KEYWORDS: Final[dict[str, tuple[str, ...]]] = {
+    "sahih": ("sahih", "صحيح"),
+    "hasan": ("hasan", "حسن"),
+    "daif": ("da'if", "da’if", "daif", "ضعيف"),
+    "mawdu": ("mawdu", "maudu", "موضوع"),
+    "munkar": ("munkar", "منكر"),
+    "shadh": ("shadh", "شاذ"),
+}
+
+# Canonical token -> human-readable display label.
+GRADE_LABELS: Final[dict[str, str]] = {
+    "sahih": "Sahih",
+    "hasan": "Hasan",
+    "hasan_sahih": "Hasan Sahih",
+    "daif": "Da'if",
+    "mawdu": "Mawdu'",
+    "munkar": "Munkar",
+    "shadh": "Shadh",
+}
+
+# Per-canonical-token predicate spec mirroring normalize_grade's priority:
+#   (required keyword groups [all must match], excluded groups [none may match]).
+# Defects (mawdu/munkar/shadh) take precedence over soundness grades, and the
+# combined "hasan sahih" grade is distinguished from plain sahih / hasan.
+_PREDICATES: Final[dict[str, tuple[tuple[str, ...], tuple[str, ...]]]] = {
+    "mawdu": (("mawdu",), ()),
+    "munkar": (("munkar",), ("mawdu",)),
+    "shadh": (("shadh",), ("mawdu", "munkar")),
+    "hasan_sahih": (("hasan", "sahih"), ("mawdu", "munkar", "shadh")),
+    "sahih": (("sahih",), ("mawdu", "munkar", "shadh", "hasan")),
+    "hasan": (("hasan",), ("mawdu", "munkar", "shadh", "sahih")),
+    "daif": (("daif",), ("mawdu", "munkar", "shadh", "sahih", "hasan")),
+}
+
+# Canonical tokens in the priority order normalize_grade applies them.
+GRADE_TOKENS: Final[tuple[str, ...]] = tuple(_PREDICATES.keys())
+
+
+def normalize_grade(raw: str | None) -> str | None:
+    """Map a free-text grade to a canonical token, or ``None`` if unrecognized.
+
+    Priority: defect grades (mawdu > munkar > shadh) override soundness grades;
+    a grade carrying both hasan and sahih keywords becomes ``hasan_sahih``.
+    """
+    if not raw or not raw.strip():
+        return None
+    text = raw.lower()
+
+    def has(group: str) -> bool:
+        return any(kw in text for kw in _KEYWORDS[group])
+
+    for token, (required, excluded) in _PREDICATES.items():
+        if all(has(g) for g in required) and not any(has(g) for g in excluded):
+            return token
+    return None
+
+
+def grade_filter_clause(
+    token: str, target: str, param_prefix: str = "grkw"
+) -> tuple[str, dict[str, list[str]]]:
+    """Build a Cypher boolean predicate matching ``target`` against a canonical token.
+
+    ``target`` is a Cypher expression evaluating to the raw grade string (e.g.
+    ``coalesce(g.grade, h.grade_composite, h.grade)``). Returns the predicate text
+    and the parameter map of keyword lists. The predicate mirrors
+    :func:`normalize_grade` exactly, so filtering by ``token`` returns precisely the
+    hadiths whose grade normalizes to ``token``. Unknown tokens yield ``"false"``.
+    """
+    spec = _PREDICATES.get(token)
+    if spec is None:
+        return "false", {}
+    required, excluded = spec
+    params: dict[str, list[str]] = {}
+    lowered = f"toLower({target})"
+
+    def group_clause(group: str) -> str:
+        key = f"{param_prefix}_{group}"
+        params[key] = list(_KEYWORDS[group])
+        return f"any(kw IN ${key} WHERE {lowered} CONTAINS kw)"
+
+    parts = [group_clause(g) for g in required]
+    if excluded:
+        neg = " OR ".join(group_clause(g) for g in excluded)
+        parts.append(f"NOT ({neg})")
+    return "(" + " AND ".join(parts) + ")", params

--- a/tests/test_api/test_hadiths.py
+++ b/tests/test_api/test_hadiths.py
@@ -24,16 +24,26 @@ def test_get_hadith_facets_empty(client: TestClient) -> None:
 
 
 def test_get_hadith_facets_with_data(client: TestClient, mock_neo4j: MagicMock) -> None:
-    """GET /api/v1/hadiths/facets returns distinct corpus values."""
-    mock_neo4j.execute_read.return_value = [
-        {"corpus": "lk"},
-        {"corpus": "sunnah"},
-        {"corpus": "thaqalayn"},
+    """GET /api/v1/hadiths/facets returns distinct corpus + normalized grade values."""
+    mock_neo4j.execute_read.side_effect = [
+        # First call: corpus facets.
+        [{"corpus": "lk"}, {"corpus": "sunnah"}, {"corpus": "thaqalayn"}],
+        # Second call: raw free-text grades off Grading nodes.
+        [
+            {"grade": "Sahih - Authentic"},
+            {"grade": "Sahih-Authentic"},
+            {"grade": "Hasan Sahih"},
+            {"grade": "Da'if in chain"},
+            {"grade": "totally unknown"},
+        ],
     ]
     resp = client.get("/api/v1/hadiths/facets")
     assert resp.status_code == 200
     body = resp.json()
     assert body["source_corpus"] == ["lk", "sunnah", "thaqalayn"]
+    # Distinct normalized tokens, sorted; "Sahih - Authentic"/"Sahih-Authentic"
+    # collapse to one, and the unrecognized value is dropped.
+    assert body["grades"] == ["daif", "hasan_sahih", "sahih"]
 
 
 def test_list_hadiths_empty(client: TestClient) -> None:
@@ -133,3 +143,68 @@ def test_get_hadith_not_found(client: TestClient) -> None:
     resp = client.get("/api/v1/hadiths/nonexistent")
     assert resp.status_code == 404
     assert "not found" in resp.json()["detail"].lower()
+
+
+# --- ig#1048: grade is read via GRADED_BY traversal, not a flat property -------
+#
+# These fixtures deliberately do NOT set grade_composite on the Hadith props
+# (matching production, where 0/34,028 hadiths carry it); the grade arrives as a
+# separate row column from the OPTIONAL MATCH (h)-[:GRADED_BY]->(g) traversal.
+
+
+def test_get_hadith_returns_traversed_grade(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """Detail surfaces the raw GRADED_BY grade and its normalized token."""
+    mock_neo4j.execute_read.return_value = [{"props": SAMPLE_HADITH, "grade": "Sahih - Authentic"}]
+    resp = client.get("/api/v1/hadiths/hdt:lk:abu_dawud:10:1574")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["grade_composite"] == "Sahih - Authentic"  # raw text for display
+    assert body["grade_normalized"] == "sahih"  # canonical token for colour
+    # The query must traverse GRADED_BY (the bug was that it never did).
+    query = mock_neo4j.execute_read.call_args_list[0][0][0]
+    assert "GRADED_BY" in query
+
+
+def test_get_hadith_ungraded_has_null_grade(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """A hadith with no Grading node returns null grade fields, not an error."""
+    mock_neo4j.execute_read.return_value = [{"props": SAMPLE_HADITH, "grade": None}]
+    resp = client.get("/api/v1/hadiths/hdt:lk:abu_dawud:10:1574")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["grade_composite"] is None
+    assert body["grade_normalized"] is None
+
+
+def test_list_hadiths_returns_traversed_grade(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """List surfaces the GRADED_BY grade per item and traverses in both queries."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 1}],
+        [{"props": SAMPLE_HADITH, "grade": "Hasan Sahih"}],
+    ]
+    resp = client.get("/api/v1/hadiths")
+    assert resp.status_code == 200
+    item = resp.json()["items"][0]
+    assert item["grade_composite"] == "Hasan Sahih"
+    assert item["grade_normalized"] == "hasan_sahih"
+    count_query, data_query = (c[0][0] for c in mock_neo4j.execute_read.call_args_list)
+    assert "GRADED_BY" in count_query
+    assert "GRADED_BY" in data_query
+
+
+def test_list_hadiths_filter_by_grade_is_real(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """The grade filter builds a predicate over the traversed grade (not a no-op)."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"total": 1}],
+        [{"props": SAMPLE_HADITH, "grade": "Sahih - Authentic"}],
+    ]
+    resp = client.get("/api/v1/hadiths?grade=sahih")
+    assert resp.status_code == 200
+    count_call = mock_neo4j.execute_read.call_args_list[0]
+    count_query, params = count_call[0][0], count_call[0][1]
+    # No longer the broken `h.grade_composite = $grade` flat-property comparison.
+    assert "h.grade_composite = $grade" not in count_query
+    # Filters against the coalesced traversed grade.
+    assert "coalesce(g.grade" in count_query
+    assert "GRADED_BY" in count_query
+    # Keyword params for the sahih predicate are bound.
+    assert any("sahih" in v for v in params.values() if isinstance(v, list))

--- a/tests/test_utils/test_grades.py
+++ b/tests/test_utils/test_grades.py
@@ -1,0 +1,105 @@
+"""Tests for hadith grade normalization (ig#1048).
+
+Uses the production-shaped free-text grade strings actually present in the graph
+(`Sahih - Authentic`, `Hasan Sahih`, `Da'if in chain`, Arabic `صحيح الإسناد مقطوع`,
+…) rather than the toy canonical tokens that older fixtures pre-populated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.grades import (
+    GRADE_TOKENS,
+    grade_filter_clause,
+    normalize_grade,
+)
+
+# (raw free-text grade, expected canonical token) — drawn from the stg distribution
+# cited in the issue plus the apostrophe/Arabic variants.
+PRODUCTION_GRADES: list[tuple[str, str]] = [
+    ("Sahih - Authentic", "sahih"),
+    ("Sahih-Authentic", "sahih"),
+    ("Sahih", "sahih"),
+    ("Sahih Maqtu'", "sahih"),
+    ("صحيح الإسناد مقطوع", "sahih"),
+    ("Hasan - Good", "hasan"),
+    ("Hasan", "hasan"),
+    ("Hasan Sahih", "hasan_sahih"),
+    ("Daif - Weak", "daif"),
+    ("Da'if", "daif"),
+    ("Da'if in chain", "daif"),
+    ("ضعيف", "daif"),
+    ("Mawdu' - Fabricated", "mawdu"),
+    ("Maudu", "mawdu"),
+    ("Munkar", "munkar"),
+    ("Shadh", "shadh"),
+]
+
+
+@pytest.mark.parametrize(("raw", "expected"), PRODUCTION_GRADES)
+def test_normalize_grade_production_values(raw: str, expected: str) -> None:
+    assert normalize_grade(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [None, "", "   ", "no-grade-here", "unknown classification"])
+def test_normalize_grade_unrecognized_returns_none(raw: str | None) -> None:
+    assert normalize_grade(raw) is None
+
+
+def test_defect_grades_take_precedence_over_soundness() -> None:
+    # A string mentioning both a defect and a soundness keyword resolves to the defect.
+    assert normalize_grade("Sahih but Munkar") == "munkar"
+    assert normalize_grade("Mawdu' though attributed Sahih") == "mawdu"
+
+
+def test_hasan_sahih_distinct_from_sahih_and_hasan() -> None:
+    assert normalize_grade("Hasan Sahih") == "hasan_sahih"
+    assert normalize_grade("Sahih") != "hasan_sahih"
+    assert normalize_grade("Hasan") != "hasan_sahih"
+
+
+def test_grade_filter_clause_unknown_token_is_false() -> None:
+    clause, params = grade_filter_clause("not-a-grade", "g.grade")
+    assert clause == "false"
+    assert params == {}
+
+
+def test_grade_filter_clause_emits_parameterized_predicate() -> None:
+    clause, params = grade_filter_clause("sahih", "g.grade")
+    assert "toLower(g.grade)" in clause
+    # sahih excludes hasan (so "Hasan Sahih" is not caught by the sahih filter).
+    assert "NOT" in clause
+    # Keyword lists are passed as params (no string interpolation of values).
+    assert any("sahih" in kws for kws in params.values())
+    assert any("hasan" in kws for kws in params.values())
+
+
+def _python_eval_clause(clause: str, params: dict[str, list[str]], raw: str) -> bool:
+    """Evaluate the generated Cypher predicate in Python to assert it mirrors
+    normalize_grade. The clause is built from a tiny, fixed Cypher subset:
+    ``any(kw IN $KEY WHERE toLower(g.grade) CONTAINS kw)`` groups joined by AND
+    with an optional ``NOT ( ... OR ... )``. Each group is replaced by its boolean
+    value (computed from params) so only True/False/and/or/not/parens remain."""
+    import re
+
+    lowered = raw.lower()
+
+    def repl(m: re.Match[str]) -> str:
+        key = m.group(1)
+        return str(any(kw in lowered for kw in params[key]))
+
+    skeleton = re.sub(r"any\(kw IN \$(\w+) WHERE toLower\(g\.grade\) CONTAINS kw\)", repl, clause)
+    skeleton = skeleton.replace("NOT (", "not (").replace(" AND ", " and ").replace(" OR ", " or ")
+    return bool(eval(skeleton))  # noqa: S307 - skeleton is only booleans + operators
+
+
+@pytest.mark.parametrize(("raw", "expected"), PRODUCTION_GRADES)
+def test_filter_clause_matches_normalize_for_its_token(raw: str, expected: str) -> None:
+    """The filter for token T must match exactly the raws that normalize to T."""
+    for token in GRADE_TOKENS:
+        clause, params = grade_filter_clause(token, "g.grade")
+        matched = _python_eval_clause(clause, params, raw)
+        assert matched == (token == expected), (
+            f"token={token!r} raw={raw!r}: clause matched={matched}, normalize={expected!r}"
+        )


### PR DESCRIPTION
## Summary
Fixes ig#1048: the hadith grade was never displayed and the grade filter was a no-op.

The grade lives on `(Hadith)-[:GRADED_BY]->(Grading {grade})` as free-text scholar strings, but `routes/hadiths.py` only queried `properties(h)` and read `h.grade_composite`/`h.grade` — both null on all 34,028 hadiths — so detail/list showed no grade and `WHERE (h.grade_composite = $grade OR h.grade = $grade)` matched nothing.

## Changes
- **Traverse `GRADED_BY`** in `get_hadith`, `list_hadiths`, and `/hadiths/facets`; the raw grade text is returned for display.
- **`src/utils/grades.py`** — `normalize_grade()` maps free-text grades (`Sahih - Authentic`, `Sahih-Authentic`, `Hasan Sahih`, `Da'if in chain`, `Sahih Maqtu'`, `Munkar`, `Shadh`, Arabic `صحيح الإسناد مقطوع`, …) to canonical tokens (`sahih`/`hasan`/`hasan_sahih`/`daif`/`mawdu`/`munkar`/`shadh`). `grade_filter_clause()` generates a parameterized Cypher predicate from the **same** rules, so filtering by a token returns exactly the hadiths whose grade normalizes to it (a unit test asserts this equivalence across all tokens × production grades).
- **API contract** — `HadithResponse` now carries `grade_composite` (raw, for display) **and** `grade_normalized` (canonical, for filter/colour). `HadithFacetsResponse.grades` lists the normalized grades actually present.
- **Filter** matches against `coalesce(g.grade, h.grade_composite, h.grade)` so any legacy flat-property data still works.
- **Frontend** — shared `lib/grades.ts` (label + colour by normalized token); detail page shows raw text coloured by the normalized token; the grade dropdown is populated from `/facets` instead of a hardcoded list whose values never matched the data.

## Acceptance (ig#1048)
- [x] Hadith detail shows the grade (raw text) with correct colour
- [x] Search grade filter narrows results (normalized match, no longer a no-op)
- [x] `/hadiths/facets` returns real grade options
- [x] Regression tests on `GRADED_BY`-shaped fixtures with real free-text grade values (old fixtures pre-populated `grade_composite`, masking the bug)

Follow-up (out of scope, noted in code): the long-term home for a stored `grade_normalized` is the data layer at load time — cf. da#153.

## Test plan
- Backend unit `tests/test_utils/test_grades.py` — **41 passed** locally (normalization on production grade strings + filter/normalize equivalence).
- `tests/test_api/test_hadiths.py` extended (GRADED_BY traversal returned in list+detail; grade filter builds a real predicate; facets returns normalized grades). These use the `mock_neo4j` fixture; **the FastAPI `app` fixture connects to a real service at startup and HANGS in the sandbox (verified: an unmodified existing test times out at RC=124)** — per charter § Sandbox Test-Verification, these run in CI.
- Frontend `vitest` — **19 passed** (`lib/__tests__/grades.test.ts` + updated `HadithDetailPage.test.tsx`); `tsc -b` clean.
- `ruff` + `mypy` clean on changed backend files.

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)
