### PR TITLE
fix(ig#1065): bound search relevance to [0,100]% (normalize Lucene scores)

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -819,12 +819,16 @@ export default function SearchPage() {
  * Result card components
  * ─────────────────────────────────────────── */
 
-function RelevanceBadge({ score }: { score: number }) {
+// Exported for unit testing (ig#1065).
+export function RelevanceBadge({ score }: { score: number }) {
   const level =
     score >= 0.9 ? 'text-sahih' : score >= 0.7 ? 'text-warning' : 'text-muted-foreground'
+  // Defensive clamp: the API normalises scores to [0,1] (ig#1065), but guard
+  // here too so a stale or out-of-range value never renders >100% or negative.
+  const pct = Math.min(100, Math.max(0, score * 100)).toFixed(0)
   return (
     <span className={`text-xs font-medium ${level}`}>
-      {(score * 100).toFixed(0)}%
+      {pct}%
     </span>
   )
 }

--- a/frontend/src/pages/__tests__/SearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/SearchPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { RelevanceBadge } from '../SearchPage'
+
+describe('RelevanceBadge (ig#1065)', () => {
+  it('renders 100% for a score above 1.0, not 130%', () => {
+    render(<RelevanceBadge score={1.3} />)
+    expect(screen.getByText('100%')).toBeTruthy()
+  })
+
+  it('renders 0% for a negative score, not a negative percentage', () => {
+    render(<RelevanceBadge score={-0.2} />)
+    expect(screen.getByText('0%')).toBeTruthy()
+  })
+
+  it('renders the exact percentage for in-range scores', () => {
+    render(<RelevanceBadge score={0.75} />)
+    expect(screen.getByText('75%')).toBeTruthy()
+  })
+
+  it('renders 100% for a score of exactly 1.0', () => {
+    render(<RelevanceBadge score={1.0} />)
+    expect(screen.getByText('100%')).toBeTruthy()
+  })
+
+  it('renders 0% for a score of exactly 0', () => {
+    render(<RelevanceBadge score={0} />)
+    expect(screen.getByText('0%')).toBeTruthy()
+  })
+})

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -87,6 +87,16 @@ def search(
                 )
             )
 
+    # --- Normalize Lucene scores to [0, 1] ---
+    # Neo4j's ``db.index.fulltext.queryNodes`` returns unbounded BM25-style
+    # scores (commonly 1–5, but no upper bound). The frontend multiplies by 100
+    # to render a percentage, so a raw score of 2.5 would display as "250%".
+    # Max-normalisation maps the top result to 1.0 and preserves relative order.
+    if results:
+        max_score = max(r.score for r in results)
+        if max_score > 0:
+            results = [r.model_copy(update={"score": r.score / max_score}) for r in results]
+
     # --- Total count across both result types ---
     # The result list above is capped at ``limit``; ``total`` must reflect the
     # full count of matching narrators + hadiths so clients can paginate.
@@ -266,13 +276,16 @@ def search_semantic(
     results: list[SearchResult] = []
     for r in rows:
         snippet = r.get("matn_en") or r["matn_ar"]
+        # ``1 - cosine_distance`` is theoretically in [-1, 1]; clamp to [0, 1]
+        # so a degenerate embedding never produces a negative relevance score.
+        raw_score = float(r.get("score") or 0.0)
         results.append(
             SearchResult(
                 id=r["id"],
                 type="hadith",
                 title=snippet[:120] + "..." if len(snippet) > 120 else snippet,
                 title_ar=r["matn_ar"][:120],
-                score=float(r.get("score") or 0.0),
+                score=max(0.0, min(1.0, raw_score)),
             )
         )
 

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -42,7 +43,9 @@ def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMo
     assert body["total"] == 19
     assert len(body["results"]) == 2
     assert body["results"][0]["type"] == "narrator"
-    assert body["results"][0]["score"] == 2.5
+    # Raw Lucene scores (2.5 narrator, 1.8 hadith) are max-normalised on the
+    # API side (ig#1065): top result maps to 1.0, relative order is preserved.
+    assert body["results"][0]["score"] == pytest.approx(1.0)
     assert body["results"][1]["type"] == "hadith"
 
     # Verify the full-text query was used (CALL db.index.fulltext)
@@ -190,6 +193,64 @@ def test_search_empty_results(client: TestClient) -> None:
     body = resp.json()
     assert body["total"] == 0
     assert body["results"] == []
+
+
+def test_search_normalizes_lucene_scores_to_unit_range(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Full-text raw Lucene scores >1 are max-normalised to [0,1] (ig#1065).
+
+    Relative ordering must be preserved: the narrator (raw 2.5) outscores the
+    hadith (raw 1.8), so after normalisation both must be ≤1.0 and the narrator
+    score must remain higher.
+    """
+    mock_neo4j.execute_read.side_effect = [
+        [{"id": "nar-1", "name_ar": "نص", "name_en": "narrator", "score": 2.5}],
+        [{"id": "had-1", "matn_ar": "نص", "matn_en": "hadith text", "score": 1.8}],
+        [{"total": 1}],
+        [{"total": 1}],
+    ]
+    resp = client.get("/api/v1/search?q=test")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+
+    narrator = next(r for r in results if r["type"] == "narrator")
+    hadith = next(r for r in results if r["type"] == "hadith")
+
+    # All scores must be within [0, 1] — no "250%" badges.
+    assert narrator["score"] <= 1.0
+    assert hadith["score"] <= 1.0
+    assert narrator["score"] >= 0.0
+    assert hadith["score"] >= 0.0
+    # Top result maps to 1.0.
+    assert narrator["score"] == pytest.approx(1.0)
+    # Relative order preserved: narrator still outscores hadith.
+    assert narrator["score"] > hadith["score"]
+
+
+def test_semantic_search_clamps_negative_score(client: TestClient, app: object) -> None:
+    """Cosine similarity ``1 - distance`` can be negative; clamp to 0 (ig#1065)."""
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = [
+        [{"id": "had-1", "matn_ar": "نص", "matn_en": "hadith text", "score": -0.1}],
+        [{"total": 1}],
+    ]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Negative raw score must clamp to 0, never surface as a negative percentage.
+    assert body["results"][0]["score"] == pytest.approx(0.0)
+
+    del app.dependency_overrides[get_pg]
 
 
 def test_search_missing_query_is_noop(client: TestClient, mock_neo4j: MagicMock) -> None:


### PR DESCRIPTION
Closes #1065

## Problem

Neo4j full-text search (`db.index.fulltext.queryNodes`) returns unbounded BM25-style Lucene scores — commonly 1–5, no upper limit. The frontend `RelevanceBadge` multiplied by 100, turning a raw score of 2.5 into a "250%" badge. Cosine similarity (`1 - distance`) from pgvector can additionally be negative, producing negative percentages.

## Approach

**API-side normalization (source of truth):**
- `GET /search`: after collecting the combined narrator + hadith result list, max-normalize to [0, 1]. Top result maps to 1.0; relative ranking is preserved. Uses `model_copy(update=...)` — the idiomatic Pydantic v2 pattern for frozen models. Guards empty-list and `max_score ≤ 0` cases.
- `GET /search/semantic`: clamp each `1 - cosine_distance` to [0.0, 1.0] so degenerate embeddings never produce negative relevance.

**Defensive frontend clamp** (`RelevanceBadge`): `Math.min(100, Math.max(0, score * 100))` so any stale or out-of-range score can never render >100% or negative, even if an un-normalised score slips through in the future.

## Files changed

| File | Change |
|------|--------|
| `src/api/routes/search.py` | Max-normalize `/search` results; clamp `/search/semantic` scores |
| `frontend/src/pages/SearchPage.tsx` | Defensive clamp in `RelevanceBadge`; export for unit testing |
| `tests/test_api/test_search.py` | 2 new tests; update existing score assertion from raw 2.5 → `pytest.approx(1.0)` |
| `frontend/src/pages/__tests__/SearchPage.test.tsx` | New — 5 `RelevanceBadge` clamp/pass-through tests |

## Test results

- Backend: all new tests PASSED locally (`test_search_normalizes_lucene_scores_to_unit_range`, `test_semantic_search_clamps_negative_score`); first 5/18 pre-existing tests confirmed green
- Frontend: all 267 tests PASSED (`npm run test`)
- mypy strict: clean; ruff lint+format: clean; ESLint: clean

## Reviewers

Requesting review from @Anya-Kowalczyk and @Marisol-Vega-Cruz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)