### PR TITLE
feat(admin): configurable log retention (keep last X days) knob (#1038)

### DIFF
--- a/frontend/src/pages/admin/ConfigPage.tsx
+++ b/frontend/src/pages/admin/ConfigPage.tsx
@@ -9,6 +9,7 @@ interface SystemConfig {
   feature_flags: Record<string, boolean>
   max_search_results: number
   max_pagination_limit: number
+  log_retention_days: number
 }
 
 interface ConfigAuditEntry {
@@ -74,6 +75,7 @@ export default function ConfigPage() {
         rate_limit_per_minute: config.rate_limit_per_minute,
         max_search_results: config.max_search_results,
         max_pagination_limit: config.max_pagination_limit,
+        log_retention_days: config.log_retention_days,
         cors_origins: [...config.cors_origins],
         feature_flags: { ...config.feature_flags },
       })
@@ -104,6 +106,9 @@ export default function ConfigPage() {
     }
     if (formData.max_pagination_limit !== config?.max_pagination_limit) {
       update.max_pagination_limit = formData.max_pagination_limit
+    }
+    if (formData.log_retention_days !== config?.log_retention_days) {
+      update.log_retention_days = formData.log_retention_days
     }
     const newOrigins = corsInput.split(',').map((s) => s.trim()).filter(Boolean)
     if (JSON.stringify(newOrigins) !== JSON.stringify(config?.cors_origins)) {
@@ -208,6 +213,26 @@ export default function ConfigPage() {
             className="form-input-block"
           />
         </label>
+      </section>
+
+      <section className="section-mb">
+        <h2>Log Retention</h2>
+        <label>
+          Keep last N days of logs
+          <input
+            type="number"
+            min={1}
+            max={365}
+            value={formData.log_retention_days ?? 7}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, log_retention_days: Number(e.target.value) }))
+            }
+            className="form-input-block"
+          />
+        </label>
+        <p className="muted-text">
+          Application logs older than this are rotated/deleted (1–365 days). Frees disk on the VPS.
+        </p>
       </section>
 
       <section className="section-mb">

--- a/frontend/src/pages/admin/__tests__/ConfigPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ConfigPage.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import ConfigPage from '../ConfigPage'
+
+const CONFIG = {
+  rate_limit_per_minute: 60,
+  cors_origins: ['http://localhost:3000'],
+  feature_flags: {},
+  max_search_results: 100,
+  max_pagination_limit: 100,
+  log_retention_days: 7,
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ConfigPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ConfigPage — log retention (ig#1038)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the log-retention control populated from config', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse({ ...CONFIG, entries: [], total: 0 }))),
+    )
+    renderPage()
+
+    await screen.findByText('Log Retention')
+    const input = screen.getByLabelText(/Keep last N days/i) as HTMLInputElement
+    expect(input.value).toBe('7')
+  })
+
+  it('PATCHes the changed log_retention_days value on save', async () => {
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'PATCH') {
+        return Promise.resolve(jsonResponse({ ...CONFIG, log_retention_days: 30 }))
+      }
+      return Promise.resolve(jsonResponse({ ...CONFIG, entries: [], total: 0 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    const input = (await screen.findByLabelText(/Keep last N days/i)) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '30' } })
+    fireEvent.click(screen.getByText('Save Configuration'))
+
+    await waitFor(() => {
+      const patchCall = fetchMock.mock.calls.find(
+        ([, init]) => (init as RequestInit | undefined)?.method === 'PATCH',
+      )
+      expect(patchCall).toBeTruthy()
+      expect(JSON.parse((patchCall![1] as RequestInit).body as string)).toEqual({
+        log_retention_days: 30,
+      })
+    })
+  })
+})

