### PR TITLE
a11y(admin): harden reset confirmation modal (Esc/focus-trap/auto-focus) + format dry-run preview (#987)

### DIFF
--- a/frontend/src/hooks/useModalA11y.ts
+++ b/frontend/src/hooks/useModalA11y.ts
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react'
+
+// Elements that can receive keyboard focus inside a modal. Disabled controls
+// and `tabindex="-1"` are excluded so the trap mirrors the browser's own
+// tab order.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+/**
+ * Wires the three keyboard-accessibility behaviours a modal dialog needs:
+ *
+ *   - **Auto-focus** — moves focus to the first focusable control on open
+ *     (falling back to the container itself if the modal has none yet).
+ *   - **Focus trap** — Tab / Shift+Tab wrap within the modal instead of
+ *     escaping to the page behind the overlay.
+ *   - **Esc-to-close** — calls `onClose` when Escape is pressed.
+ *   - **Focus restore** — returns focus to whatever was focused before the
+ *     modal opened (the trigger) when the modal unmounts.
+ *
+ * Apply the returned ref to the dialog container and give that container
+ * `tabIndex={-1}` so the container-focus fallback works.
+ *
+ * The modal is expected to be conditionally mounted/unmounted (as ResetPage
+ * mounts it), so setup runs once on mount and restore runs on unmount. `onClose`
+ * is read through a ref to keep that effect from re-running — and re-stealing
+ * focus — on every parent render.
+ */
+export function useModalA11y(onClose: () => void) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const onCloseRef = useRef(onClose)
+
+  // Keep the close callback current without re-running the setup effect below
+  // (which would re-steal focus on every parent render).
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    // Remember the trigger so focus can return to it when the modal closes.
+    const previouslyFocused = document.activeElement as HTMLElement | null
+
+    const focusables = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+
+    // Auto-focus the primary control (first focusable) on open.
+    const initial = focusables()[0]
+    if (initial) initial.focus()
+    else container.focus()
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onCloseRef.current()
+        return
+      }
+      if (event.key !== 'Tab') return
+
+      const items = focusables()
+      const first = items[0]
+      const last = items[items.length - 1]
+      if (!first || !last) {
+        // Nothing tabbable yet — keep focus pinned to the container.
+        event.preventDefault()
+        return
+      }
+      const active = document.activeElement
+
+      // Wrap at the boundaries (and reel focus back in if it has drifted
+      // outside the container entirely).
+      if (event.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else if (active === last || !container.contains(active)) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    container.addEventListener('keydown', onKeyDown)
+    return () => {
+      container.removeEventListener('keydown', onKeyDown)
+      previouslyFocused?.focus?.()
+    }
+  }, [])
+
+  return containerRef
+}

