### PR TITLE
harden(admin): self-demote lockout guard + inline role-error surface (#988)

### DIFF
--- a/frontend/src/pages/admin/UserManagementPage.tsx
+++ b/frontend/src/pages/admin/UserManagementPage.tsx
@@ -6,7 +6,7 @@ import {
   fetchRoles,
   setUserRole,
 } from '../../api/admin-client'
-import { deriveHighestRole, type UserRole } from '../../hooks/useAuth'
+import { deriveHighestRole, useAuth, type UserRole } from '../../hooks/useAuth'
 
 // The selectable role vocabulary mirrors the user-service canonical hierarchy
 // (ontology/repos/user-service.yaml → trial | reader | researcher | admin).
@@ -19,8 +19,24 @@ function titleCase(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
+// Message shown when an admin tries to strip `admin` from their OWN row. The
+// user-service has no last-admin guard and the isnad-graph backend role route
+// is a 501 stub, so this client-side block is the only thing standing between
+// an operator and a self-inflicted lockout (recovery is the us#159 seed-admin
+// redeploy path). We block rather than confirm() so the demote can never go
+// through by reflex (ig#988).
+const SELF_DEMOTE_MESSAGE =
+  'You cannot remove admin from your own account — you could lock yourself out. ' +
+  'Ask another admin to change your role.'
+
 export default function UserManagementPage() {
   const queryClient = useQueryClient()
+  const { user: currentUser } = useAuth()
+  // Per-row error surface for role-change failures (silent before ig#988): a
+  // self-demote block or a rejected assign/remove mutation. Keyed by the user
+  // id so the message renders under the right row's select, and only one shows
+  // at a time (a fresh attempt clears the previous).
+  const [roleError, setRoleError] = useState<{ userId: string; message: string } | null>(null)
   // user-service list pagination is cursor-based (opaque `next_cursor`), not
   // page-numbered. Keep a stack of the cursors we've visited so "Previous" can
   // pop back; the first entry is `null` (the initial, un-cursored page).
@@ -54,8 +70,31 @@ export default function UserManagementPage() {
       role: string
       currentRoles: string[]
     }) => setUserRole(userId, role, currentRoles, roles ?? []),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+    onSuccess: (_data, variables) => {
+      // The assign/remove landed — clear any stale error for this row.
+      setRoleError((prev) => (prev?.userId === variables.userId ? null : prev))
+      return queryClient.invalidateQueries({ queryKey: ['admin-users'] })
+    },
+    onError: (err, variables) => {
+      // Surface the rejected mutation inline instead of failing silently.
+      setRoleError({ userId: variables.userId, message: (err as Error).message })
+    },
   })