--- a/src/api/loki_retention.py
+++ b/src/api/loki_retention.py
@@ -1,0 +1,99 @@
+"""Loki retention enforcement for the admin "log retention (days)" control (ig#1038).
+
+The admin Config panel persists ``log_retention_days`` to Postgres (source of
+truth). This module is the propagation half: it rewrites Loki's hot-reloadable
+``runtime_config`` overrides file so the new window takes effect *without a Loki
+restart*. The deploy side (deploy#451) wires the file:
+
+- ``loki-config.yml`` enables ``runtime_config`` with ``period: 30s`` — Loki
+  re-reads the overrides file every 30s and the compactor applies any changed
+  ``retention_period`` on its next compaction cycle.
+- The ``loki_runtime`` volume is mounted **read-write into the api container** at
+  ``/etc/loki/runtime`` precisely so this code can write the value, and
+  **read-side into loki** at the same path.
+
+Contract details that this writer honours:
+
+- **In-place truncate write, never rename-replace.** The overrides file is a
+  bind/volume view; ``os.replace`` would swap the inode and break loki's view.
+  ``open(path, "w")`` truncates the existing inode in place — exactly right.
+- **Surgical line rewrite.** Only the ``retention_period`` value is changed so
+  the deploy-seeded comments, tenant id, and any other limits are preserved.
+- **Best-effort.** When the runtime volume is not mounted (local/dev/test) the
+  write is a logged no-op; the DB-persisted value remains authoritative and Loki
+  falls back to its static ``limits_config.retention_period`` (7d).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from src.config import get_settings
+from src.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+__all__ = ["apply_loki_retention", "retention_period_for_days"]
+
+# Matches the single ``retention_period:`` line in the overrides file, capturing
+# its indentation so we can rewrite the value while preserving structure.
+_RETENTION_LINE_RE = re.compile(
+    r"^(?P<indent>[ \t]*)retention_period:[ \t]*\S.*$",
+    re.MULTILINE,
+)
+
+
+def retention_period_for_days(days: int) -> str:
+    """Convert a day count to the hour-suffixed duration Loki expects (e.g. ``"720h"``)."""
+    return f"{days * 24}h"
+
+
+def apply_loki_retention(days: int, *, path: str | Path | None = None) -> bool:
+    """Rewrite the Loki runtime overrides file with the new retention window.
+
+    Returns ``True`` when the file was rewritten, ``False`` when the write was a
+    best-effort no-op (volume/file absent, key missing, or an OS error). Never
+    raises — log retention is a propagation concern and must not fail the admin
+    config update whose DB write is the source of truth.
+    """
+    target = Path(path) if path is not None else Path(get_settings().loki.runtime_overrides_path)
+    period = retention_period_for_days(days)
+
+    if not target.parent.exists():
+        log.warning(
+            "loki_retention_skipped",
+            reason="runtime overrides dir absent (loki_runtime volume not mounted)",
+            path=str(target),
+        )
+        return False
+    if not target.exists():
+        log.warning("loki_retention_skipped", reason="overrides file absent", path=str(target))
+        return False
+
+    try:
+        original = target.read_text(encoding="utf-8")
+        new_text, n = _RETENTION_LINE_RE.subn(
+            lambda m: (
+                f"{m.group('indent')}retention_period: {period}"
+                "  # set via admin Config — log retention (days), ig#1038"
+            ),
+            original,
+            count=1,
+        )
+        if n == 0:
+            log.warning(
+                "loki_retention_skipped",
+                reason="no retention_period key found in overrides file",
+                path=str(target),
+            )
+            return False
+        # In-place truncate write — preserves the inode the loki volume view tracks.
+        with open(target, "w", encoding="utf-8") as fh:
+            fh.write(new_text)
+    except OSError as exc:
+        log.warning("loki_retention_write_failed", path=str(target), error=str(exc))
+        return False
+
+    log.info("loki_retention_applied", path=str(target), retention_period=period, days=days)
+    return True

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -609,6 +609,9 @@ class SystemConfig(BaseModel):
     feature_flags: dict[str, bool] = {}
     max_search_results: int = 100
     max_pagination_limit: int = 100
+    # Days of application logs to retain before rotation/deletion. Surfaced in the
+    # admin Config panel; the persisted value drives Loki retention (deploy#451).
+    log_retention_days: int = Field(default=7, ge=1, le=365)
 
 
 class SystemConfigUpdate(BaseModel):
@@ -619,6 +622,7 @@ class SystemConfigUpdate(BaseModel):
     feature_flags: dict[str, bool] | None = None
     max_search_results: int | None = None
     max_pagination_limit: int | None = None
+    log_retention_days: int | None = Field(default=None, ge=1, le=365)
 
 
 class ConfigAuditEntry(BaseModel):

--- a/src/api/routes/admin/config.py
+++ b/src/api/routes/admin/config.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.auth import User
 from src.api.deps import get_pg
+from src.api.loki_retention import apply_loki_retention
 from src.api.middleware import require_admin
 from src.api.models import (
     FORBIDDEN_CONFIG_KEYS,
@@ -135,6 +136,13 @@ def update_config(
             """,
             (key, old_serialized, new_serialized, admin.id),
         )