--- a/frontend/src/pages/admin/ResetPage.tsx
+++ b/frontend/src/pages/admin/ResetPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { resetStage, resetSource, resetFull, ResetError } from '../../api/admin-client'
+import { useModalA11y } from '../../hooks/useModalA11y'
 import type {
   ResetLevel,
   ResetResponse,
@@ -26,8 +27,90 @@ interface PendingReset {
   confirm: () => Promise<ResetResponse>
 }
 
-function formatSummary(summary: ResetSummary): string {
-  return typeof summary === 'string' ? summary : JSON.stringify(summary, null, 2)
+// Turns a snake_case / camelCase contract key into a human label,
+// e.g. "would_delete" → "Would delete", "kafkaTopics" → "Kafka topics".
+function humanizeKey(key: string): string {
+  const spaced = key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .trim()
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+// Renders a single summary value readably: counts get thousands separators,
+// booleans read as Yes/No, primitive arrays are comma-joined, and anything
+// still structured falls back to indented JSON (the contract is loose, so an
+// unexpected nested shape stays legible rather than breaking the page).
+function formatValue(value: unknown): string {
+  if (typeof value === 'number') return value.toLocaleString()
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (value === null || value === undefined) return '—'
+  if (Array.isArray(value) && value.every((v) => typeof v !== 'object' || v === null)) {
+    return value.length === 0 ? '—' : value.map((v) => formatValue(v)).join(', ')
+  }
+  if (typeof value === 'object') return JSON.stringify(value, null, 2)
+  return String(value)
+}
+
+// The dry-run / executed summary. A plain-string blob is shown verbatim; an
+// object blob is laid out as a readable label → value list instead of raw JSON.
+function ResetSummaryView({ summary }: { summary: ResetSummary }) {
+  if (typeof summary === 'string') {
+    return (
+      <pre
+        style={{
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          fontSize: 'var(--text-sm)',
+          marginTop: 8,
+        }}
+      >
+        {summary}
+      </pre>
+    )
+  }
+
+  const entries = Object.entries(summary)
+  if (entries.length === 0) {
+    return (
+      <p className="small-muted" style={{ marginTop: 8 }}>
+        No changes reported.
+      </p>
+    )
+  }
+
+  return (
+    <dl
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+        gap: '4px 12px',
+        margin: '8px 0 0',
+        fontSize: 'var(--text-sm)',
+      }}
+    >
+      {entries.map(([key, value]) => {
+        const formatted = formatValue(value)
+        const isBlock = formatted.includes('\n')
+        return (
+          <div key={key} style={{ display: 'contents' }}>
+            <dt className="small-muted" style={{ fontWeight: 600 }}>
+              {humanizeKey(key)}
+            </dt>
+            <dd style={{ margin: 0 }}>
+              {isBlock ? (
+                <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: 0 }}>
+                  {formatted}
+                </pre>
+              ) : (
+                formatted
+              )}
+            </dd>
+          </div>
+        )
+      })}
+    </dl>
+  )
 }
 
 // Renders a reset response — used for both the dry-run preview and the
@@ -53,16 +136,7 @@ function ResetResultPanel({ result }: { result: ResetResponse }) {
       <p className="small-muted">
         Audit entry: <code>{result.audit_entry_path}</code>
       </p>
-      <pre
-        style={{
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-          fontSize: 'var(--text-sm)',
-          marginTop: 8,
-        }}
-      >
-        {formatSummary(result.summary)}
-      </pre>
+      <ResetSummaryView summary={result.summary} />
     </div>
   )
 }