+
+  // Guarded role change. Blocks an admin from stripping `admin` off their OWN
+  // account (self-demote lockout), otherwise runs the assign/remove mutation.
+  // A self-demote is "I am editing my own row, I currently hold admin, and the
+  // role I'm switching to is not admin" — selecting any lower role removes
+  // admin because setUserRole() collapses to exactly the chosen role.
+  const handleRoleChange = (userId: string, role: string, currentRoles: string[]) => {
+    const isSelf = !!currentUser && currentUser.id === userId
+    if (isSelf && currentRoles.includes('admin') && role !== 'admin') {
+      setRoleError({ userId, message: SELF_DEMOTE_MESSAGE })
+      return
+    }
+    setRoleError((prev) => (prev?.userId === userId ? null : prev))
+    roleMutation.mutate({ userId, role, currentRoles })
+  }
 
   const goNext = () => {
     if (data?.next_cursor) {
@@ -126,13 +165,7 @@ export default function UserManagementPage() {
                       <select
                         className="form-input w-[130px] p-1"
                         value={deriveHighestRole(currentRoles)}
-                        onChange={(e) =>
-                          roleMutation.mutate({
-                            userId: u.id,
-                            role: e.target.value,
-                            currentRoles,
-                          })
-                        }
+                        onChange={(e) => handleRoleChange(u.id, e.target.value, currentRoles)}
                         disabled={roleMutation.isPending || !roles}
                         aria-label={`Role for ${u.display_name ?? u.email}`}
                       >
@@ -142,6 +175,11 @@ export default function UserManagementPage() {
                           </option>
                         ))}
                       </select>
+                      {roleError?.userId === u.id && (
+                        <p className="error-text mt-1 max-w-[180px]" role="alert">
+                          {roleError.message}
+                        </p>
+                      )}
                     </td>
                     <td>
                       <span className={u.is_active ? 'text-active' : 'text-suspended'}>

--- a/frontend/src/pages/admin/__tests__/UserManagementPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UserManagementPage.test.tsx
@@ -17,6 +17,19 @@ vi.mock('../../../api/admin-client', () => ({
   setUserRole: vi.fn(),
 }))
 
+// Partial-mock the auth hook so the panel can read the current user's id (for
+// the self-demote guard) while keeping the real `deriveHighestRole` the page
+// also imports from this module.
+const mockUseAuth = vi.fn()
+vi.mock('../../../hooks/useAuth', async (importActual) => {
+  const actual = await importActual<typeof import('../../../hooks/useAuth')>()
+  return { ...actual, useAuth: () => mockUseAuth() }
+})
+
+// Current operator id used by default — distinct from the `u1` fixture so the
+// pre-existing role-change tests are NOT treated as self-edits.
+const SELF_ID = 'admin-self'
+
 // Role names kept as variables so the test survives any future vocab change.
 const READER = 'reader'
 const ADMIN = 'admin'
@@ -56,6 +69,7 @@ describe('UserManagementPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(fetchRoles).mockResolvedValue(CATALOG)
+    mockUseAuth.mockReturnValue({ user: { id: SELF_ID } })
   })
 
   it('shows the loading state initially', () => {
@@ -155,5 +169,62 @@ describe('UserManagementPage', () => {
     vi.mocked(fetchAdminUsers).mockResolvedValue({ items: [], next_cursor: null })
     renderPage()
     expect(await screen.findByText('No users found.')).toBeInTheDocument()
+  })
+
+  it('blocks an admin from removing admin from their OWN row and warns inline', async () => {
+    // The current operator IS this row, currently an admin.
+    mockUseAuth.mockReturnValue({ user: { id: SELF_ID } })
+    const list: AdminUserList = {
+      items: [makeUser({ id: SELF_ID, display_name: 'Me', roles: [ADMIN] })],
+      next_cursor: null,
+    }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    renderPage()
+
+    const select = (await screen.findByLabelText('Role for Me')) as HTMLSelectElement
+    await waitFor(() => expect(select.value).toBe(ADMIN))
+
+    fireEvent.change(select, { target: { value: READER } })
+
+    // Guard fires: no mutation, an inline alert, and the select stays on admin.
+    expect(setUserRole).not.toHaveBeenCalled()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/lock yourself out/i)
+    expect(select.value).toBe(ADMIN)
+  })
+
+  it('allows demoting a DIFFERENT admin (not a self-demote)', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: SELF_ID } })
+    const list: AdminUserList = {
+      items: [makeUser({ id: 'u2', display_name: 'Other', roles: [ADMIN] })],
+      next_cursor: null,
+    }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    vi.mocked(setUserRole).mockResolvedValue(undefined)
+    renderPage()
+
+    const select = (await screen.findByLabelText('Role for Other')) as HTMLSelectElement
+    await waitFor(() => expect(select.value).toBe(ADMIN))
+
+    fireEvent.change(select, { target: { value: READER } })
+
+    await waitFor(() => expect(setUserRole).toHaveBeenCalledOnce())
+    expect(setUserRole).toHaveBeenCalledWith('u2', READER, [ADMIN], CATALOG)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a failed role-change mutation inline under the row', async () => {
+    const list: AdminUserList = { items: [makeUser({ roles: [READER] })], next_cursor: null }
+    vi.mocked(fetchAdminUsers).mockResolvedValue(list)
+    vi.mocked(setUserRole).mockRejectedValue(new Error('assign failed: 409 conflict'))
+    renderPage()
+
+    const select = (await screen.findByLabelText('Role for Amina')) as HTMLSelectElement
+    await waitFor(() => expect(select.value).toBe(READER))
+
+    fireEvent.change(select, { target: { value: ADMIN } })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('assign failed: 409 conflict')
   })
 })


### PR DESCRIPTION
## Summary
Hardening follow-ups for the admin user-management panel, from the ig#805 / PR #985 review (Anya, primary). Both are client-side — the isnad-graph `/api/v1/admin/users` role route is a 501 stub and the real RBAC store is the user-service, so the panel is the only place these guards can live in this repo. A server-side last-admin guard belongs to user-service (tracked separately; us#159 is the current lockout recovery), out of scope for ig#988.

### 1. Self-demote lockout guard
An admin selecting any lower role on their **own** row removes `admin` (setUserRole collapses to exactly the chosen role) and locks them out, with no recovery short of a seed-admin redeploy. `handleRoleChange` now detects "editing my own row + I currently hold admin + target role is not admin" and **blocks** the change (no mutation), surfacing an inline warning. Block (not `confirm()`) so a reflex click can't push it through. Demoting a *different* admin is unaffected.

### 2. Inline role-change error surface
Role mutation rejections were silent. Failed assign/remove (and the self-demote block) now render a per-row `role="alert"` message under the select, keyed by user id and cleared on the next attempt / success.

## Test Plan
- `frontend` vitest: `UserManagementPage.test.tsx` — 12 pass (9 existing + 3 new):
  - self-demote on own row → `setUserRole` NOT called, inline alert shown, select stays `admin`
  - a different admin is still demotable normally (no alert)
  - a rejected mutation renders its message inline under the row
- Existing admin + auth-related suites green (54 tests); `eslint`, `tsc --noEmit`, and `npm run build` clean.
- useAuth is partial-mocked (real `deriveHighestRole` retained) to supply the current operator id.

## Review focus
- Self-demote predicate correctness in `handleRoleChange` (own-row + holds-admin + target≠admin).
- Whether block (vs warn/confirm) is the right call for the lockout guard.
- Per-row error keying / clearing in `roleError` state.

Closes #988
Refs ig#805, PR #985, us#159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