+
+    # Propagate log retention to Loki's hot-reloadable runtime overrides so the
+    # new window takes effect without a redeploy (ig#1038 / deploy#451). The DB
+    # write above is the source of truth; this file write is best-effort and a
+    # no-op when the loki_runtime volume is not mounted (local/dev).
+    if "log_retention_days" in updates:
+        apply_loki_retention(int(updates["log_retention_days"]))
 
     return _load_config(pg)
 

--- a/src/config.py
+++ b/src/config.py
@@ -149,6 +149,22 @@ class SecurityHeaderSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="SECURITY_")
 
 
+class LokiSettings(BaseSettings):
+    """Loki log-retention runtime override (ig#1038 / deploy#451).
+
+    Path to the hot-reloadable Loki ``runtime_config`` overrides file. The admin
+    "log retention (days)" control rewrites ``overrides.<tenant>.retention_period``
+    in this file in place; Loki re-reads it every ``runtime_config.period`` (30s)
+    with no restart. On the VPS this is the ``loki_runtime`` volume mounted into
+    the api container at ``/etc/loki/runtime``; absent in local/dev (the write is
+    then a no-op and the DB-persisted value remains the source of truth).
+    """
+
+    runtime_overrides_path: str = "/etc/loki/runtime/overrides.yaml"
+
+    model_config = SettingsConfigDict(env_prefix="LOKI_")
+
+
 class Settings(BaseSettings):
     """Root application settings, composed from nested service settings."""
 
@@ -158,6 +174,7 @@ class Settings(BaseSettings):
     rate_limit: RateLimitSettings = RateLimitSettings()
     auth: AuthSettings = AuthSettings()
     security_headers: SecurityHeaderSettings = SecurityHeaderSettings()
+    loki: LokiSettings = LokiSettings()
 
     cors_origins: list[str] = ["http://localhost:3000"]
 

--- a/tests/test_api/test_admin_config.py
+++ b/tests/test_api/test_admin_config.py
@@ -67,6 +67,7 @@ class TestGetConfig:
         assert data["feature_flags"] == {}
         assert data["max_search_results"] == 100
         assert data["max_pagination_limit"] == 100
+        assert data["log_retention_days"] == 7
 
     def test_from_db(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
         def fake_execute(query: str, params: object = None) -> list[dict[str, object]]:
@@ -142,6 +143,82 @@ class TestUpdateConfig:
             json={"rate_limit_per_minute": "not_a_number"},
         )
         assert resp.status_code == 422
