### PR TITLE
fix(search): compute + load hadith embeddings so /search/semantic returns results (#1049)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ CORS_ORIGINS=["http://localhost:3000"]
 LOG_LEVEL=INFO
 LOG_FORMAT=console
 
+# Semantic search embedding model (see src/enrich/embeddings.py).
+# "hashing" = dependency-free deterministic encoder (dev / CI / sandbox default).
+# Production sets a 384-dim sentence-transformers model on the cluster, e.g.:
+#   EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+EMBEDDING_MODEL=hashing
+
 # Production Docker Compose (docker-compose.prod.yml)
 POSTGRES_USER=isnad
 POSTGRES_PASSWORD=change-me-in-production

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ check:           ## Run all CI checks locally (lint + typecheck + test)
 	uv run pytest tests/ -v --tb=short -x -m "not integration and not e2e"
 	@echo "All checks passed. Safe to push."
 
+embed-hadiths: ## Compute hadith embeddings and load pgvector (semantic search; #1049)
+	uv run isnad embed-hadiths $(ARGS)
+
 backup: ## Run database backup to Backblaze B2
 	bash scripts/backup.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,12 @@ ignore_missing_imports = true
 module = ["prometheus_fastapi_instrumentator", "prometheus_fastapi_instrumentator.*"]
 ignore_missing_imports = true
 
+# Optional ML extra (production embedding load only); not a runtime dependency,
+# so its stubs are never installed in CI. See src/enrich/embeddings.py.
+[[tool.mypy.overrides]]
+module = ["sentence_transformers", "sentence_transformers.*"]
+ignore_missing_imports = true
+
 [tool.pydantic-mypy]
 init_forbid_extra = true
 init_typed = true

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from src.api.deps import get_neo4j, get_pg
 from src.api.models import SearchResult, SearchResultsResponse
+from src.enrich.embeddings import get_embedder, to_pgvector_literal
 from src.utils.neo4j_client import Neo4jClient
 from src.utils.pg_client import PgClient
 
@@ -188,26 +189,27 @@ def search_semantic(
 ) -> SearchResultsResponse:
     """Semantic similarity search using pgvector.
 
-    Queries the ``isnad_graph.hadith_embeddings`` table for cosine-similar
-    hadiths.  Returns 503 when the table or pgvector extension is unavailable.
+    Embeds the query with the configured embedder (see ``src/enrich/embeddings.py``)
+    and cosine-ranks the ``isnad_graph.hadith_embeddings`` table against that
+    vector. Returns 503 when the table or pgvector extension is unavailable.
+
+    The query is embedded at request time rather than looked up by exact text:
+    the previous implementation matched the query string against stored hadith
+    text (``WHERE text = %s``), so anything but a verbatim hadith returned
+    nothing even when embeddings were loaded (isnad-graph#1049).
     """
+    query_vector = to_pgvector_literal(get_embedder().embed([q])[0])
     try:
         rows = pg.execute(
             """
             SELECT h.id, h.matn_ar, h.matn_en,
-                   1 - (e.embedding <=> (
-                       SELECT embedding FROM isnad_graph.hadith_embeddings
-                       WHERE text = %s LIMIT 1
-                   )) AS score
+                   1 - (e.embedding <=> %s::vector) AS score
             FROM isnad_graph.hadith_embeddings e
             JOIN isnad_graph.hadiths h ON h.id = e.hadith_id
-            ORDER BY e.embedding <=> (
-                SELECT embedding FROM isnad_graph.hadith_embeddings
-                WHERE text = %s LIMIT 1
-            )
+            ORDER BY e.embedding <=> %s::vector
             LIMIT %s
             """,
-            (q, q, limit),
+            (query_vector, query_vector, limit),
         )
         # Total count of candidate hadiths (the LIMIT above caps ``rows`` at
         # ``limit``; ``total`` must reflect the full searchable set).

--- a/src/cli.py
+++ b/src/cli.py
@@ -99,6 +99,37 @@ def _cmd_enrich_historical() -> None:
     print(f"  skipped (max lifetime) : {result.narrators_skipped_max_lifetime}")
 
 
+def _cmd_embed_hadiths(batch_size: int, limit: int | None) -> None:
+    """Compute hadith embeddings and load them into pgvector.
+
+    Closes the gap behind #1049: with no embeddings loaded, ``/search/semantic``
+    has nothing to cosine-match and always returns empty. This is the
+    reproducible mechanism — re-running is idempotent (every write is an upsert).
+    The embedding model is selected by ``EMBEDDING_MODEL`` (default ``hashing``,
+    the dependency-free encoder; set a sentence-transformers model on the cluster
+    for the production load).
+    """
+    _check_neo4j()
+
+    from src.enrich.embeddings import get_embedder, run_embedding_load
+    from src.utils.neo4j_client import Neo4jClient
+    from src.utils.pg_client import PgClient
+
+    embedder = get_embedder()
+    print(f"Embedding hadiths (model={embedder.model_name}, dim={embedder.dim})...")
+    with Neo4jClient() as neo4j, PgClient() as pg:
+        result = run_embedding_load(
+            neo4j, pg, embedder=embedder, batch_size=batch_size, limit=limit
+        )
+
+    print("=== embedding load complete ===")
+    print(f"  hadiths loaded     : {result.hadiths_loaded}")
+    print(f"  embeddings loaded  : {result.embeddings_loaded}")
+    print(f"  skipped (no matn)  : {result.skipped_empty}")
+    print(f"  model              : {result.model_name}")
+    print(f"  dim                : {result.dim}")
+
+
 def main() -> None:
     """Run the isnad-graph CLI."""
     parser = argparse.ArgumentParser(description="isnad-graph: Hadith Analysis Platform")
@@ -108,6 +139,16 @@ def main() -> None:
     subparsers.add_parser(
         "enrich-historical",
         help="Load HistoricalEvent nodes and link narrators (ACTIVE_DURING)",
+    )
+    embed_parser = subparsers.add_parser(
+        "embed-hadiths",
+        help="Compute hadith embeddings and load them into pgvector (semantic search)",
+    )
+    embed_parser.add_argument(
+        "--batch-size", type=int, default=256, help="Embedding/upsert batch size (default 256)"
+    )
+    embed_parser.add_argument(
+        "--limit", type=int, default=None, help="Only embed the first N hadiths (default: all)"
     )
 
     args = parser.parse_args()
@@ -120,6 +161,8 @@ def main() -> None:
         _cmd_info()
     elif args.command == "enrich-historical":
         _cmd_enrich_historical()
+    elif args.command == "embed-hadiths":
+        _cmd_embed_hadiths(args.batch_size, args.limit)
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -164,6 +164,12 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     log_format: str = "console"
 
+    # Semantic-search embedding model. The default ``"hashing"`` selects the
+    # dependency-free encoder (CI / sandbox / local dev); production sets this to
+    # a real sentence-transformers model name on the cluster (P5W4 load). See
+    # ``src/enrich/embeddings.py``. Read via env ``EMBEDDING_MODEL``.
+    embedding_model: str = "hashing"
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/src/enrich/__init__.py
+++ b/src/enrich/__init__.py
@@ -2,13 +2,23 @@
 
 The enrich stage runs *after* the graph load and adds derived structure on top
 of the loaded nodes: graph metrics, topic classification, and the historical
-overlay. Only the historical overlay (``ACTIVE_DURING`` edge creation plus the
-``HistoricalEvent`` reference-node load) is implemented in this repo today;
-metrics (Neo4j GDS) and topic classification are tracked as future work.
+overlay. The historical overlay (``ACTIVE_DURING`` edge creation plus the
+``HistoricalEvent`` reference-node load) and the semantic-search embedding load
+(hadith vectors → pgvector) are implemented in this repo today; metrics
+(Neo4j GDS) and topic classification are tracked as future work.
 """
 
 from __future__ import annotations
 
+from src.enrich.embeddings import (
+    EMBEDDING_DIM,
+    Embedder,
+    HashingEmbedder,
+    ensure_embedding_schema,
+    get_embedder,
+    run_embedding_load,
+    to_pgvector_literal,
+)
 from src.enrich.historical import (
     compute_active_during,
     default_events_path,
@@ -18,9 +28,16 @@ from src.enrich.historical import (
 )
 
 __all__ = [
+    "EMBEDDING_DIM",
+    "Embedder",
+    "HashingEmbedder",
     "compute_active_during",
     "default_events_path",
+    "ensure_embedding_schema",
     "event_to_graph_props",
+    "get_embedder",
     "load_events_from_yaml",
+    "run_embedding_load",
     "run_historical_overlay",
+    "to_pgvector_literal",
 ]

--- a/src/enrich/embeddings.py
+++ b/src/enrich/embeddings.py
@@ -1,0 +1,381 @@
+"""Semantic-search embedding enrichment — compute hadith vectors and load pgvector.
+
+This stage closes the gap behind isnad-graph#1049 ("semantic search returns
+nothing — 0/34,028 hadiths have embeddings"). ``/search/semantic`` (see
+``src/api/routes/search.py``) does a pgvector cosine match against
+``isnad_graph.hadith_embeddings``; that table was never populated, so the
+endpoint always returned empty. This module is the reproducible mechanism that
+fills it.
+
+Storage decision (the issue asks us to pick one and align both sides):
+**pgvector in Postgres**, not ``h.embedding`` on Neo4j. The semantic endpoint
+already targets ``isnad_graph.hadith_embeddings`` / ``isnad_graph.hadiths`` and
+``PgClient.ensure_schema()`` already creates the ``vector`` extension, so
+Postgres is the established home for vectors. The loader here writes there and
+the endpoint reads from there — one backend, both sides aligned.
+
+Embedder choice — why pluggable and dependency-free by default:
+This repo carries **no heavy ML runtime** (no ``torch`` / ``sentence-transformers``;
+``make setup`` is a bare ``uv sync``) and runs on Python 3.14, for which those
+wheels are not yet published. A hard ML dependency would break ``make setup`` and
+CI. So the embedder is a small :class:`Embedder` protocol with two
+implementations:
+
+* :class:`HashingEmbedder` — deterministic, pure-Python, zero-dependency. This is
+  the default and the one CI / the sandbox exercise. It produces L2-normalised
+  hashed bag-of-token vectors, so cosine similarity carries real lexical signal
+  (the full vector path is genuinely exercised, not mocked) and results are
+  perfectly reproducible.
+* :class:`SentenceTransformerEmbedder` — lazily imports ``sentence_transformers``
+  and is selected only when ``EMBEDDING_MODEL`` names a real model *and* the
+  package is installed. This is the production / staging path
+  (P5W4 cluster load), where a multilingual sentence-transformer gives true
+  semantic similarity over the Arabic + English matn.
+
+The dimension (:data:`EMBEDDING_DIM`, 384) matches the common multilingual
+MiniLM family, so swapping the default for a real model in production needs an
+env var, not a column migration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from functools import lru_cache
+from typing import TYPE_CHECKING, Protocol
+
+from src.config import get_settings
+from src.models.enrich import EmbeddingLoadResult
+from src.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from src.utils.neo4j_client import Neo4jClient
+    from src.utils.pg_client import PgClient
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "EMBEDDING_DIM",
+    "Embedder",
+    "HashingEmbedder",
+    "SentenceTransformerEmbedder",
+    "embedding_text",
+    "ensure_embedding_schema",
+    "fetch_hadiths_from_neo4j",
+    "get_embedder",
+    "run_embedding_load",
+    "to_pgvector_literal",
+]
+
+log = get_logger(__name__)
+
+# Vector dimension. 384 == sentence-transformers MiniLM family, so the default
+# HashingEmbedder and a production multilingual MiniLM share a column type and a
+# swap needs no migration. Changing this requires re-creating the embeddings
+# table (the vector(N) type is fixed at DDL time).
+EMBEDDING_DIM = 384
+
+# Sentinel model name selecting the dependency-free hashing embedder.
+HASHING_MODEL_NAME = "hashing"
+
+DEFAULT_BATCH_SIZE = 256
+
+# Unicode-aware word tokenizer: ``\w+`` under ``re.UNICODE`` keeps Arabic letters
+# as well as Latin/digits, so both matn_ar and matn_en contribute tokens.
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+class Embedder(Protocol):
+    """A text → fixed-dimension vector encoder.
+
+    Implementations must be deterministic for a given text and return vectors of
+    length :attr:`dim`. ``embed`` takes a batch so model-backed encoders can
+    amortise per-call overhead.
+    """
+
+    @property
+    def dim(self) -> int:
+        """Dimension of every returned vector."""
+        ...
+
+    @property
+    def model_name(self) -> str:
+        """Human-readable identifier recorded with the load result."""
+        ...
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Encode ``texts`` into a list of ``dim``-length float vectors."""
+        ...
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase, Unicode-aware word tokens (Arabic + Latin + digits)."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+class HashingEmbedder:
+    """Deterministic, dependency-free hashing embedder (the CI/sandbox default).
+
+    Each token is hashed to a bucket index and a sign via a stable digest
+    (``blake2b``), accumulated into a fixed-width vector, then L2-normalised so
+    cosine distance (pgvector ``<=>``) ranks by token overlap. No external
+    dependency, no network, identical output across runs and machines.
+    """
+
+    def __init__(self, dim: int = EMBEDDING_DIM) -> None:
+        if dim <= 0:
+            raise ValueError(f"dim must be positive, got {dim}")
+        self._dim = dim
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return f"{HASHING_MODEL_NAME}-{self._dim}"
+
+    def _embed_one(self, text: str) -> list[float]:
+        vec = [0.0] * self._dim
+        for token in _tokenize(text):
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            bucket = int.from_bytes(digest[:4], "big") % self._dim
+            sign = 1.0 if digest[4] & 1 else -1.0
+            vec[bucket] += sign
+        norm = math.sqrt(sum(component * component for component in vec))
+        if norm > 0.0:
+            vec = [component / norm for component in vec]
+        return vec
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed_one(text) for text in texts]
+
+
+class SentenceTransformerEmbedder:
+    """Model-backed embedder for production (lazy ``sentence_transformers`` import).
+
+    Selected only when ``EMBEDDING_MODEL`` names a real model and the optional
+    ``sentence-transformers`` package is installed (the staging/production cluster,
+    P5W4). Kept out of the default path so CI and the sandbox never need ``torch``.
+    """
+
+    def __init__(self, model_name: str, *, expected_dim: int = EMBEDDING_DIM) -> None:
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:  # pragma: no cover - exercised only on the cluster
+            raise RuntimeError(
+                "sentence-transformers is not installed; install the optional ML "
+                "extras or set EMBEDDING_MODEL=hashing for the dependency-free encoder."
+            ) from exc
+
+        self._model_name = model_name
+        self._model = SentenceTransformer(model_name)
+        reported_dim = int(self._model.get_sentence_embedding_dimension())
+        if reported_dim != expected_dim:
+            raise ValueError(
+                f"model {model_name!r} produces dim={reported_dim}, but the "
+                f"hadith_embeddings column is vector({expected_dim}). Set "
+                f"EMBEDDING_DIM to match or pick a {expected_dim}-dim model."
+            )
+        self._dim = reported_dim
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def embed(self, texts: list[str]) -> list[list[float]]:  # pragma: no cover - cluster only
+        vectors = self._model.encode(texts, normalize_embeddings=True, convert_to_numpy=False)
+        return [[float(component) for component in vector] for vector in vectors]
+
+
+@lru_cache(maxsize=4)
+def get_embedder(model_name: str | None = None) -> Embedder:
+    """Return the configured embedder (cached so a model loads at most once).
+
+    Resolution order: explicit ``model_name`` arg → ``EMBEDDING_MODEL`` setting →
+    the dependency-free :class:`HashingEmbedder`. The cache means a heavy
+    model-backed embedder is constructed once per process and reused by both the
+    loader and the ``/search/semantic`` request path.
+    """
+    name = model_name or _configured_model_name()
+    if name in (HASHING_MODEL_NAME, "", None):
+        return HashingEmbedder(EMBEDDING_DIM)
+    return SentenceTransformerEmbedder(name, expected_dim=EMBEDDING_DIM)
+
+
+def _configured_model_name() -> str:
+    """Read ``EMBEDDING_MODEL`` off settings, defaulting to the hashing sentinel."""
+    return getattr(get_settings(), "embedding_model", HASHING_MODEL_NAME)
+
+
+def to_pgvector_literal(vector: list[float]) -> str:
+    """Render a vector as a pgvector text literal, e.g. ``[0.1,-0.2,0.3]``.
+
+    Passed as a bound parameter cast with ``%s::vector`` so the value is never
+    string-interpolated into SQL.
+    """
+    return "[" + ",".join(repr(component) for component in vector) + "]"
+
+
+def embedding_text(matn_ar: str | None, matn_en: str | None) -> str:
+    """Pick the text to embed for a hadith.
+
+    Prefers the English matn (the semantic model's stronger language and the
+    endpoint's display snippet), falling back to the Arabic matn. Returns an
+    empty string when neither is present so the caller can skip it.
+    """
+    return (matn_en or matn_ar or "").strip()
+
+
+_FETCH_HADITHS_QUERY = """
+MATCH (h:Hadith)
+RETURN h.id AS id, h.matn_ar AS matn_ar, h.matn_en AS matn_en
+"""
+
+
+def fetch_hadiths_from_neo4j(
+    neo4j: Neo4jClient, *, limit: int | None = None
+) -> list[dict[str, str | None]]:
+    """Read ``(id, matn_ar, matn_en)`` for every Hadith node (source of truth)."""
+    query = _FETCH_HADITHS_QUERY
+    params: dict[str, int] = {}
+    if limit is not None:
+        query = query + "\nLIMIT $limit"
+        params["limit"] = limit
+    return neo4j.execute_read(query, params or None)
+
+
+def ensure_embedding_schema(pg: PgClient, dim: int = EMBEDDING_DIM) -> None:
+    """Create the schema, ``vector`` extension, and embedding tables (idempotent).
+
+    ``dim`` is interpolated into the ``vector(N)`` type (a type, not a value, so it
+    cannot be a bound parameter); it is validated as a positive int first so the
+    interpolation is injection-safe.
+    """
+    if not isinstance(dim, int) or dim <= 0:
+        raise ValueError(f"dim must be a positive int, got {dim!r}")
+    pg.execute("CREATE SCHEMA IF NOT EXISTS isnad_graph")
+    pg.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    pg.execute(
+        """
+        CREATE TABLE IF NOT EXISTS isnad_graph.hadiths (
+            id      text PRIMARY KEY,
+            matn_ar text,
+            matn_en text
+        )
+        """
+    )
+    pg.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS isnad_graph.hadith_embeddings (
+            hadith_id text PRIMARY KEY
+                REFERENCES isnad_graph.hadiths (id) ON DELETE CASCADE,
+            text      text,
+            embedding vector({dim})
+        )
+        """
+    )
+    # ivfflat cosine index — matches the ``<=>`` operator the endpoint uses.
+    pg.execute(
+        """
+        CREATE INDEX IF NOT EXISTS hadith_embeddings_embedding_idx
+        ON isnad_graph.hadith_embeddings
+        USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)
+        """
+    )
+    log.info("embedding_schema_ensured", dim=dim)
+
+
+_UPSERT_HADITH_SQL = """
+INSERT INTO isnad_graph.hadiths (id, matn_ar, matn_en)
+VALUES (%s, %s, %s)
+ON CONFLICT (id) DO UPDATE
+SET matn_ar = EXCLUDED.matn_ar, matn_en = EXCLUDED.matn_en
+"""
+
+_UPSERT_EMBEDDING_SQL = """
+INSERT INTO isnad_graph.hadith_embeddings (hadith_id, text, embedding)
+VALUES (%s, %s, %s::vector)
+ON CONFLICT (hadith_id) DO UPDATE
+SET text = EXCLUDED.text, embedding = EXCLUDED.embedding
+"""
+
+
+def run_embedding_load(
+    neo4j: Neo4jClient,
+    pg: PgClient,
+    *,
+    embedder: Embedder | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    limit: int | None = None,
+) -> EmbeddingLoadResult:
+    """Compute hadith embeddings and load them into pgvector (idempotent).
+
+    Reads Hadith nodes from Neo4j (the source of truth for matn text), mirrors
+    ``(id, matn_ar, matn_en)`` into ``isnad_graph.hadiths`` and the computed
+    vector into ``isnad_graph.hadith_embeddings``. Every write is an upsert, so
+    re-running reconciles state rather than duplicating it. Hadiths with no matn
+    text at all are skipped (nothing to embed).
+    """
+    active = embedder or get_embedder()
+    ensure_embedding_schema(pg, active.dim)
+
+    rows = fetch_hadiths_from_neo4j(neo4j, limit=limit)
+
+    hadiths_loaded = 0
+    embeddings_loaded = 0
+    skipped_empty = 0
+
+    for start in range(0, len(rows), batch_size):
+        chunk = rows[start : start + batch_size]
+        hadith_params: list[tuple[object, ...]] = []
+        texts: list[str] = []
+        embed_meta: list[tuple[str, str]] = []  # (hadith_id, source_text)
+
+        for row in chunk:
+            hadith_id = row["id"]
+            if hadith_id is None:
+                skipped_empty += 1
+                continue
+            text = embedding_text(row.get("matn_ar"), row.get("matn_en"))
+            hadith_params.append((hadith_id, row.get("matn_ar"), row.get("matn_en")))
+            if not text:
+                skipped_empty += 1
+                continue
+            texts.append(text)
+            embed_meta.append((hadith_id, text))
+
+        if hadith_params:
+            pg.execute_many(_UPSERT_HADITH_SQL, hadith_params)
+            hadiths_loaded += len(hadith_params)
+
+        if texts:
+            vectors = active.embed(texts)
+            embedding_params = [
+                (hadith_id, source_text, to_pgvector_literal(vector))
+                for (hadith_id, source_text), vector in zip(embed_meta, vectors, strict=True)
+            ]
+            pg.execute_many(_UPSERT_EMBEDDING_SQL, embedding_params)
+            embeddings_loaded += len(embedding_params)
+
+    result = EmbeddingLoadResult(
+        hadiths_loaded=hadiths_loaded,
+        embeddings_loaded=embeddings_loaded,
+        skipped_empty=skipped_empty,
+        model_name=active.model_name,
+        dim=active.dim,
+    )
+    log.info(
+        "embedding_load_complete",
+        hadiths_seen=len(rows),
+        hadiths_loaded=hadiths_loaded,
+        embeddings_loaded=embeddings_loaded,
+        skipped_empty=skipped_empty,
+        model_name=active.model_name,
+        dim=active.dim,
+    )
+    return result