@@ -84,6 +158,9 @@ function ResetConfirmModal({
   const [obliterate, setObliterate] = useState('')
   const [busy, setBusy] = useState<'idle' | 'preview' | 'confirm'>('idle')
   const [error, setError] = useState<string | null>(null)
+
+  // Esc-to-close, focus trap, auto-focus on open, and focus restore on close.
+  const dialogRef = useModalA11y(onClose)
 
   const runDryRun = async () => {
     setError(null)
@@ -128,9 +205,11 @@ function ResetConfirmModal({
       }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="reset-modal-title"
+        tabIndex={-1}
         style={{
           background: 'var(--color-background)',
           color: 'var(--color-foreground)',

--- a/frontend/src/pages/admin/__tests__/ResetPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ResetPage.test.tsx
@@ -167,3 +167,85 @@ describe('ResetPage', () => {
     expect(resetStage).not.toHaveBeenCalled()
   })
 })
+
+describe('ResetPage — modal accessibility (#987)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('auto-focuses the primary control when the modal opens', async () => {
+    const user = userEvent.setup()
+    render(<ResetPage />)
+    await user.click(screen.getByRole('button', { name: 'Reset stage…' }))
+    expect(screen.getByRole('button', { name: 'Run dry-run preview' })).toHaveFocus()
+  })
+
+  it('closes on Escape and restores focus to the trigger', async () => {
+    const user = userEvent.setup()
+    render(<ResetPage />)
+    const trigger = screen.getByRole('button', { name: 'Reset stage…' })
+    await user.click(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // Focus returns to the control that opened the modal.
+    expect(trigger).toHaveFocus()
+  })
+
+  it('traps Tab focus inside the dialog (forward wrap)', async () => {
+    const user = userEvent.setup()
+    render(<ResetPage />)
+    await user.click(screen.getByRole('button', { name: 'Reset stage…' }))
+
+    const dryRun = screen.getByRole('button', { name: 'Run dry-run preview' })
+    const cancel = screen.getByRole('button', { name: 'Cancel' })
+    expect(dryRun).toHaveFocus()
+
+    await user.tab()
+    expect(cancel).toHaveFocus()
+    // Tabbing past the last control wraps back to the first.
+    await user.tab()
+    expect(dryRun).toHaveFocus()
+  })
+
+  it('traps Shift+Tab focus inside the dialog (backward wrap)', async () => {
+    const user = userEvent.setup()
+    render(<ResetPage />)
+    await user.click(screen.getByRole('button', { name: 'Reset stage…' }))
+
+    const dryRun = screen.getByRole('button', { name: 'Run dry-run preview' })
+    const cancel = screen.getByRole('button', { name: 'Cancel' })
+    expect(dryRun).toHaveFocus()
+
+    // Shift+Tabbing back from the first control wraps to the last.
+    await user.tab({ shift: true })
+    expect(cancel).toHaveFocus()
+  })
+
+  it('renders an object dry-run summary as a readable list, not raw JSON', async () => {
+    const user = userEvent.setup()
+    vi.mocked(resetStage).mockResolvedValueOnce(
+      makeResponse({
+        level: 'stage',
+        dry_run: true,
+        summary: { would_delete: 1234, kafka_topics: ['raw', 'dedup'] },
+      }),
+    )
+    render(<ResetPage />)
+    await user.click(screen.getByRole('button', { name: 'Reset stage…' }))
+    await user.click(screen.getByRole('button', { name: 'Run dry-run preview' }))
+    await screen.findByText(/Dry-run preview/)
+
+    // Humanized labels instead of raw snake_case keys.
+    expect(screen.getByText('Would delete')).toBeInTheDocument()
+    expect(screen.getByText('Kafka topics')).toBeInTheDocument()
+    // Count is formatted (locale-tolerant) and the array is comma-joined.
+    expect(
+      screen.getByText((content) => content.replace(/[,\s]/g, '') === '1234'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('raw, dedup')).toBeInTheDocument()
+    // The preview is not dumped as a raw JSON blob.
+    expect(screen.queryByText(/"would_delete"/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Hardens the admin pipeline-reset confirmation modal (`frontend/src/pages/admin/ResetPage.tsx`) for keyboard accessibility and makes the dry-run preview readable.

A new `useModalA11y` hook (`frontend/src/hooks/useModalA11y.ts`) provides the dialog a11y behaviours the modal was missing:

- **Esc-to-close**
- **Focus trap** — Tab / Shift+Tab wrap within the dialog instead of escaping to the page behind the overlay
- **Auto-focus** the primary control (first focusable) on open
- **Focus restore** — focus returns to the trigger when the modal closes

The close callback is read through a ref so the setup effect runs once on mount (auto-focus fires only then), not on every parent re-render — important here because typing the OBLITERATE token re-renders the parent.

**Dry-run preview formatting:** an object summary blob now renders as a humanized label → value list (`would_delete` → "Would delete", thousands-separated counts, Yes/No booleans, comma-joined primitive arrays) instead of a raw `JSON.stringify` dump. String blobs are still shown verbatim, and an unexpected nested shape falls back to indented JSON so a loose-contract addition can't break the page. The shared `ResetResultPanel` is used for both the dry-run preview and the executed result, so both read cleanly.

## Test Plan

- `npx vitest run src/pages/admin/__tests__/ResetPage.test.tsx` — 12 pass, including 5 new `#987` tests:
  - auto-focuses the primary control on open
  - closes on Escape and restores focus to the trigger
  - traps Tab focus (forward wrap)
  - traps Shift+Tab focus (backward wrap)
  - renders an object summary as a readable list, not raw JSON (locale-tolerant number assertion)
- Full suite: `npx vitest run` — 274/274 pass (no regressions)
- `npx eslint` (changed files) — clean
- `npx tsc --noEmit` (strict) — clean

## Review focus

- Focus-trap correctness in `useModalA11y` (boundary wrap logic, run-once effect via the onClose ref, focus-restore on unmount).
- `formatValue` / `ResetSummaryView` handling of the loose `ResetSummary` contract — string vs object vs nested-fallback.

Closes #987
