### PR TITLE
fix(frontend): default graph subgraph on load + width-constrain session modal (ig#1031, ig#1027)

### DIFF
--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -12,9 +12,23 @@ import { communityColor } from '../components/ForceGraph'
 import type { GraphNode, GraphEdge, Narrator, ChainSummary } from '../types/api'
 
 const NODE_LIMIT = 5000
-const SUGGESTED_NARRATORS = ['Abu Hurayra', 'al-Zuhri', 'Malik ibn Anas', 'Aisha bint Abi Bakr']
+
+// Number of narrators to fetch as default-graph seed candidates. We pick the
+// highest-degree narrator among them to render a non-empty landing subgraph and
+// surface the top few as one-click, ID-seeded suggestion chips (#1031). The
+// `/narrators` list endpoint orders by id (≈ uniform over the uuid5 id space),
+// so a generous sample reliably contains a well-connected hub to seed from.
+const SEED_CANDIDATE_LIMIT = 100
+const SUGGESTION_COUNT = 6
 
 type LayoutMode = 'force' | 'hierarchy' | 'radial'
+
+function narratorDegree(n: {
+  in_degree: number | null
+  out_degree: number | null
+}): number {
+  return (n.in_degree ?? 0) + (n.out_degree ?? 0)
+}
 
 export default function GraphExplorerPage() {
   // --- State ---
@@ -32,6 +46,9 @@ export default function GraphExplorerPage() {
   const [layoutMode, setLayoutMode] = useState<LayoutMode>('force')
   const containerRef = useRef<HTMLDivElement | null>(null)
   const searchRef = useRef<HTMLInputElement | null>(null)
+  // Guards the one-shot default-graph auto-seed so it never fights a user's own
+  // selection and never re-seeds after an explicit Reset (#1031).
+  const didAutoSeedRef = useRef(false)
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 })
 
   // --- Data queries ---
@@ -59,6 +76,24 @@ export default function GraphExplorerPage() {
     enabled: selectedNarratorId != null && detailOpen,
   })
 