--- a/src/models/enrich.py
+++ b/src/models/enrich.py
@@ -2,7 +2,25 @@
 
 from pydantic import BaseModel, ConfigDict
 
-__all__ = ["EnrichSummary", "HistoricalResult", "MetricsResult", "TopicResult"]
+__all__ = [
+    "EmbeddingLoadResult",
+    "EnrichSummary",
+    "HistoricalResult",
+    "MetricsResult",
+    "TopicResult",
+]
+
+
+class EmbeddingLoadResult(BaseModel):
+    """Result of the semantic-search embedding load (hadith vectors → pgvector)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    hadiths_loaded: int
+    embeddings_loaded: int
+    skipped_empty: int
+    model_name: str
+    dim: int
 
 
 class MetricsResult(BaseModel):

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -216,6 +216,44 @@ def test_semantic_search_returns_results_when_pg_available(client: TestClient, a
     del app.dependency_overrides[get_pg]
 
 
+def test_semantic_search_embeds_query_at_runtime(client: TestClient, app: object) -> None:
+    """The query is embedded into a pgvector literal, not matched by exact text.
+
+    Regression for #1049: the old implementation looked the query up by
+    ``WHERE text = %s``, so an arbitrary query returned nothing even with
+    embeddings loaded. The endpoint must now pass an embedded *vector* to the
+    ``<=>`` operator.
+    """
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = [
+        [{"id": "had-1", "matn_ar": "نص", "matn_en": "ranked hadith", "score": 0.7}],
+        [{"total": 12}],
+    ]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=prayer in congregation&limit=5")
+    assert resp.status_code == 200
+
+    # First pg.execute is the ranked data query; its first bound param must be the
+    # embedded query vector (a pgvector literal), never the raw query string.
+    data_sql, data_params = mock_pg.execute.call_args_list[0].args
+    vector_literal = data_params[0]
+    assert vector_literal.startswith("[") and vector_literal.endswith("]")
+    assert "prayer in congregation" not in str(data_params)
+    # The cast `%s::vector` keeps the literal a bound parameter, never inline SQL.
+    assert "%s::vector" in data_sql
+    assert data_params[-1] == 5  # limit threaded through
+
+    del app.dependency_overrides[get_pg]
+
+
 def test_semantic_search_limit_over_cap_is_422(client: TestClient, app: object) -> None:
     """semantic limit above its cap (50) is rejected with 422 — the frontend
     results page must stay within this cap (#1025).

--- a/tests/test_enrich/test_embeddings.py
+++ b/tests/test_enrich/test_embeddings.py
@@ -1,0 +1,235 @@
+"""Unit tests for semantic-search embedding enrichment (#1049).
+
+All tests run without a live DB — the loader is exercised against mock Neo4j /
+Postgres clients, and the embedder + helpers are pure functions. The full
+staging embedding load is a cluster-internal step (P5W4); these tests prove the
+mechanism, the idempotent upserts, and that the vector path is genuinely
+exercised (≥1 embedded hadith) rather than mocked away.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.enrich.embeddings import (
+    EMBEDDING_DIM,
+    HashingEmbedder,
+    embedding_text,
+    ensure_embedding_schema,
+    fetch_hadiths_from_neo4j,
+    get_embedder,
+    run_embedding_load,
+    to_pgvector_literal,
+)
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+# --- HashingEmbedder ----------------------------------------------------------
+
+
+def test_hashing_embedder_dim_and_shape() -> None:
+    emb = HashingEmbedder()
+    vectors = emb.embed(["hello world", "another hadith text"])
+    assert emb.dim == EMBEDDING_DIM
+    assert len(vectors) == 2
+    assert all(len(v) == EMBEDDING_DIM for v in vectors)
+
+
+def test_hashing_embedder_is_deterministic() -> None:
+    """Same text → identical vector across calls and instances (reproducible)."""
+    a = HashingEmbedder().embed(["the prophet said"])[0]
+    b = HashingEmbedder().embed(["the prophet said"])[0]
+    assert a == b
+
+
+def test_hashing_embedder_l2_normalised() -> None:
+    [vec] = HashingEmbedder().embed(["prayer and fasting"])
+    norm = math.sqrt(sum(x * x for x in vec))
+    assert norm == pytest.approx(1.0)
+
+
+def test_hashing_embedder_self_similarity_is_one() -> None:
+    [vec] = HashingEmbedder().embed(["zakat charity"])
+    assert _cosine(vec, vec) == pytest.approx(1.0)
+
+
+def test_hashing_embedder_overlap_ranks_above_disjoint() -> None:
+    """Token overlap yields higher cosine than a disjoint sentence — real signal."""
+    emb = HashingEmbedder()
+    query = emb.embed(["prayer is a pillar of faith"])[0]
+    overlap = emb.embed(["prayer is obligatory in faith"])[0]
+    disjoint = emb.embed(["zzz qqq xxx vvv"])[0]
+    assert _cosine(query, overlap) > _cosine(query, disjoint)
+
+
+def test_hashing_embedder_handles_arabic_tokens() -> None:
+    [vec] = HashingEmbedder().embed(["إنما الأعمال بالنيات"])
+    assert math.sqrt(sum(x * x for x in vec)) == pytest.approx(1.0)
+
+
+def test_hashing_embedder_empty_text_is_zero_vector() -> None:
+    [vec] = HashingEmbedder().embed([""])
+    assert vec == [0.0] * EMBEDDING_DIM
+
+
+def test_hashing_embedder_rejects_bad_dim() -> None:
+    with pytest.raises(ValueError):
+        HashingEmbedder(dim=0)
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+def test_to_pgvector_literal_format() -> None:
+    assert to_pgvector_literal([1.0, -0.5, 0.25]) == "[1.0,-0.5,0.25]"
+
+
+def test_embedding_text_prefers_english() -> None:
+    assert embedding_text("نص عربي", "english matn") == "english matn"
+
+
+def test_embedding_text_falls_back_to_arabic() -> None:
+    assert embedding_text("نص عربي", None) == "نص عربي"
+
+
+def test_embedding_text_empty_when_neither() -> None:
+    assert embedding_text(None, "   ") == ""
+
+
+def test_get_embedder_defaults_to_hashing() -> None:
+    get_embedder.cache_clear()
+    emb = get_embedder("hashing")
+    assert isinstance(emb, HashingEmbedder)
+    assert emb.dim == EMBEDDING_DIM
+
+
+# --- ensure_embedding_schema --------------------------------------------------
+
+
+def test_ensure_embedding_schema_creates_tables_with_dim() -> None:
+    pg = MagicMock()
+    ensure_embedding_schema(pg, EMBEDDING_DIM)
+    executed = " ".join(call.args[0] for call in pg.execute.call_args_list)
+    assert "CREATE EXTENSION IF NOT EXISTS vector" in executed
+    assert "isnad_graph.hadiths" in executed
+    assert "isnad_graph.hadith_embeddings" in executed
+    assert f"vector({EMBEDDING_DIM})" in executed
+    assert "ivfflat" in executed
+
+
+def test_ensure_embedding_schema_rejects_non_int_dim() -> None:
+    pg = MagicMock()
+    with pytest.raises(ValueError):
+        ensure_embedding_schema(pg, "384")  # type: ignore[arg-type]
+
+
+# --- fetch_hadiths_from_neo4j -------------------------------------------------
+
+
+def test_fetch_hadiths_applies_limit() -> None:
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = [{"id": "h1", "matn_ar": "a", "matn_en": "b"}]
+    fetch_hadiths_from_neo4j(neo4j, limit=5)
+    query, params = neo4j.execute_read.call_args.args
+    assert "LIMIT $limit" in query
+    assert params == {"limit": 5}
+
+
+def test_fetch_hadiths_no_limit_passes_none() -> None:
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = []
+    fetch_hadiths_from_neo4j(neo4j)
+    query, params = neo4j.execute_read.call_args.args
+    assert "LIMIT" not in query
+    assert params is None
+
+
+# --- run_embedding_load (the mechanism, against mock clients) -----------------
+
+
+def test_run_embedding_load_embeds_and_upserts() -> None:
+    """End-to-end mechanism: hadiths mirrored + ≥1 real embedding upserted."""
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = [
+        {"id": "h1", "matn_ar": "نص1", "matn_en": "first hadith"},
+        {"id": "h2", "matn_ar": "نص2", "matn_en": "second hadith"},
+    ]
+    pg = MagicMock()
+
+    result = run_embedding_load(neo4j, pg, embedder=HashingEmbedder(), batch_size=10)
+
+    assert result.hadiths_loaded == 2
+    assert result.embeddings_loaded == 2
+    assert result.skipped_empty == 0
+    assert result.dim == EMBEDDING_DIM
+    assert result.model_name.startswith("hashing")
+
+    # Two execute_many calls: hadiths upsert + embeddings upsert.
+    upsert_sqls = [call.args[0] for call in pg.execute_many.call_args_list]
+    assert any("INSERT INTO isnad_graph.hadiths" in sql for sql in upsert_sqls)
+    assert any("INSERT INTO isnad_graph.hadith_embeddings" in sql for sql in upsert_sqls)
+    # Every upsert is ON CONFLICT — re-running is idempotent.
+    assert all("ON CONFLICT" in sql for sql in upsert_sqls)
+
+    # The embedding rows carry a real pgvector literal (the vector path, not a mock).
+    embedding_call = next(
+        call for call in pg.execute_many.call_args_list if "hadith_embeddings" in call.args[0]
+    )
+    embedding_rows = embedding_call.args[1]
+    assert len(embedding_rows) == 2
+    hadith_id, source_text, vector_literal = embedding_rows[0]
+    assert hadith_id == "h1"
+    assert source_text == "first hadith"
+    assert vector_literal.startswith("[") and vector_literal.endswith("]")
+
+
+def test_run_embedding_load_skips_textless_hadiths() -> None:
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = [
+        {"id": "h1", "matn_ar": "نص", "matn_en": "has text"},
+        {"id": "h2", "matn_ar": None, "matn_en": None},
+    ]
+    pg = MagicMock()
+
+    result = run_embedding_load(neo4j, pg, embedder=HashingEmbedder())
+
+    # Both hadiths mirrored to the metadata table; only the one with text embedded.
+    assert result.hadiths_loaded == 2
+    assert result.embeddings_loaded == 1
+    assert result.skipped_empty == 1
+
+
+def test_run_embedding_load_empty_corpus_is_noop() -> None:
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = []
+    pg = MagicMock()
+
+    result = run_embedding_load(neo4j, pg, embedder=HashingEmbedder())
+
+    assert result.hadiths_loaded == 0
+    assert result.embeddings_loaded == 0
+    pg.execute_many.assert_not_called()
+
+
+def test_run_embedding_load_batches() -> None:
+    """Multiple batches each issue their own upserts (batch_size respected)."""
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = [
+        {"id": f"h{i}", "matn_ar": f"ar{i}", "matn_en": f"en{i}"} for i in range(5)
+    ]
+    pg = MagicMock()
+
+    result = run_embedding_load(neo4j, pg, embedder=HashingEmbedder(), batch_size=2)
+
+    assert result.embeddings_loaded == 5
+    # 3 batches (2 + 2 + 1) × 2 upserts each = 6 execute_many calls.
+    assert pg.execute_many.call_count == 6


### PR DESCRIPTION
## Summary

Closes #1049. Semantic search returned nothing because **0 / 34,028 hadiths had embeddings** — the vectorization/load step never ran, so the pgvector cosine match had no data. This PR adds the reproducible mechanism to compute and load embeddings, and fixes a second latent bug in the endpoint.

## Storage decision

**pgvector in Postgres** (not `h.embedding` on Neo4j). The `/search/semantic` endpoint already targets `isnad_graph.hadith_embeddings` / `isnad_graph.hadiths`, and `PgClient.ensure_schema()` already creates the `vector` extension — both the loader and the endpoint now align on Postgres.

## Two bugs fixed

1. **Data gap (the reported symptom)** — no embeddings were ever computed/loaded. New `src/enrich/embeddings.py` reads Hadith nodes from Neo4j (source of truth for matn), computes vectors, and idempotently upserts `isnad_graph.hadiths` + `isnad_graph.hadith_embeddings`.
2. **Latent endpoint bug** — the old query looked the search string up by *exact text* (`WHERE text = %s`), so an arbitrary query returned nothing even once embeddings existed. The endpoint now **embeds the query at request time** and cosine-ranks against that vector (`%s::vector`).

## Embedder design (why pluggable + dependency-free default)

The repo carries **no heavy ML runtime** (no `torch`/`sentence-transformers`; `make setup` is a bare `uv sync`) and runs on Python 3.14, for which those wheels are not yet published. A hard ML dependency would break setup/CI. So the embedder is a small `Embedder` protocol with:

- **`HashingEmbedder`** — deterministic, pure-Python, zero-dependency. The CI/sandbox/dev default; L2-normalised hashed bag-of-token vectors, so cosine carries real lexical signal and the vector path is genuinely exercised.
- **`SentenceTransformerEmbedder`** — lazy `sentence_transformers` import, selected via `EMBEDDING_MODEL` only on the cluster (P5W4 production load), where a 384-dim multilingual model gives true semantic similarity over Arabic + English matn.

`EMBEDDING_DIM = 384` matches the multilingual-MiniLM family, so swapping the production model needs an env var, not a column migration.

## Reproducible run step

- `isnad embed-hadiths [--batch-size N] [--limit N]`
- `make embed-hadiths`

Production / staging load (cluster-internal, P5W4): `EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 isnad embed-hadiths`

## Tests

- `tests/test_enrich/test_embeddings.py` — **21 tests, no DB**: embedder determinism/normalisation/Arabic handling/overlap-ranking, schema DDL, the idempotent loader against mock Neo4j+PG (with ≥1 embedded hadith so the vector path is exercised — fixture-masks-bug remediation), batching, skip-textless.
- `tests/test_api/test_search.py::test_semantic_search_embeds_query_at_runtime` — asserts the query is embedded into a pgvector literal (not matched by text) and passed via `%s::vector`.

### Test evidence
- `ruff check` + `ruff format --check`: clean. `mypy --strict`: clean (51 files). Embedding unit tests: **21 passed in 0.43s**.
- API endpoint tests hang **in the sandbox** (request-time Redis `ping()` in `RateLimitMiddleware`, no backend) — confirmed the **identical hang on the unmodified base branch** (`test_semantic_search_returns_results_when_pg_available` and `test_health` both time out at EXIT=124 without my changes), so it is environmental and pre-existing. These run in CI.

## Out of scope / follow-up
- The actual bulk embedding compute + load onto staging is the cluster-internal **P5W4 production-load step** (heavy; cannot run from the sandbox, no live DB). This PR delivers the mechanism + fixture tests.

## Reviewers
@ Farhan Malik + Marisol Vega-Cruz (2-reviewer rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
