### PR TITLE
feat(ig#1066): observability quick-links on admin dashboard

### DIFF
--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -34,6 +34,90 @@ function StatCard({ label, value }: { label: string; value: string | number }) {
   )
 }
 
+interface ObsLink {
+  label: string
+  description: string
+  href: string
+}
+
+const OBS_LINKS: ObsLink[] = [
+  {
+    label: 'Grafana',
+    description: 'Dashboards and metrics',
+    href: '/grafana/',
+  },
+  {
+    label: 'Logs (Loki)',
+    description: 'Explore log streams via Grafana',
+    href: '/grafana/explore',
+  },
+  {
+    label: 'Alerts',
+    description: 'Active and silenced alert rules',
+    href: '/grafana/alerting/list',
+  },
+]
+
+function ObservabilitySection() {
+  return (
+    <section style={{ marginTop: 'var(--spacing-6)' }}>
+      <h3
+        style={{
+          fontFamily: 'var(--font-heading)',
+          fontSize: 'var(--text-base)',
+          marginBottom: 'var(--spacing-3)',
+        }}
+      >
+        Observability
+      </h3>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+          gap: 'var(--spacing-4)',
+        }}
+      >
+        {OBS_LINKS.map(({ label, description, href }) => (
+          <a
+            key={href}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              display: 'block',
+              padding: 'var(--spacing-4)',
+              background: 'var(--color-card)',
+              border: 'var(--border-width-thin) solid var(--color-border)',
+              borderRadius: 'var(--radius-lg)',
+              textDecoration: 'none',
+              color: 'var(--color-foreground)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 'var(--text-sm)',
+                fontWeight: 600,
+                fontFamily: 'var(--font-heading)',
+                marginBottom: 'var(--spacing-1)',
+              }}
+            >
+              {label}
+            </div>
+            <div
+              style={{
+                fontSize: 'var(--text-xs)',
+                color: 'var(--color-muted-foreground)',
+              }}
+            >
+              {description}
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 export default function DashboardPage() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['admin-dashboard-stats'],
@@ -93,6 +177,8 @@ export default function DashboardPage() {
           </table>
         </>
       )}
+
+      <ObservabilitySection />
     </div>
   )
 }

--- a/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
@@ -135,4 +135,37 @@ describe("DashboardPage", () => {
     })
     expect(container.querySelector("h2")).toBeNull()
   })
+
+  it("renders Observability section with three links using relative hrefs", async () => {
+    const stats: DashboardStats = {
+      total_users: 10,
+      active_users: 10,
+      deactivated_users: 0,
+      new_registrations_7d: 0,
+      active_sessions: 1,
+      users_by_role: [],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    await screen.findByText("Observability")
+
+    // Accessible names are the full text content of each <a>. Anchor patterns to
+    // avoid false-matches (e.g. "Logs (Loki) Explore log streams via Grafana"
+    // also contains "grafana" — use leading-word anchors instead).
+    const grafanaLink = screen.getByRole("link", { name: /^Grafana/i })
+    expect(grafanaLink).toHaveAttribute("href", "/grafana/")
+    expect(grafanaLink).toHaveAttribute("target", "_blank")
+    expect(grafanaLink).toHaveAttribute("rel", "noopener noreferrer")
+
+    const logsLink = screen.getByRole("link", { name: /^Logs/i })
+    expect(logsLink).toHaveAttribute("href", "/grafana/explore")
+    expect(logsLink).toHaveAttribute("target", "_blank")
+    expect(logsLink).toHaveAttribute("rel", "noopener noreferrer")
+
+    const alertsLink = screen.getByRole("link", { name: /^Alerts/i })
+    expect(alertsLink).toHaveAttribute("href", "/grafana/alerting/list")
+    expect(alertsLink).toHaveAttribute("target", "_blank")
+    expect(alertsLink).toHaveAttribute("rel", "noopener noreferrer")
+  })
 })


### PR DESCRIPTION
Closes #1066

## Approach

Adds an **Observability** section to `DashboardPage` below the existing stat cards and users-by-role table. Three link cards are rendered using the same inline-style card design already used in this file:

| Link | Href |
|------|------|
| Grafana | `/grafana/` |
| Logs (Loki) | `/grafana/explore` |
| Alerts | `/grafana/alerting/list` |

All three links use `target="_blank"` + `rel="noopener noreferrer"`. Hrefs are **relative** (no hardcoded hostname), relying on the Caddy reverse-proxy rule `handle /grafana/* { reverse_proxy grafana:3000 }` — correct on staging and prod automatically.

## Files changed

- `frontend/src/pages/admin/DashboardPage.tsx` — `ObsLink` type, `OBS_LINKS` constant, `ObservabilitySection` component, and mount in `DashboardPage`
- `frontend/src/pages/admin/__tests__/DashboardPage.test.tsx` — new test asserting the three links render with correct `href`, `target`, and `rel` attributes

## Verification

- `npm run build` (tsc + vite): green
- `npm run test` (Vitest, 263 tests): green
- `npm run lint` (ESLint): 0 errors, 12 pre-existing warnings (not from this change)

## Reviewers

Requesting review from @Ravi Wickramasinghe and @Marisol Vega-Cruz.