+  // Default-graph seed candidates: a sample of real narrators used both to
+  // auto-seed a non-empty landing subgraph and to build one-click, ID-seeded
+  // suggestion chips (#1031). Degrades gracefully — if `/narrators` is
+  // unavailable the page falls back to the empty state with the search box.
+  const { data: seedData } = useQuery({
+    queryKey: ['graph-seed-narrators'],
+    queryFn: () => fetchNarrators(1, SEED_CANDIDATE_LIMIT),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Top narrators by degree — real, existing nodes (no name-search round-trip).
+  const suggestedNarrators = useMemo(() => {
+    const items = seedData?.items ?? []
+    return [...items]
+      .sort((a, b) => narratorDegree(b) - narratorDegree(a))
+      .slice(0, SUGGESTION_COUNT)
+  }, [seedData])
+
   // --- Merge network data (progressive subgraph loading) ---
   useEffect(() => {
     if (!networkData) return
@@ -82,6 +117,19 @@ export default function GraphExplorerPage() {
       return merged
     })
   }, [networkData])
+
+  // --- Default-graph auto-seed (#1031) ---
+  // On first load, seed the highest-degree narrator's ego network so `/graph` is
+  // never blank. Runs once: the ref is set when we seed AND on explicit Reset, so
+  // it neither overrides a user selection nor re-seeds a deliberately-cleared canvas.
+  useEffect(() => {
+    if (didAutoSeedRef.current) return
+    if (selectedNarratorId != null) return
+    const top = suggestedNarrators[0]
+    if (!top) return
+    didAutoSeedRef.current = true
+    setSelectedNarratorId(top.id)
+  }, [suggestedNarrators, selectedNarratorId])
 
   // --- Resize observer ---
   useEffect(() => {
@@ -154,6 +202,9 @@ export default function GraphExplorerPage() {
   }, [])
 
   const handleReset = useCallback(() => {
+    // Explicit Reset means "blank canvas" — suppress the default auto-seed so it
+    // doesn't immediately repopulate the graph the user just cleared (#1031).
+    didAutoSeedRef.current = true
     setAllNodes([])
     setAllEdges([])
     setSelectedNarratorId(null)
@@ -173,10 +224,14 @@ export default function GraphExplorerPage() {
     [],
   )
 
-  const handleSuggestedSearch = useCallback((name: string) => {
-    setSearchInput(name)
-    setSearchOpen(true)
-    searchRef.current?.focus()
+  // One-click, ID-seeded suggestion chip: focus the graph on a real narrator
+  // directly (no name-search round-trip). Detail panel stays closed for a clean
+  // landing view (#1031).
+  const handleSelectSuggested = useCallback((narratorId: string) => {
+    didAutoSeedRef.current = true
+    setSelectedNarratorId(narratorId)
+    setSearchInput('')
+    setSearchOpen(false)
   }, [])
 
   const overLimit = allNodes.length > NODE_LIMIT
@@ -379,24 +434,26 @@ export default function GraphExplorerPage() {
               <div className="empty-state-body">
                 Search for a narrator to explore the transmission network.
               </div>
-              <p className="mt-4" style={{ fontSize: 'var(--text-sm)' }}>
-                Try:{' '}
-                {SUGGESTED_NARRATORS.map((name, i) => (
-                  <span key={name}>
-                    {i > 0 && ', '}
-                    <button
-                      onClick={() => handleSuggestedSearch(name)}
-                      className="link-primary cursor-pointer border-none p-0 underline"
-                      style={{
-                        background: 'none',
-                        font: 'inherit',
-                      }}
-                    >
-                      {name}
-                    </button>
-                  </span>
-                ))}
-              </p>
+              {suggestedNarrators.length > 0 && (
+                <p className="mt-4" style={{ fontSize: 'var(--text-sm)' }}>
+                  Try:{' '}
+                  {suggestedNarrators.map((n, i) => (
+                    <span key={n.id}>
+                      {i > 0 && ', '}
+                      <button
+                        onClick={() => handleSelectSuggested(n.id)}
+                        className="link-primary cursor-pointer border-none p-0 underline"
+                        style={{
+                          background: 'none',
+                          font: 'inherit',
+                        }}
+                      >
+                        {n.name_en || n.name_ar}
+                      </button>
+                    </span>
+                  ))}
+                </p>
+              )}
             </div>
           )}
 

--- a/frontend/src/pages/__tests__/GraphExplorerPage.test.tsx
+++ b/frontend/src/pages/__tests__/GraphExplorerPage.test.tsx
@@ -19,8 +19,15 @@
  * actual canvas drawing of D3 belong in Playwright (golden path / accessibility),
  * not Vitest — see frontend/tests/e2e/graph.spec.ts.
  *
- * The narrator-search dropdown, depth/layout toggles, reset behavior, suggested-
- * narrator quick-links, and detail-panel open/close are all covered here.
+ * `fetchNarrators` is called from two places with different signatures: the
+ * default-graph SEED query (`fetchNarrators(1, 100)` — no `q`) and the search-box
+ * query (`fetchNarrators(1, 10, q)` — with `q`). The mock below is argument-aware
+ * so the two are controlled independently via the module-scoped `seedItems` /
+ * `searchItems` arrays — seed defaults to empty so search-focused tests are not
+ * perturbed by the auto-seed (#1031).
+ *
+ * The narrator-search dropdown, depth/layout toggles, reset behavior, ID-seeded
+ * suggestion chips, default auto-seed, and detail-panel open/close are all covered here.
  */
 import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -116,6 +123,14 @@ function makeNode(overrides: Partial<GraphNode> = {}): GraphNode {
   }
 }
 
+function page(items: Narrator[]): PaginatedResponse<Narrator> {
+  return { items, total: items.length, page: 1, limit: Math.max(items.length, 10) }
+}
+
+// Independently-controlled fixtures for the two fetchNarrators call sites.
+let seedItems: Narrator[] = []
+let searchItems: Narrator[] = []
+
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -131,6 +146,12 @@ function renderPage() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  seedItems = []
+  searchItems = []
+  // Argument-aware: the seed query passes no `q`; the search query passes one.
+  vi.mocked(fetchNarrators).mockImplementation((_page, _limit, q) =>
+    Promise.resolve(page(q ? searchItems : seedItems)),
+  )
   // ResizeObserver isn't in jsdom — minimal stub so the resize-effect doesn't throw.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(globalThis as any).ResizeObserver = class {
@@ -140,22 +161,18 @@ beforeEach(() => {
   }
 })
 
-describe("GraphExplorerPage — empty state", () => {
-  it("renders the empty-state message and suggested narrators by default", () => {
+describe("GraphExplorerPage — empty state (no seed data)", () => {
+  it("renders the empty-state message when there is no seed data", () => {
     renderPage()
     expect(screen.getByText("No graph data")).toBeInTheDocument()
     expect(
       screen.getByText(/Search for a narrator to explore/i),
     ).toBeInTheDocument()
-    // Suggested narrators rendered as buttons
-    expect(screen.getByRole("button", { name: "Abu Hurayra" })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "al-Zuhri" })).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: "Malik ibn Anas" }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: "Aisha bint Abi Bakr" }),
-    ).toBeInTheDocument()
+  })
+
+  it("renders no suggestion chips when seed data is unavailable", () => {
+    renderPage()
+    expect(screen.queryByText(/^Try:/)).not.toBeInTheDocument()
   })
 
   it("renders 0 nodes / 0 edges in the status bar by default", () => {
@@ -166,6 +183,85 @@ describe("GraphExplorerPage — empty state", () => {
   it("does NOT render the ForceGraph stub when there are no nodes", () => {
     renderPage()
     expect(screen.queryByTestId("force-graph-stub")).not.toBeInTheDocument()
+  })
+})
+
+describe("GraphExplorerPage — default auto-seed (#1031)", () => {
+  it("seeds the highest-degree narrator's network on load with no user interaction", async () => {
+    // Two candidates; the second is the higher-degree hub and must be chosen.
+    seedItems = [
+      makeNarrator({ id: "low", name_en: "Low Degree", in_degree: 1, out_degree: 1 }),
+      makeNarrator({ id: "hub", name_en: "Big Hub", in_degree: 100, out_degree: 200 }),
+    ]
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "hub",
+      nodes: [makeNode({ id: "hub" }), makeNode({ id: "n2", label: "n2" })],
+      edges: [
+        { source: "hub", target: "n2", relationship: "TRANSMITTED_TO", weight: 1 },
+      ],
+      teachers: 1,
+      students: 1,
+    })
+
+    renderPage()
+
+    const stub = await screen.findByTestId("force-graph-stub")
+    expect(stub).toHaveAttribute("data-selected", "hub")
+    expect(stub).toHaveAttribute("data-node-count", "2")
+    // The ego-network query was issued for the highest-degree narrator.
+    expect(fetchGraphNetwork).toHaveBeenCalledWith("hub", 1)
+  })
+})
+
+describe("GraphExplorerPage — ID-seeded suggestion chips (#1031)", () => {
+  it("renders one-click chips from real seed narrators", async () => {
+    seedItems = [
+      makeNarrator({ id: "low", name_en: "Low Degree", in_degree: 1, out_degree: 0 }),
+      makeNarrator({ id: "hub", name_en: "Big Hub", in_degree: 100, out_degree: 50 }),
+    ]
+    // Seed network is empty so the empty state (and its chips) stays rendered.
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "hub",
+      nodes: [],
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+
+    renderPage()
+
+    const hubChip = await screen.findByRole("button", { name: "Big Hub" })
+    const lowChip = screen.getByRole("button", { name: "Low Degree" })
+    expect(hubChip).toBeInTheDocument()
+    expect(lowChip).toBeInTheDocument()
+  })
+
+  it("selects the narrator by id in a single click (no name-search round-trip)", async () => {
+    const user = userEvent.setup()
+    seedItems = [
+      makeNarrator({ id: "hub", name_en: "Big Hub", in_degree: 100, out_degree: 50 }),
+      makeNarrator({ id: "other", name_en: "Other Narrator", in_degree: 5, out_degree: 5 }),
+    ]
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "hub",
+      nodes: [],
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+
+    renderPage()
+
+    const otherChip = await screen.findByRole("button", { name: "Other Narrator" })
+    await user.click(otherChip)
+
+    // One click issues the network query for that narrator's id directly.
+    await waitFor(() => {
+      expect(fetchGraphNetwork).toHaveBeenCalledWith("other", 1)
+    })
+    // The search box was not used to resolve the chip.
+    const input = screen.getByLabelText("Search for a narrator") as HTMLInputElement
+    expect(input.value).toBe("")
   })
 })
 
@@ -211,56 +307,23 @@ describe("GraphExplorerPage — toolbar controls", () => {
 
   it("opens the search dropdown when typing", async () => {
     const user = userEvent.setup()
-    // Use a name that's NOT in the suggested-narrator list, so the dropdown
-    // match is unambiguous and the suggested-list duplicate doesn't confuse
-    // text queries.
-    const results: PaginatedResponse<Narrator> = {
-      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    }
-    vi.mocked(fetchNarrators).mockResolvedValue(results)
+    // Use a name that's NOT a seed chip, so the dropdown match is unambiguous.
+    searchItems = [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })]
 
     renderPage()
     const input = screen.getByLabelText("Search for a narrator")
     await user.type(input, "Sufy")
     await waitFor(() => {
-      expect(fetchNarrators).toHaveBeenCalled()
+      expect(fetchNarrators).toHaveBeenCalledWith(1, 10, "Sufy")
     })
     expect(await screen.findByText("Sufyan al-Thawri")).toBeInTheDocument()
-  })
-})
-
-describe("GraphExplorerPage — suggested narrator quick-search", () => {
-  it("focuses the search input and pre-fills it when a suggested narrator is clicked", async () => {
-    const user = userEvent.setup()
-    vi.mocked(fetchNarrators).mockResolvedValue({
-      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    })
-
-    renderPage()
-    await user.click(screen.getByRole("button", { name: "al-Zuhri" }))
-
-    const input = screen.getByLabelText(
-      "Search for a narrator",
-    ) as HTMLInputElement
-    expect(input.value).toBe("al-Zuhri")
   })
 })
 
 describe("GraphExplorerPage — network data integration", () => {
   it("renders the ForceGraph stub when network data is loaded via search selection", async () => {
     const user = userEvent.setup()
-    vi.mocked(fetchNarrators).mockResolvedValue({
-      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    })
+    searchItems = [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })]
 
     const network: NarratorNetworkResponse = {
       narrator_id: "n1",
@@ -297,12 +360,7 @@ describe("GraphExplorerPage — network data integration", () => {
 
   it("opens the detail panel and renders narrator metadata after selection", async () => {
     const user = userEvent.setup()
-    vi.mocked(fetchNarrators).mockResolvedValue({
-      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    })
+    searchItems = [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })]
     vi.mocked(fetchGraphNetwork).mockResolvedValue({
       narrator_id: "n1",
       nodes: [makeNode({ id: "n1" })],
@@ -344,12 +402,7 @@ describe("GraphExplorerPage — network data integration", () => {
 
   it("closes the detail panel when the close button is clicked", async () => {
     const user = userEvent.setup()
-    vi.mocked(fetchNarrators).mockResolvedValue({
-      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    })
+    searchItems = [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })]
     vi.mocked(fetchGraphNetwork).mockResolvedValue({
       narrator_id: "n1",
       nodes: [makeNode({ id: "n1" })],
@@ -383,12 +436,7 @@ describe("GraphExplorerPage — network data integration", () => {
 
   it("resets all state when Reset is clicked", async () => {
     const user = userEvent.setup()
-    vi.mocked(fetchNarrators).mockResolvedValue({
-      items: [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    })
+    searchItems = [makeNarrator({ id: "n1", name_en: "Sufyan al-Thawri" })]
     vi.mocked(fetchGraphNetwork).mockResolvedValue({
       narrator_id: "n1",
       nodes: [makeNode({ id: "n1" })],
@@ -421,17 +469,45 @@ describe("GraphExplorerPage — network data integration", () => {
     expect(screen.getByText("No graph data")).toBeInTheDocument()
     expect(screen.getByText("0 nodes, 0 edges")).toBeInTheDocument()
   })
+
+  it("does not re-seed the default graph after an explicit Reset", async () => {
+    const user = userEvent.setup()
+    // Seed data is present — but a Reset must leave the canvas blank, not
+    // immediately repopulate it with the default subgraph (#1031).
+    seedItems = [makeNarrator({ id: "hub", name_en: "Big Hub", in_degree: 100, out_degree: 50 })]
+    vi.mocked(fetchGraphNetwork).mockResolvedValue({
+      narrator_id: "hub",
+      nodes: [makeNode({ id: "hub" })],
+      edges: [],
+      teachers: 0,
+      students: 0,
+    })
+    vi.mocked(fetchNarrator).mockResolvedValue(makeNarrator({ id: "hub" }))
+    vi.mocked(fetchNarratorChains).mockResolvedValue({
+      narrator_id: "hub",
+      chains: [],
+      total: 0,
+    })
+
+    renderPage()
+    // Auto-seed renders the default graph first.
+    await screen.findByTestId("force-graph-stub")
+
+    await user.click(screen.getByRole("button", { name: "Reset" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("force-graph-stub")).not.toBeInTheDocument()
+    })
+    // Stays blank — the auto-seed effect must not fire again.
+    expect(screen.getByText("No graph data")).toBeInTheDocument()
+    expect(screen.getByText("0 nodes, 0 edges")).toBeInTheDocument()
+  })
 })
 
 describe("GraphExplorerPage — over-limit warning", () => {
   it("renders the over-limit banner when more than NODE_LIMIT nodes are loaded", async () => {
     const user = userEvent.setup()
-    vi.mocked(fetchNarrators).mockResolvedValue({
-      items: [makeNarrator({ id: "big", name_en: "Big Network" })],
-      total: 1,
-      page: 1,
-      limit: 10,
-    })
+    searchItems = [makeNarrator({ id: "big", name_en: "Big Network" })]
     // 5001 nodes — exceeds the page's NODE_LIMIT (5000)
     const bigNodes = Array.from({ length: 5001 }, (_, i) =>
       makeNode({ id: `n${i}` }),

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,6 +1,42 @@
 @import "tailwindcss";
 @import "@noorinalabs/design-system/styles.css";
 
+/* ============================================================
+ * DESIGN-SYSTEM COMPONENT UTILITIES → FORCE-GENERATED (#1027)
+ * ------------------------------------------------------------
+ * The design system ships its components as compiled React (dist JS) plus a
+ * token-only `styles.css` (`:root { --color-* }`, etc.) — it does NOT ship the
+ * Tailwind *utility* classes its components reference. Those class names live
+ * only inside the DS dist JS, which this app's Tailwind v4 content scan does
+ * not crawl (node_modules is not scanned by default, and scanning the minified
+ * bundle would pull in false-positive candidates and bloat the CSS).
+ *
+ * The practical effect: any DS-component utility that this app's own source
+ * never also uses produces ZERO rules. Common utilities (`bg-card`, `p-4`,
+ * `rounded-md`, `border`, …) happen to be used directly in app code so they
+ * generate; the Dialog's *positioning/sizing* utilities (`fixed`, `start-1/2`,
+ * `top-1/2`, `-translate-x-1/2`, `-translate-y-1/2`, `max-w-lg`, the overlay's
+ * `inset-0`/`bg-black/80`) appear nowhere in app source — so the modal rendered
+ * with no fixed positioning, no centering transform and no max-width, blowing
+ * out past the browser width (the session-expired modal bug, #1027).
+ *
+ * `@source inline(...)` is the Tailwind v4 mechanism to force-generate a known,
+ * explicit set of utilities regardless of content scanning. We list the full
+ * DS Dialog class contract (Overlay, Content, Close button, Header/Footer,
+ * Title/Description) so EVERY dialog in the app (session-expired modal,
+ * SearchPage filters, any future dialog) renders centered and width-constrained
+ * as the DS intends. Listing utilities the app already generates is harmless
+ * (Tailwind de-duplicates). This is the component-utility analogue of the
+ * `@theme inline` color-token bridge below (#1000). Keep this list in sync if
+ * the DS Dialog class set changes (the DS owning the utility CSS it references
+ * — e.g. shipping a compiled utilities layer — would let us drop this).
+ * ============================================================ */
+@source inline("fixed inset-0 z-50 bg-black/80");
+@source inline("start-1/2 top-1/2 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg rounded-lg");
+@source inline("absolute end-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-2 focus:outline-offset-2 focus:outline-ring disabled:pointer-events-none");
+@source inline("flex flex-col gap-y-1.5 text-center sm:text-start flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2");
+@source inline("text-lg font-semibold leading-none tracking-tight text-sm text-muted-foreground");
+
 /*
  * Isnad Graph — App-Specific Overrides
  * =====================================

--- a/frontend/tests/e2e/session-modal.spec.ts
+++ b/frontend/tests/e2e/session-modal.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Session-expired modal E2E — #1027
+ * ---------------------------------
+ * Regression test for the session-expired modal blowing out past the browser
+ * width. Root cause: the design-system Dialog's positioning/sizing utilities
+ * (`start-1/2`, `-translate-x/y-1/2`, `max-w-lg`, …) are referenced only inside
+ * the compiled DS bundle, which the app's Tailwind content scan does not crawl,
+ * so they produced no CSS and the modal rendered unconstrained. The fix
+ * force-generates that utility set via `@source inline(...)` in
+ * `src/styles/theme.css`.
+ *
+ * These assertions verify the *rendered* result (the only place the bug is
+ * observable): the dialog is width-constrained well below the viewport, is
+ * horizontally centered, and never introduces a horizontal page scrollbar — at
+ * both a narrow (mobile) and a wide (desktop) viewport.
+ *
+ * Like the other specs here, the backend is mocked at the route layer — only the
+ * built frontend on `baseURL` (vite preview) is required.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const authUser = {
+  id: 'test-user-001',
+  email: 'test@example.com',
+  name: 'Test User',
+  is_admin: false,
+  provider: 'email',
+  email_verified: true,
+  roles: ['reader'],
+}
+
+async function mockAuth(page: Page) {
+  // Identity endpoint — makes AuthProvider set `user`, which is the precondition
+  // for the session-expired event to surface the modal.
+  await page.route('**/api/v1/users/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(authUser),
+    }),
+  )
+  // Everything else returns empty 200 so unscoped queries don't hang.
+  await page.route('**/api/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+  await page.addInitScript(() => {
+    localStorage.setItem('access_token', 'mock-token')
+  })
+}
+
+// Surface the modal by emitting the same event the API clients fire on a
+// genuinely-expired session. Dispatched in a poll because the handler is a no-op
+// until `user` has loaded; re-dispatching is harmless.
+async function openSessionExpiredModal(page: Page) {
+  const title = page.getByText('Session expired', { exact: true })
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate(() =>
+          window.dispatchEvent(new Event('auth:session-expired')),
+        )
+        return title.isVisible().catch(() => false)
+      },
+      { timeout: 8000 },
+    )
+    .toBe(true)
+}
+
+const VIEWPORTS = [
+  { name: 'mobile', width: 375, height: 720 },
+  { name: 'desktop', width: 1280, height: 800 },
+]
+
+for (const vp of VIEWPORTS) {
+  test(`session-expired modal is width-constrained and centered (${vp.name})`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: vp.width, height: vp.height })
+    await mockAuth(page)
+    await page.goto('/narrators')
+
+    await openSessionExpiredModal(page)
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const box = await dialog.boundingBox()
+    expect(box).not.toBeNull()
+    if (!box) return
+
+    // 1. Width-constrained: never wider than the viewport, and capped near the
+    //    DS `max-w-lg` (32rem ≈ 512px) on wide screens (pre-fix it spanned the
+    //    full viewport width).
+    expect(box.width).toBeLessThanOrEqual(vp.width)
+    expect(box.width).toBeLessThanOrEqual(560)
+
+    // 2. Horizontally centered (within a small tolerance).
+    const boxCenter = box.x + box.width / 2
+    expect(Math.abs(boxCenter - vp.width / 2)).toBeLessThanOrEqual(24)
+
+    // 3. No horizontal page overflow — the core "blows out browser width" bug.
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    )
+    expect(overflow).toBeLessThanOrEqual(1)
+  })
+}


### PR DESCRIPTION
## What & why

Fixes two P5W3 frontend bugs in one PR (shared frontend area).

### ig#1031 — `/graph` empty on load
- **Default landing subgraph:** on first load the page fetches a sample of real narrators and auto-seeds the **highest-degree** narrator's ego network, so `/graph` is never blank. The seed is one-shot and guarded so it never overrides a user selection and never re-seeds after an explicit **Reset**. If `/narrators` is unavailable it degrades gracefully to the empty state + search box (no crash, **not blocked on #1024**).
- **One-click, ID-seeded chips:** the static English-name suggestions (only 2/4 resolved, 2 clicks each, routed through name-search) are replaced with chips built from real existing narrators ordered by degree — each selects by `narrator_id` directly.
- **Arabic search:** already works at the API layer (`narrator_search` fulltext + `CONTAINS` fallback both cover `name_ar`); no frontend change needed.

### ig#1027 — session-expired modal blows out browser width
- **Root cause:** the design-system `Dialog`'s positioning/sizing utilities (`fixed`, `start-1/2`, `top-1/2`, `-translate-x/y-1/2`, `max-w-lg`, overlay `inset-0`/`bg-black/80`) are referenced only inside the **compiled DS bundle**, which the app's Tailwind v4 content scan does not crawl — so they emitted **zero CSS** and the modal rendered with no fixed positioning, no centering transform and no max-width.
- **Fix:** force-generate the full DS Dialog class contract via `@source inline(...)` in `src/styles/theme.css` — the component-utility analogue of the existing #1000 `@theme inline` color-token bridge. Fixes **every** dialog app-wide (session modal, SearchPage filters, future dialogs) for **+1.2 KB** CSS, with no minified-JS scan / no bloat.
- The "modal only on genuine expiry" behavior is already handled by the refresh-on-401-then-emit path (#1016); the paired access-TTL lengthening is user-service **us#166** (separate owner).

## Verification
- `npx vitest run` — **226/226 pass** (new coverage: default auto-seed, ID-seeded chips, no-re-seed-after-Reset).
- `npx eslint src/` — 0 errors (2 warnings, both the pre-existing `set-state-in-effect` pattern).
- `npm run build` (tsc + vite) — green; confirmed the dialog centering/width utilities now generate (`max-width:var(--container-lg)`, `translate(-50%,-50%)`, etc.).
- `tests/e2e/session-modal.spec.ts` — asserts the modal is width-constrained, centered, and causes no horizontal page overflow at 375px and 1280px. **Verified to fail pre-fix (off-center by 256px) and pass post-fix.**

Closes #1031
Closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)