+
+
+class TestLogRetention:
+    """ig#1038 — configurable 'keep last X days' log retention knob."""
+
+    def test_round_trip(self, admin_client: TestClient, mock_pg: MagicMock) -> None:
+        # Persist a new value, then read it back from the (mocked) DB.
+        resp = admin_client.patch(
+            "/api/v1/admin/config",
+            json={"log_retention_days": 30},
+        )
+        assert resp.status_code == 200
+        calls = mock_pg.execute.call_args_list
+        upserts = [c for c in calls if "INSERT INTO system_config" in str(c)]
+        # The serialized value lands in the upsert params.
+        assert any("log_retention_days" in str(c) and "30" in str(c) for c in upserts)
+
+        def fake_execute(query: str, params: object = None) -> list[dict[str, object]]:
+            if "SELECT key, value FROM system_config" in query:
+                return [{"key": "log_retention_days", "value": "30"}]
+            return []
+
+        mock_pg.execute.side_effect = fake_execute
+        read_back = admin_client.get("/api/v1/admin/config")
+        assert read_back.status_code == 200
+        assert read_back.json()["log_retention_days"] == 30
+
+    def test_rejects_below_min(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch("/api/v1/admin/config", json={"log_retention_days": 0})
+        assert resp.status_code == 422
+
+    def test_rejects_above_max(self, admin_client: TestClient) -> None:
+        resp = admin_client.patch("/api/v1/admin/config", json={"log_retention_days": 366})
+        assert resp.status_code == 422
+
+    def test_non_admin_cannot_set(self, mock_neo4j: MagicMock) -> None:
+        from fastapi import HTTPException
+
+        from src.api.app import create_app
+
+        app = create_app()
+        app.state.neo4j = mock_neo4j
+
+        def _raise_not_found() -> User:
+            raise HTTPException(status_code=404, detail="Not Found")
+
+        app.dependency_overrides[require_admin] = _raise_not_found
+        client = TestClient(app)
+        resp = client.patch("/api/v1/admin/config", json={"log_retention_days": 14})
+        assert resp.status_code == 404
+
+    def test_propagates_to_loki_on_change(
+        self, admin_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Updating the knob drives the Loki runtime overrides write (enforcement).
+        import src.api.routes.admin.config as config_route
+
+        calls: list[int] = []
+        monkeypatch.setattr(config_route, "apply_loki_retention", lambda days: calls.append(days))
+
+        resp = admin_client.patch("/api/v1/admin/config", json={"log_retention_days": 45})
+        assert resp.status_code == 200
+        assert calls == [45]
+
+    def test_no_loki_write_for_unrelated_change(
+        self, admin_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A config update that doesn't touch retention must not write the Loki file.
+        import src.api.routes.admin.config as config_route
+
+        calls: list[int] = []
+        monkeypatch.setattr(config_route, "apply_loki_retention", lambda days: calls.append(days))
+
+        resp = admin_client.patch("/api/v1/admin/config", json={"rate_limit_per_minute": 120})
+        assert resp.status_code == 200
+        assert calls == []
 
 
 class TestConfigAudit:

--- a/tests/test_api/test_loki_retention.py
+++ b/tests/test_api/test_loki_retention.py
@@ -1,0 +1,75 @@
+"""Tests for the Loki retention enforcement writer (ig#1038).
+
+Exercises the propagation half of the admin "log retention (days)" control: the
+in-place rewrite of Loki's hot-reloadable runtime overrides file. The contract
+(deploy#451) requires an in-place truncate write (inode preserved) that touches
+only the ``retention_period`` value and is a safe no-op when the runtime volume
+is not mounted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.api.loki_retention import apply_loki_retention, retention_period_for_days
+
+# The deploy-seeded overrides file shape (infra/loki/runtime-overrides.yaml).
+_SEED = """\
+# Loki runtime overrides — hot-reloadable per-tenant limits (deploy#451).
+overrides:
+  fake:
+    retention_period: 168h  # 7 days (default; admin control overwrites this)
+"""
+
+
+def test_retention_period_for_days() -> None:
+    assert retention_period_for_days(7) == "168h"
+    assert retention_period_for_days(30) == "720h"
+    assert retention_period_for_days(1) == "24h"
+
+
+def test_rewrites_value_in_place(tmp_path: Path) -> None:
+    target = tmp_path / "overrides.yaml"
+    target.write_text(_SEED, encoding="utf-8")
+    inode_before = target.stat().st_ino
+
+    assert apply_loki_retention(30, path=target) is True
+
+    text = target.read_text(encoding="utf-8")
+    assert "retention_period: 720h" in text
+    assert "168h" not in text
+    # Inode preserved (truncate-write, not rename-replace) so loki's volume view holds.
+    assert target.stat().st_ino == inode_before
+
+
+def test_preserves_surrounding_structure(tmp_path: Path) -> None:
+    target = tmp_path / "overrides.yaml"
+    target.write_text(_SEED, encoding="utf-8")
+
+    apply_loki_retention(14, path=target)
+
+    text = target.read_text(encoding="utf-8")
+    # Comment header, tenant id, and indentation are untouched.
+    assert text.startswith("# Loki runtime overrides")
+    assert "overrides:\n  fake:\n" in text
+    assert "    retention_period: 336h" in text
+
+
+def test_noop_when_dir_absent(tmp_path: Path) -> None:
+    missing = tmp_path / "no-such-dir" / "overrides.yaml"
+    assert apply_loki_retention(30, path=missing) is False
+
+
+def test_noop_when_file_absent(tmp_path: Path) -> None:
+    target = tmp_path / "overrides.yaml"  # dir exists, file does not
+    assert apply_loki_retention(30, path=target) is False
+
+
+def test_noop_when_key_missing_does_not_corrupt(tmp_path: Path) -> None:
+    target = tmp_path / "overrides.yaml"
+    body = "overrides:\n  fake:\n    ingestion_rate_mb: 8\n"
+    target.write_text(body, encoding="utf-8")
+
+    assert apply_loki_retention(30, path=target) is False
+    # File left untouched, not half-written.
+    assert target.read_text(encoding="utf-8") == body


### PR DESCRIPTION
## Summary

- Adds a configurable **"Log retention (days)"** knob (1–365) to the admin Config panel (ig#1038) so an admin can cap log history on the disk-constrained VPS **without a redeploy**.
- Persists + audits `log_retention_days` through the existing `system_config` / `config_audit` path; bounds enforced by pydantic (`422` out of range).
- Propagates the value to Loki's hot-reloadable `runtime_config` overrides on the API side (the deploy#451 contract), so the new window takes effect with no Loki restart.

**isnad-graph-only** — the deploy half (deploy#451 / noorinalabs-deploy#455) is already merged. No deploy-repo changes here.

## Related Issues

Closes #1038

## What shipped

**Backend**
- `SystemConfig` / `SystemConfigUpdate` gain `log_retention_days` — `Field(default=7, ge=1, le=365)`. Persisted + audited via the same path as every other config field.
- New `LokiSettings` (`env_prefix=LOKI_`, `runtime_overrides_path` default `/etc/loki/runtime/overrides.yaml`).
- New `src/api/loki_retention.py` — best-effort **in-place truncate-write** of Loki's runtime-overrides file (preserves the inode the `loki_runtime` volume tracks; surgical rewrite of only the `retention_period` line). Logged **no-op** when the volume/file is absent (local/dev/test); never raises — the DB write stays source of truth.
- `update_config` calls the writer **only when `log_retention_days` changes**.

**Frontend**
- `ConfigPage` gains a bounded numeric "Keep last N days of logs" control (1–365), wired into the existing PATCH save flow, styled consistently with the sibling controls.

## Enforcement contract (drives Loki via deploy#451)

The persisted `log_retention_days` is the value deploy#451's Loki `runtime_config` override consumes:

1. Admin PATCHes `log_retention_days` → persisted to Postgres (source of truth) + audited.
2. The API rewrites `overrides.<tenant>.retention_period` in `/etc/loki/runtime/overrides.yaml` (the `loki_runtime` volume, mounted **rw into api**, **read-side into loki**) as `{days*24}h`.
3. Loki re-reads `runtime_config` every 30s and applies the new `retention_period` on its next compaction — **no restart**.

Verified against the merged deploy contract (deploy#455): path `/etc/loki/runtime/overrides.yaml`; named volume `loki_runtime` shared rw between `loki-runtime-init` (seed), `api` (write), `loki` (read); tenant id `fake`; static fallback `limits_config.retention_period = 168h` (7d) when no override is present. The volume is seeded once and **not** clobbered on redeploy, so an admin-set value persists.

**RBAC:** `PATCH /api/v1/admin/config` is gated by `require_admin` (unchanged) — non-admins cannot read or set the control.

## Test plan

- `tests/test_api/test_loki_retention.py` (pure, no DB) — duration conversion, in-place rewrite with **inode preservation**, structure preservation, no-op safety (dir/file absent, key missing → not corrupted). **6/6 pass locally.**
- `tests/test_api/test_admin_config.py::TestLogRetention` — round-trip persist+read, bounds rejection (422), RBAC rejection, propagation-on-change, no-write-on-unrelated-change. DB-backed `TestClient` fixture (hangs without a live DB in the sandbox) → **covered by CI**.
- `frontend/.../ConfigPage.test.tsx` — control renders from config + PATCHes the changed value. **2/2 pass locally.**
- Local gates: `ruff check` / `ruff format --check` (src+tests) ✓, `mypy src/` ✓, frontend `eslint` (0 errors) ✓, `tsc --noEmit` ✓.

Acceptance:
- [x] `log_retention_days` settable in admin Config panel (bounded 1–365), persisted + audited
- [x] Effective-retention contract documented (drives Loki via deploy#451)
- [x] Non-admins cannot change it (RBAC)

## Review Checklist
- [ ] CI checks passing (lint, typecheck, test, security-audit)
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
- [ ] Issues closed after merge

## Must-Fix Items
None

## Tech Debt Items
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
