### PR TITLE
fix(ig#1073): hide admin Observability links until forward_auth SSO ships

### DIFF
--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -58,7 +58,14 @@ const OBS_LINKS: ObsLink[] = [
   },
 ]
 
-function ObservabilitySection() {
+// Gated OFF until the app-session → Grafana SSO bridge ships (forward_auth RBAC
+// admin-gating — noorinalabs-deploy#458). Until then these links dead-end at
+// Grafana's own login wall (no single-sign-on), so we hide them rather than
+// ship a dead-end. Flip to `true` once deploy#458 lands (ig#1073).
+const OBSERVABILITY_LINKS_ENABLED = false
+
+// Exported for unit testing while the section is gated off the page (ig#1073).
+export function ObservabilitySection() {
   return (
     <section style={{ marginTop: 'var(--spacing-6)' }}>
       <h3
@@ -178,7 +185,7 @@ export default function DashboardPage() {
         </>
       )}
 
-      <ObservabilitySection />
+      {OBSERVABILITY_LINKS_ENABLED && <ObservabilitySection />}
     </div>
   )
 }

--- a/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import DashboardPage from "../DashboardPage"
+import DashboardPage, { ObservabilitySection } from "../DashboardPage"
 import { fetchDashboardStats } from "../../../api/admin-client"
 import type { DashboardStats } from "../../../api/admin-client"
 
@@ -136,7 +136,10 @@ describe("DashboardPage", () => {
     expect(container.querySelector("h2")).toBeNull()
   })
 
-  it("renders Observability section with three links using relative hrefs", async () => {
+  it("does NOT mount the Observability section while gated off (ig#1073)", async () => {
+    // The obs-links are hidden until the Grafana SSO bridge ships (deploy#458):
+    // until then they dead-end at Grafana's login. Assert the section is absent
+    // from the rendered dashboard. Re-enable assertion when deploy#458 lands.
     const stats: DashboardStats = {
       total_users: 10,
       active_users: 10,
@@ -148,11 +151,23 @@ describe("DashboardPage", () => {
     vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
     renderPage()
 
-    await screen.findByText("Observability")
+    // Dashboard has rendered (stats visible) but the Observability section is not.
+    await screen.findByText("Admin Dashboard")
+    expect(screen.queryByText("Observability")).toBeNull()
+    expect(screen.queryByRole("link", { name: /^Grafana/i })).toBeNull()
+  })
+})
 
-    // Accessible names are the full text content of each <a>. Anchor patterns to
-    // avoid false-matches (e.g. "Logs (Loki) Explore log streams via Grafana"
-    // also contains "grafana" — use leading-word anchors instead).
+describe("ObservabilitySection (gated component, ig#1073)", () => {
+  // The section is mounted off-page for now, but its markup must stay correct so
+  // flipping OBSERVABILITY_LINKS_ENABLED back on (when deploy#458 ships) is safe.
+  it("renders three links with relative hrefs, target=_blank, rel=noopener", () => {
+    render(<ObservabilitySection />)
+
+    expect(screen.getByText("Observability")).toBeTruthy()
+
+    // Leading-word anchors avoid false-matches (e.g. the Logs description also
+    // contains "Grafana").
     const grafanaLink = screen.getByRole("link", { name: /^Grafana/i })
     expect(grafanaLink).toHaveAttribute("href", "/grafana/")
     expect(grafanaLink).toHaveAttribute("target", "_blank")


### PR DESCRIPTION
Closes #1073.

## Why
The Grafana / Logs / Alerts quick-links added in ig#1066 dead-end at Grafana's own login wall — there is **no app-session → Grafana SSO** yet. Live-verified on staging: `/grafana/`, `/grafana/explore`, `/grafana/alerting/list` all 302 → `/grafana/login`. The SSO bridge (forward_auth RBAC admin-gating) is tracked in **deploy#458** for P5W4. Owner decision 2026-06-14: **hide the links until SSO ships** rather than present a dead-end (pre-launch, no users).

## Change
- `DashboardPage.tsx`: gate the `<ObservabilitySection />` mount behind `OBSERVABILITY_LINKS_ENABLED = false`, commented with the deploy#458 pointer. Re-enable in P5W4 = flip the flag to `true`.
- Export `ObservabilitySection` and keep full href/target/rel coverage via a **direct component test**, so re-enabling is safe.
- Page-level test now asserts the section is **NOT** mounted while gated.

## Verification (local, in worktree)
- `tsc --noEmit`: 0
- `eslint` (changed files): 0
- `vitest` DashboardPage suite: 8/8 pass (gated-off page test + direct component test + 6 existing)

## Re-enable (P5W4, when deploy#458 lands)
Flip `OBSERVABILITY_LINKS_ENABLED = true` and restore the page-level render assertion.

Refs: ig#1066 (added the links), deploy#458 (the SSO fix), meta-issue noorinalabs-main#681.

Reviewers: Ravi Wickramasinghe, Marisol Vega-Cruz