### PR TITLE
fix(search): apply collection/grading/century/topic facets + nullable Narrator type (#1036, #1046)

### DIFF
--- a/frontend/src/lib/__tests__/searchFacets.test.ts
+++ b/frontend/src/lib/__tests__/searchFacets.test.ts
@@ -88,10 +88,16 @@ describe('matchesFacets', () => {
       expect(matchesFacets(r, { ...NO_FACETS, centuries: [3] })).toBe(false)
     })
 
-    it('treats the largest selected bucket as open-ended (5th+)', () => {
+    it('keeps a mid bucket exact — a lone "3rd" must not leak later centuries', () => {
+      expect(matchesFacets(result({ type: 'narrator', century: 3 }), { ...NO_FACETS, centuries: [3] })).toBe(true)
+      expect(matchesFacets(result({ type: 'narrator', century: 7 }), { ...NO_FACETS, centuries: [3] })).toBe(false)
+      expect(matchesFacets(result({ type: 'narrator', century: 4 }), { ...NO_FACETS, centuries: [3] })).toBe(false)
+    })
+
+    it('treats only the fixed top bucket as open-ended (5th+)', () => {
       expect(matchesFacets(result({ type: 'narrator', century: 7 }), { ...NO_FACETS, centuries: [5] })).toBe(true)
       expect(matchesFacets(result({ type: 'narrator', century: 4 }), { ...NO_FACETS, centuries: [5] })).toBe(false)
-      // a non-max bucket stays exact even when a higher bucket is also selected
+      // a non-top bucket stays exact even when the top bucket is also selected
       expect(matchesFacets(result({ type: 'narrator', century: 2 }), { ...NO_FACETS, centuries: [1, 5] })).toBe(false)
       expect(matchesFacets(result({ type: 'narrator', century: 1 }), { ...NO_FACETS, centuries: [1, 5] })).toBe(true)
     })

--- a/frontend/src/lib/__tests__/searchFacets.test.ts
+++ b/frontend/src/lib/__tests__/searchFacets.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { matchesFacets, type FacetSelection } from '../searchFacets'
+import type { SearchResult } from '../../types/api'
+
+const NO_FACETS: FacetSelection = {
+  collections: [],
+  gradings: [],
+  centuries: [],
+  topics: [],
+}
+
+function result(overrides: Partial<SearchResult>): SearchResult {
+  return {
+    id: 'x',
+    type: 'hadith',
+    title: 'title',
+    title_ar: 'عنوان',
+    score: 1,
+    ...overrides,
+  }
+}
+
+describe('matchesFacets', () => {
+  it('passes everything when no facets are selected', () => {
+    expect(matchesFacets(result({ type: 'narrator' }), NO_FACETS)).toBe(true)
+    expect(matchesFacets(result({ type: 'hadith' }), NO_FACETS)).toBe(true)
+    expect(matchesFacets(result({ type: 'collection' }), NO_FACETS)).toBe(true)
+  })
+
+  describe('collection facet', () => {
+    it('keeps a hadith whose collection matches the selected full name', () => {
+      const r = result({ type: 'hadith', collection: 'Sahih al-Bukhari' })
+      expect(matchesFacets(r, { ...NO_FACETS, collections: ['Sahih al-Bukhari'] })).toBe(true)
+    })
+
+    it('drops a hadith whose collection does not match', () => {
+      const r = result({ type: 'hadith', collection: 'Sahih Muslim' })
+      expect(matchesFacets(r, { ...NO_FACETS, collections: ['Sahih al-Bukhari'] })).toBe(false)
+    })
+
+    it('matches case-insensitively and on substring', () => {
+      const r = result({ type: 'hadith', collection: 'Sahih al-Bukhari' })
+      expect(matchesFacets(r, { ...NO_FACETS, collections: ['bukhari'] })).toBe(true)
+    })
+
+    it('keeps a hadith with unknown (null) collection', () => {
+      const r = result({ type: 'hadith', collection: null })
+      expect(matchesFacets(r, { ...NO_FACETS, collections: ['Sahih al-Bukhari'] })).toBe(true)
+    })
+
+    it('ignores the collection facet for narrators (not applicable)', () => {
+      const r = result({ type: 'narrator' })
+      expect(matchesFacets(r, { ...NO_FACETS, collections: ['Sahih al-Bukhari'] })).toBe(true)
+    })
+  })
+
+  describe('grading facet', () => {
+    it('matches a normalized grade token against the display label', () => {
+      expect(
+        matchesFacets(result({ grade: 'sahih' }), { ...NO_FACETS, gradings: ['Sahih'] }),
+      ).toBe(true)
+      // apostrophe in the label must not block the match
+      expect(
+        matchesFacets(result({ grade: 'daif' }), { ...NO_FACETS, gradings: ["Da'if"] }),
+      ).toBe(true)
+      expect(
+        matchesFacets(result({ grade: 'mawdu' }), { ...NO_FACETS, gradings: ["Mawdu'"] }),
+      ).toBe(true)
+    })
+
+    it('drops a hadith whose grade token does not match', () => {
+      expect(
+        matchesFacets(result({ grade: 'sahih' }), { ...NO_FACETS, gradings: ['Hasan'] }),
+      ).toBe(false)
+    })
+
+    it('keeps a hadith with unknown grade', () => {
+      expect(
+        matchesFacets(result({ grade: null }), { ...NO_FACETS, gradings: ['Sahih'] }),
+      ).toBe(true)
+    })
+  })
+
+  describe('century facet', () => {
+    it('matches a narrator in the selected century', () => {
+      const r = result({ type: 'narrator', century: 2 })
+      expect(matchesFacets(r, { ...NO_FACETS, centuries: [2] })).toBe(true)
+      expect(matchesFacets(r, { ...NO_FACETS, centuries: [3] })).toBe(false)
+    })
+
+    it('treats the largest selected bucket as open-ended (5th+)', () => {
+      expect(matchesFacets(result({ type: 'narrator', century: 7 }), { ...NO_FACETS, centuries: [5] })).toBe(true)
+      expect(matchesFacets(result({ type: 'narrator', century: 4 }), { ...NO_FACETS, centuries: [5] })).toBe(false)
+      // a non-max bucket stays exact even when a higher bucket is also selected
+      expect(matchesFacets(result({ type: 'narrator', century: 2 }), { ...NO_FACETS, centuries: [1, 5] })).toBe(false)
+      expect(matchesFacets(result({ type: 'narrator', century: 1 }), { ...NO_FACETS, centuries: [1, 5] })).toBe(true)
+    })
+
+    it('keeps a narrator with unknown century and ignores the facet for hadiths', () => {
+      expect(matchesFacets(result({ type: 'narrator', century: null }), { ...NO_FACETS, centuries: [2] })).toBe(true)
+      expect(matchesFacets(result({ type: 'hadith' }), { ...NO_FACETS, centuries: [2] })).toBe(true)
+    })
+  })
+
+  describe('topic facet', () => {
+    it('matches a topic tag against the parenthetical token of the label', () => {
+      const r = result({ type: 'hadith', topics: ['fiqh', 'prayer'] })
+      expect(matchesFacets(r, { ...NO_FACETS, topics: ['Jurisprudence (fiqh)'] })).toBe(true)
+    })
+
+    it('matches a single-word label with no parenthetical', () => {
+      const r = result({ type: 'hadith', topics: ['eschatology'] })
+      expect(matchesFacets(r, { ...NO_FACETS, topics: ['Eschatology'] })).toBe(true)
+    })
+
+    it('drops a hadith with no overlapping topic', () => {
+      const r = result({ type: 'hadith', topics: ['inheritance'] })
+      expect(matchesFacets(r, { ...NO_FACETS, topics: ['Theology (aqidah)'] })).toBe(false)
+    })
+
+    it('keeps a hadith with no topic tags', () => {
+      expect(matchesFacets(result({ type: 'hadith', topics: [] }), { ...NO_FACETS, topics: ['Theology (aqidah)'] })).toBe(true)
+    })
+  })
+
+  it('requires all active facet groups to match (AND across groups)', () => {
+    const r = result({ type: 'hadith', collection: 'Sahih al-Bukhari', grade: 'sahih', topics: ['fiqh'] })
+    expect(
+      matchesFacets(r, {
+        collections: ['Sahih al-Bukhari'],
+        gradings: ['Sahih'],
+        centuries: [],
+        topics: ['Jurisprudence (fiqh)'],
+      }),
+    ).toBe(true)
+    expect(
+      matchesFacets(r, {
+        collections: ['Sahih al-Bukhari'],
+        gradings: ['Hasan'], // grade mismatch fails the whole result
+        centuries: [],
+        topics: ['Jurisprudence (fiqh)'],
+      }),
+    ).toBe(false)
+  })
+})

--- a/frontend/src/lib/searchFacets.ts
+++ b/frontend/src/lib/searchFacets.ts
@@ -1,0 +1,128 @@
+import type { SearchResult } from '../types/api'
+
+/**
+ * Client-side facet filtering for the search page (#1036).
+ *
+ * The search endpoints return a flat result list; the collection / grading /
+ * century / topic facets are applied here over the result metadata the API now
+ * carries on each {@link SearchResult}. This mirrors the page's existing
+ * client-side entity-type filtering rather than introducing a server round-trip.
+ *
+ * Matching is *type-aware*: a facet only constrains result types it applies to
+ * (collection → hadith + collection, grading → hadith, century → narrator,
+ * topic → hadith). For non-applicable types the facet is ignored, so e.g.
+ * filtering by collection narrows hadiths without dropping matching narrators.
+ *
+ * Matching is also *permissive on missing data*: a result whose applicable
+ * attribute is null/empty is treated as "unknown" and is NOT excluded. This
+ * keeps semantic hits (which lack graph-derived metadata) and partially-loaded
+ * records visible instead of silently disappearing under an active facet.
+ */
+export interface FacetSelection {
+  collections: string[]
+  gradings: string[]
+  centuries: number[]
+  topics: string[]
+}
+
+interface FacetApplicability {
+  collection: boolean
+  grade: boolean
+  century: boolean
+  topic: boolean
+}
+
+const FACET_APPLIES: Record<string, FacetApplicability> = {
+  hadith: { collection: true, grade: true, century: false, topic: true },
+  collection: { collection: true, grade: false, century: false, topic: false },
+  narrator: { collection: false, grade: false, century: true, topic: false },
+}
+
+const NO_FACETS: FacetApplicability = {
+  collection: false,
+  grade: false,
+  century: false,
+  topic: false,
+}
+
+/**
+ * Normalize a label/value for tolerant comparison: lowercase, drop the various
+ * apostrophe/hamza glyphs (so "Da'if" === "daif", "Mawdu'" === "mawdu"), and
+ * collapse whitespace.
+ */
+function norm(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/['’ʼʿ`´‘]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function matchesCollection(value: string | null | undefined, selected: string[]): boolean {
+  if (selected.length === 0) return true
+  if (!value) return true // unknown collection is not excluded
+  const v = norm(value)
+  return selected.some((label) => {
+    const l = norm(label)
+    return v === l || v.includes(l) || l.includes(v)
+  })
+}
+
+function matchesGrade(value: string | null | undefined, selected: string[]): boolean {
+  if (selected.length === 0) return true
+  if (!value) return true
+  // `value` is already a canonical token (e.g. "sahih", "daif", "hasan_sahih");
+  // the facet labels normalize to the same tokens for the simple grades.
+  const v = norm(value)
+  return selected.some((label) => v === norm(label))
+}
+
+function matchesCentury(value: number | null | undefined, selected: number[]): boolean {
+  if (selected.length === 0) return true
+  if (value == null) return true
+  // The largest facet bucket is open-ended ("5th+"), so it also matches later
+  // centuries; smaller buckets are exact.
+  const maxBucket = Math.max(...selected)
+  return selected.some((c) => (c === maxBucket ? value >= c : value === c))
+}
+
+/**
+ * Tokens a topic facet label can match against a hadith's `topic_tags`, e.g.
+ * "Jurisprudence (fiqh)" -> ["fiqh", "jurisprudence"], "Eschatology" ->
+ * ["eschatology"]. A tag matches if it contains, or is contained by, any token.
+ */
+function topicTokens(label: string): string[] {
+  const tokens: string[] = []
+  const captured = label.match(/\(([^)]+)\)/)?.[1]
+  if (captured) tokens.push(norm(captured))
+  const lead = norm(label.replace(/\([^)]*\)/, ''))
+  if (lead) tokens.push(lead)
+  return tokens
+}
+
+function matchesTopic(values: string[] | undefined, selected: string[]): boolean {
+  if (selected.length === 0) return true
+  if (!values || values.length === 0) return true
+  const tags = values.map(norm).filter(Boolean)
+  if (tags.length === 0) return true
+  return selected.some((label) =>
+    topicTokens(label).some((token) =>
+      tags.some((tag) => tag.includes(token) || token.includes(tag)),
+    ),
+  )
+}
+
+/**
+ * True when a search result passes every active facet group. An empty group
+ * (no values selected) imposes no constraint.
+ */
+export function matchesFacets(result: SearchResult, facets: FacetSelection): boolean {
+  const applies = FACET_APPLIES[result.type] ?? NO_FACETS
+  if (applies.collection && !matchesCollection(result.collection, facets.collections)) {
+    return false
+  }
+  if (applies.grade && !matchesGrade(result.grade, facets.gradings)) return false
+  if (applies.century && !matchesCentury(result.century, facets.centuries)) return false
+  if (applies.topic && !matchesTopic(result.topics, facets.topics)) return false
+  return true
+}

--- a/frontend/src/lib/searchFacets.ts
+++ b/frontend/src/lib/searchFacets.ts
@@ -18,6 +18,14 @@ import type { SearchResult } from '../types/api'
  * keeps semantic hits (which lack graph-derived metadata) and partially-loaded
  * records visible instead of silently disappearing under an active facet.
  */
+
+/**
+ * The century facet's fixed top bucket ("5th+" — the last entry of CENTURIES in
+ * SearchPage). Only this bucket is open-ended; 1st–4th are exact ordinals. Keep
+ * in sync with the UI's CENTURIES list.
+ */
+export const OPEN_ENDED_CENTURY = 5
+
 export interface FacetSelection {
   collections: string[]
   gradings: string[]
@@ -80,10 +88,12 @@ function matchesGrade(value: string | null | undefined, selected: string[]): boo
 function matchesCentury(value: number | null | undefined, selected: number[]): boolean {
   if (selected.length === 0) return true
   if (value == null) return true
-  // The largest facet bucket is open-ended ("5th+"), so it also matches later
-  // centuries; smaller buckets are exact.
-  const maxBucket = Math.max(...selected)
-  return selected.some((c) => (c === maxBucket ? value >= c : value === c))
+  // Only the fixed top bucket ("5th+") is open-ended; 1st–4th are exact
+  // ordinals. Keying off the selection's own max would make e.g. a lone "3rd"
+  // selection leak every later century, contradicting the UI labels.
+  return selected.some((c) =>
+    c >= OPEN_ENDED_CENTURY ? value >= OPEN_ENDED_CENTURY : value === c,
+  )
 }
 
 /**

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../components/ui/Dialog'
+import { matchesFacets } from '../lib/searchFacets'
 
 type SearchMode = 'fulltext' | 'semantic'
 type SortOption = 'relevance' | 'date-asc' | 'date-desc' | 'name-en' | 'name-ar'
@@ -244,10 +245,11 @@ export default function SearchPage() {
     setPage(1)
   }
 
-  // Client-side filtering of results
+  // Client-side filtering of results: entity type first, then the
+  // collection/grading/century/topic facets (see matchesFacets). (#1036)
   const filteredResults = (searchData?.results ?? []).filter((r) => {
     if (!filters.entityTypes.includes(r.type as EntityType)) return false
-    return true
+    return matchesFacets(r, filters)
   })
 
   // Client-side sort

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -8,16 +8,19 @@ export interface PaginatedResponse<T> {
 export interface Narrator {
   id: string
   name_ar: string
-  name_en: string
+  // name_en/generation/gender/sect_affiliation/trustworthiness_consensus are
+  // nullable to match the API's NarratorResponse contract (#1024/#1046): the
+  // graph carries these only for a subset of narrators. Render paths null-guard.
+  name_en: string | null
   kunya: string | null
   nisba: string | null
   laqab: string | null
   birth_year_ah: number | null
   death_year_ah: number | null
-  generation: string
-  gender: string
-  sect_affiliation: string
-  trustworthiness_consensus: string
+  generation: string | null
+  gender: string | null
+  sect_affiliation: string | null
+  trustworthiness_consensus: string | null
   aliases: string[]
   betweenness_centrality: number | null
   in_degree: number | null
@@ -86,6 +89,13 @@ export interface SearchResult {
   title: string
   title_ar: string
   score: number
+  // Facet metadata, populated per result type (see backend SearchResult).
+  // `grade` is the canonical normalized token (e.g. "sahih", "daif"), not raw
+  // scholar text. Absent/empty where the attribute does not apply. (#1036)
+  collection?: string | null
+  grade?: string | null
+  century?: number | null
+  topics?: string[]
 }
 
 export interface SearchResultsResponse {

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -272,7 +272,15 @@ class NarratorNetworkResponse(BaseModel):
 
 
 class SearchResult(BaseModel):
-    """A single search result."""
+    """A single search result.
+
+    Beyond the display fields, results carry the facet metadata the search page
+    filters on client-side (collection / grade / century / topic). Each field is
+    populated only for the result types it applies to and left null/empty
+    otherwise: ``collection`` + ``grade`` + ``topics`` for hadiths, ``century``
+    for narrators. ``grade`` is the canonical normalized token (see
+    ``src.utils.grades.normalize_grade``), not the raw scholar string. (#1036)
+    """
 
     model_config = ConfigDict(frozen=True)
 
@@ -281,6 +289,10 @@ class SearchResult(BaseModel):
     title: str
     title_ar: str
     score: float
+    collection: str | None = None
+    grade: str | None = None
+    century: int | None = None
+    topics: list[str] = []
 
 
 class SearchResultsResponse(BaseModel):

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -11,12 +11,24 @@ from fastapi.responses import JSONResponse
 from src.api.deps import get_neo4j, get_pg
 from src.api.models import SearchResult, SearchResultsResponse
 from src.enrich.embeddings import get_embedder, to_pgvector_literal
+from src.utils.grades import normalize_grade
 from src.utils.neo4j_client import Neo4jClient
 from src.utils.pg_client import PgClient
 
 router = APIRouter()
 
 log = logging.getLogger(__name__)
+
+
+def _death_year_to_century(death_year_ah: object) -> int | None:
+    """Map a Hijri death year to its 1-based century (124 AH -> 2nd century).
+
+    Returns ``None`` for missing/non-positive years so the century facet treats
+    the narrator as unknown rather than excluding them. (#1036)
+    """
+    if isinstance(death_year_ah, int) and death_year_ah > 0:
+        return (death_year_ah - 1) // 100 + 1
+    return None
 
 
 @router.get("/search", response_model=SearchResultsResponse)
@@ -52,6 +64,7 @@ def search(
                 title=r.get("name_en") or r["name_ar"],
                 title_ar=r["name_ar"],
                 score=r["score"],
+                century=_death_year_to_century(r.get("death_year_ah")),
             )
         )
 
@@ -68,6 +81,9 @@ def search(
                     title=snippet[:120] + "..." if len(snippet) > 120 else snippet,
                     title_ar=r["matn_ar"][:120],
                     score=r["score"],
+                    collection=r.get("collection_name"),
+                    grade=normalize_grade(r.get("grade")),
+                    topics=r.get("topic_tags") or [],
                 )
             )
 
@@ -87,7 +103,7 @@ def _fulltext_narrator_search(neo4j: Neo4jClient, query: str, limit: int) -> lis
             CALL db.index.fulltext.queryNodes('narrator_search', $q)
             YIELD node, score
             RETURN node.id AS id, node.name_ar AS name_ar,
-                   node.name_en AS name_en, score
+                   node.name_en AS name_en, node.death_year_ah AS death_year_ah, score
             LIMIT $limit
             """,
             {"q": query, "limit": limit},
@@ -99,7 +115,7 @@ def _fulltext_narrator_search(neo4j: Neo4jClient, query: str, limit: int) -> lis
             MATCH (n:Narrator)
             WHERE n.name_ar CONTAINS $q OR n.name_en CONTAINS $q
             RETURN n.id AS id, n.name_ar AS name_ar, n.name_en AS name_en,
-                   1.0 AS score
+                   n.death_year_ah AS death_year_ah, 1.0 AS score
             LIMIT $limit
             """,
             {"q": query, "limit": limit},
@@ -108,13 +124,21 @@ def _fulltext_narrator_search(neo4j: Neo4jClient, query: str, limit: int) -> lis
 
 def _fulltext_hadith_search(neo4j: Neo4jClient, query: str, limit: int) -> list[dict[str, Any]]:
     """Search hadiths using full-text index, falling back to CONTAINS."""
+    # ``grade`` resolves the connected Grading node, falling back to the legacy
+    # flat property, mirroring the hadiths route's ``_GRADE_EXPR``; the caller
+    # normalizes it to a canonical token. ``collection_name`` and ``topic_tags``
+    # feed the collection/topic facets. (#1036)
     try:
         return neo4j.execute_read(
             """
             CALL db.index.fulltext.queryNodes('hadith_search', $q)
             YIELD node, score
+            OPTIONAL MATCH (node)-[:GRADED_BY]->(g:Grading)
             RETURN node.id AS id, node.matn_ar AS matn_ar,
-                   node.matn_en AS matn_en, score
+                   node.matn_en AS matn_en, score,
+                   node.collection_name AS collection_name,
+                   node.topic_tags AS topic_tags,
+                   coalesce(g.grade, node.grade_composite, node.grade) AS grade
             LIMIT $limit
             """,
             {"q": query, "limit": limit},
@@ -125,8 +149,12 @@ def _fulltext_hadith_search(neo4j: Neo4jClient, query: str, limit: int) -> list[
             """
             MATCH (h:Hadith)
             WHERE h.matn_ar CONTAINS $q OR h.matn_en CONTAINS $q
+            OPTIONAL MATCH (h)-[:GRADED_BY]->(g:Grading)
             RETURN h.id AS id, h.matn_ar AS matn_ar, h.matn_en AS matn_en,
-                   1.0 AS score
+                   1.0 AS score,
+                   h.collection_name AS collection_name,
+                   h.topic_tags AS topic_tags,
+                   coalesce(g.grade, h.grade_composite, h.grade) AS grade
             LIMIT $limit
             """,
             {"q": query, "limit": limit},
@@ -230,6 +258,11 @@ def search_semantic(
             },
         )
 
+    # Facet metadata (collection/grade/topics) is intentionally left empty for
+    # semantic hits: those attributes live on the Neo4j graph, not on the
+    # ``isnad_graph.hadiths`` projection this query reads, and the search-page
+    # matcher treats a missing value as "unknown, not excluded" — so facets do
+    # not (yet) refine semantic results. (#1036)
     results: list[SearchResult] = []
     for r in rows:
         snippet = r.get("matn_en") or r["matn_ar"]

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -53,6 +53,73 @@ def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMo
     assert "count(" in count_query
 
 
+def test_search_populates_facet_metadata(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """Results carry the facet metadata the search page filters on (#1036).
+
+    Narrators get a derived ``century`` (from death year); hadiths get
+    ``collection``, a normalized ``grade`` token, and ``topics``.
+    """
+    mock_neo4j.execute_read.side_effect = [
+        # narrator full-text search — death_year_ah drives the century facet
+        [
+            {
+                "id": "nar-1",
+                "name_ar": "الزهري",
+                "name_en": "al-Zuhri",
+                "death_year_ah": 124,
+                "score": 2.0,
+            }
+        ],
+        # hadith full-text search — raw grade is normalized to its canonical token
+        [
+            {
+                "id": "had-1",
+                "matn_ar": "نص",
+                "matn_en": "matn text",
+                "score": 1.0,
+                "collection_name": "Sahih al-Bukhari",
+                "topic_tags": ["intentions"],
+                "grade": "Sahih - Authentic",
+            }
+        ],
+        [{"total": 1}],  # narrator count
+        [{"total": 1}],  # hadith count
+    ]
+    resp = client.get("/api/v1/search?q=test")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+
+    narrator = next(r for r in results if r["type"] == "narrator")
+    assert narrator["century"] == 2  # 124 AH -> 2nd century
+    assert narrator["collection"] is None
+    assert narrator["topics"] == []
+
+    hadith = next(r for r in results if r["type"] == "hadith")
+    assert hadith["collection"] == "Sahih al-Bukhari"
+    assert hadith["grade"] == "sahih"  # normalized from "Sahih - Authentic"
+    assert hadith["topics"] == ["intentions"]
+    assert hadith["century"] is None
+
+
+def test_search_facet_metadata_defaults_when_absent(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Missing graph properties leave facet fields null/empty, not erroring (#1036)."""
+    mock_neo4j.execute_read.side_effect = [
+        [{"id": "nar-1", "name_ar": "x", "name_en": "n", "score": 1.0}],
+        [{"id": "had-1", "matn_ar": "m", "matn_en": "h", "score": 1.0}],
+        [{"total": 1}],
+        [{"total": 1}],
+    ]
+    resp = client.get("/api/v1/search?q=test")
+    assert resp.status_code == 200
+    for r in resp.json()["results"]:
+        assert r["century"] is None
+        assert r["collection"] is None
+        assert r["grade"] is None
+        assert r["topics"] == []
+
+
 def test_search_total_exceeds_limit(client: TestClient, mock_neo4j: MagicMock) -> None:
     """total reflects the true match count even when results are capped at limit."""
     narrator_hits = [


### PR DESCRIPTION
## What & why

The search page tracked the collection / grading / century / topic facets in
component state but only ever applied `entityTypes` to the result list, so
selecting any of those facets did nothing (**ig#1036**). This wires them
through end to end, and syncs the frontend `Narrator` type to the API's
nullable contract (**ig#1046**).

## ig#1036 — apply the facets

Search results carried no facet metadata and the endpoints accepted no filter
params, so the facets had nothing to filter on. Approach (consistent with the
page's existing client-side entity-type filtering on a capped fetch):

- **Backend** — `SearchResult` now carries the facet metadata each result type
  can be filtered by: `collection` / `grade` / `topics` for hadiths, `century`
  for narrators. The full-text route populates them from the Hadith/Narrator
  nodes — `grade` via the `GRADED_BY` traversal normalized to a canonical token
  (`src.utils.grades.normalize_grade`), `century` derived from `death_year_ah`.
- **Frontend** — a pure matcher (`src/lib/searchFacets.ts`) applies the facets
  client-side. Matching is **type-aware** (a facet only constrains the result
  types it applies to) and **tolerant**: case-insensitive + apostrophe-insensitive
  (so the `"Da'if"` label matches the `daif` token), collection by substring
  (label vs full `name_en`), and the largest century bucket is open-ended (`5th+`).
- **Missing-data is permissive** — a result whose applicable attribute is
  null/empty is treated as "unknown" and not excluded.

### Known limitation (documented in code)
Semantic hits leave facet metadata empty: those attributes live on the Neo4j
graph, not on the `isnad_graph.hadiths` pgvector projection the semantic query
reads. With permissive-null matching, semantic results stay visible but the
collection/grade/topic facets do not (yet) refine them. Topic matching is
best-effort (label token vs `topic_tags`); there is no canonical topic
vocabulary in-repo yet, and `topic_tags` are currently sparse.

## ig#1046 — nullable Narrator type

`name_en`, `generation`, `gender`, `sect_affiliation`,
`trustworthiness_consensus` are now `string | null`, matching the API's
`NarratorResponse` (#1024). No runtime change — existing render paths already
null-guard (verified `ratingScore`/`ratingColor` take `string | null`,
`profileFields` is `[string, string | null][]`, ForceGraph maps from the
already-nullable `GraphNode`).

## Tests
- **Backend** (`tests/test_api/test_search.py`): facet-metadata population +
  grade normalization, and absent-property defaults.
- **Frontend** (`src/lib/__tests__/searchFacets.test.ts`, 17 cases): each facet,
  missing-data, type-applicability, and AND-across-groups.
- Gates green locally: backend ruff + mypy + `test_search` (16 passed);
  frontend eslint + `tsc -b` + full vitest (255 passed). Re-verified after
  rebase onto the current wave branch (incl. #1056/#1058).

Closes #1036
Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)
