### PR TITLE
feat(admin): per-source graph purge action (ig#989)

### DIFF
--- a/frontend/src/api/admin-client.ts
+++ b/frontend/src/api/admin-client.ts
@@ -5,6 +5,8 @@ import type {
   UsageAnalytics,
   DataOverview,
   DataSources,
+  PurgeRequest,
+  PurgeResult,
   ResetResponse,
   ResetStage,
   FullResetRequest,
@@ -255,6 +257,29 @@ export async function fetchDataOverview(): Promise<DataOverview> {
 
 export async function fetchDataSources(): Promise<DataSources> {
   return fetchAdminJson(`${API_BASE}/data/sources`)
+}
+
+// --- Per-source graph purge (ig#989, destructive) ---
+// Hits isnad-graph's OWN admin API (same-origin, cookie-credentialed) — unlike
+// the pipeline reset below, this is a graph-level DETACH DELETE. Two-phase:
+//   * dryRun=true  → preview counts, touches nothing.
+//   * dryRun=false → requires `confirmation === sourceCorpus`; the backend
+//     rejects a mismatch with 400 (mirrors the OBLITERATE typed-confirm gate).
+// The confirmation token only travels on the real run.
+export async function purgeSource(
+  sourceCorpus: string,
+  dryRun: boolean,
+  confirmation?: string,
+): Promise<PurgeResult> {
+  const body: PurgeRequest = { source_corpus: sourceCorpus, dry_run: dryRun }
+  if (!dryRun && confirmation !== undefined) {
+    body.confirmation = confirmation
+  }
+  return fetchAdminJson(`${API_BASE}/data/purge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
 }
 
 // ============================================================================

--- a/frontend/src/pages/admin/DataManagementPage.module.css
+++ b/frontend/src/pages/admin/DataManagementPage.module.css
@@ -44,3 +44,48 @@
 .errorText {
   color: var(--color-destructive);
 }
+
+.dangerZone {
+  border: var(--border-width-thin) solid var(--color-destructive);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-6);
+}
+
+.dangerZone .sectionTitle {
+  color: var(--color-destructive);
+}
+
+.purgeControls {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-4);
+}
+
+.purgeButton {
+  background: var(--color-destructive);
+  color: var(--color-destructive-foreground);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-2) var(--spacing-4);
+  cursor: pointer;
+}
+
+.purgeButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.purgeResult {
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-4);
+  border: var(--border-width-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-card);
+}
+
+.purgeBreakdown {
+  margin: var(--spacing-2) 0 0;
+  padding-left: var(--spacing-6);
+}

--- a/frontend/src/pages/admin/DataManagementPage.tsx
+++ b/frontend/src/pages/admin/DataManagementPage.tsx
@@ -1,5 +1,7 @@
-import { useQuery } from '@tanstack/react-query'
-import { fetchDataOverview, fetchDataSources } from '../../api/admin-client'
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchDataOverview, fetchDataSources, purgeSource } from '../../api/admin-client'
+import type { PurgeResult } from '../../types/admin'
 import styles from './DataManagementPage.module.css'
 
 function StatCard({ label, value }: { label: string; value: string | number }) {
@@ -129,6 +131,145 @@ function SourcesSection() {
   )
 }
 
+function PurgeResultPanel({ result }: { result: PurgeResult }) {
+  const heading = result.deleted ? 'Purge complete' : 'Dry-run preview'
+  return (
+    <div role="status" className={styles.purgeResult}>
+      <p>
+        <strong>{heading}</strong> — source corpus <code>{result.source_corpus}</code>
+      </p>
+      <p>
+        {result.deleted ? 'Removed' : 'Would remove'} {result.total_nodes.toLocaleString()} node
+        {result.total_nodes === 1 ? '' : 's'} and{' '}
+        {result.total_relationships.toLocaleString()} relationship
+        {result.total_relationships === 1 ? '' : 's'}.
+      </p>
+      {result.node_counts.length > 0 && (
+        <ul className={styles.purgeBreakdown}>
+          {result.node_counts.map((n) => (
+            <li key={n.label}>
+              {n.label}: {n.count.toLocaleString()}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+// Danger zone: per-source GRAPH purge (ig#989). Two-phase, mirroring the reset
+// UX — a dry-run preview MUST run before the destructive control is usable, and
+// the real run stays disabled until the admin types the exact corpus name. This
+// is distinct from the ingest-platform pipeline reset (that wipes the staging
+// store; this DETACH DELETEs loaded Neo4j nodes/edges).
+function PurgeSection() {
+  const queryClient = useQueryClient()
+  const { data: sources } = useQuery({
+    queryKey: ['admin-data-sources'],
+    queryFn: fetchDataSources,
+  })
+
+  const [selected, setSelected] = useState('')
+  const [confirmText, setConfirmText] = useState('')
+  const [preview, setPreview] = useState<PurgeResult | null>(null)
+
+  // Selecting a different corpus invalidates any prior preview / typed token so
+  // a confirmation can never carry over onto a corpus it wasn't reviewed for.
+  function onSelect(value: string) {
+    setSelected(value)
+    setConfirmText('')
+    setPreview(null)
+  }
+
+  const previewMutation = useMutation({
+    mutationFn: () => purgeSource(selected, true),
+    onSuccess: (result) => setPreview(result),
+  })
+
+  const purgeMutation = useMutation({
+    mutationFn: () => purgeSource(selected, false, confirmText),
+    onSuccess: () => {
+      // Reflect the now-removed data in the inventory + provenance panels.
+      void queryClient.invalidateQueries({ queryKey: ['admin-data-overview'] })
+      void queryClient.invalidateQueries({ queryKey: ['admin-data-sources'] })
+      setConfirmText('')
+      setPreview(null)
+    },
+  })
+
+  const options = sources?.sources ?? []
+  const canPurge =
+    selected !== '' && preview !== null && confirmText === selected && !purgeMutation.isPending
+  const error = previewMutation.error ?? purgeMutation.error
+
+  return (
+    <section className={`${styles.section} ${styles.dangerZone}`}>
+      <h3 className={styles.sectionTitle}>Danger Zone — Per-source Purge</h3>
+      <p className={styles.emptyText}>
+        Permanently delete all graph nodes and relationships attributed to a single source
+        corpus. This is irreversible. Preview first, then type the corpus name to confirm.
+      </p>
+
+      <div className={styles.purgeControls}>
+        <label htmlFor="purge-source-select">Source corpus</label>
+        <select
+          id="purge-source-select"
+          value={selected}
+          onChange={(e) => onSelect(e.target.value)}
+        >
+          <option value="">Select a source…</option>
+          {options.map((s) => (
+            <option key={s.source_corpus} value={s.source_corpus}>
+              {s.source_corpus}
+            </option>
+          ))}
+        </select>
+
+        <button
+          type="button"
+          disabled={selected === '' || previewMutation.isPending}
+          onClick={() => previewMutation.mutate()}
+        >
+          {previewMutation.isPending ? 'Previewing…' : 'Preview removal'}
+        </button>
+      </div>
+
+      {error && (
+        <p role="alert" className={styles.errorText}>
+          Error: {(error as Error).message}
+        </p>
+      )}
+
+      {preview && !preview.deleted && <PurgeResultPanel result={preview} />}
+
+      {preview && !preview.deleted && (
+        <div className={styles.purgeControls}>
+          <label htmlFor="purge-confirm-input">
+            Type <code>{selected}</code> to confirm
+          </label>
+          <input
+            id="purge-confirm-input"
+            type="text"
+            value={confirmText}
+            autoComplete="off"
+            onChange={(e) => setConfirmText(e.target.value)}
+          />
+          <button
+            type="button"
+            className={styles.purgeButton}
+            disabled={!canPurge}
+            onClick={() => purgeMutation.mutate()}
+          >
+            {purgeMutation.isPending ? 'Purging…' : 'Purge graph data'}
+          </button>
+        </div>
+      )}
+
+      {purgeMutation.data?.deleted && <PurgeResultPanel result={purgeMutation.data} />}
+    </section>
+  )
+}
+
 export default function DataManagementPage() {
   return (
     <div>
@@ -138,6 +279,7 @@ export default function DataManagementPage() {
       </p>
       <OverviewSection />
       <SourcesSection />
+      <PurgeSection />
     </div>
   )
 }

--- a/frontend/src/pages/admin/__tests__/DataManagementPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DataManagementPage.test.tsx
@@ -1,13 +1,15 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import DataManagementPage from "../DataManagementPage"
-import { fetchDataOverview, fetchDataSources } from "../../../api/admin-client"
-import type { DataOverview, DataSources } from "../../../types/admin"
+import { fetchDataOverview, fetchDataSources, purgeSource } from "../../../api/admin-client"
+import type { DataOverview, DataSources, PurgeResult } from "../../../types/admin"
 
 vi.mock("../../../api/admin-client", () => ({
   fetchDataOverview: vi.fn(),
   fetchDataSources: vi.fn(),
+  purgeSource: vi.fn(),
 }))
 
 function renderPage() {
@@ -84,10 +86,13 @@ describe("DataManagementPage", () => {
     renderPage()
 
     await screen.findByText("Distinct Sources")
-    expect(screen.getByText("Provenance by Source Corpus")).toBeInTheDocument()
-    expect(screen.getByText("sunnah")).toBeInTheDocument()
-    expect(screen.getByText("40")).toBeInTheDocument()
-    expect(screen.getByText("thaqalayn")).toBeInTheDocument()
+    // Scope to the provenance section: the danger-zone purge dropdown below also
+    // renders the corpus names (as <option>s), so a bare getByText would be
+    // ambiguous.
+    const provSection = screen.getByText("Provenance by Source Corpus").closest("section")!
+    expect(within(provSection).getByText("sunnah")).toBeInTheDocument()
+    expect(within(provSection).getByText("40")).toBeInTheDocument()
+    expect(within(provSection).getByText("thaqalayn")).toBeInTheDocument()
   })
 
   it("shows empty-state copy when nothing is loaded", async () => {
@@ -110,5 +115,90 @@ describe("DataManagementPage", () => {
     })
     expect(screen.getByText("No relationships loaded.")).toBeInTheDocument()
     expect(screen.getByText("No source-attributed content loaded.")).toBeInTheDocument()
+  })
+})
+
+const PREVIEW: PurgeResult = {
+  source_corpus: "thaqalayn",
+  node_counts: [
+    { label: "Hadith", count: 7 },
+    { label: "Collection", count: 1 },
+  ],
+  relationship_counts: [{ rel_type: "APPEARS_IN", count: 7 }],
+  total_nodes: 8,
+  total_relationships: 7,
+  dry_run: true,
+  deleted: false,
+}
+
+describe("DataManagementPage — per-source purge (danger zone)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchDataOverview).mockResolvedValue(OVERVIEW)
+    vi.mocked(fetchDataSources).mockResolvedValue(SOURCES)
+  })
+
+  it("previews removal (dry run) and shows the per-label breakdown", async () => {
+    const user = userEvent.setup()
+    vi.mocked(purgeSource).mockResolvedValue(PREVIEW)
+    renderPage()
+
+    await screen.findByText("Danger Zone — Per-source Purge")
+    // The dropdown options come from the (async) sources query.
+    await screen.findByRole("option", { name: "thaqalayn" })
+    await user.selectOptions(screen.getByLabelText("Source corpus"), "thaqalayn")
+    await user.click(screen.getByRole("button", { name: "Preview removal" }))
+
+    await screen.findByText("Dry-run preview")
+    // Dry run is non-destructive — confirmation flag false.
+    expect(purgeSource).toHaveBeenCalledWith("thaqalayn", true)
+    expect(screen.getByText("Hadith: 7")).toBeInTheDocument()
+    expect(screen.getByText("Collection: 1")).toBeInTheDocument()
+  })
+
+  it("keeps the purge disabled until the exact corpus name is typed, then executes", async () => {
+    const user = userEvent.setup()
+    vi.mocked(purgeSource)
+      .mockResolvedValueOnce(PREVIEW)
+      .mockResolvedValueOnce({ ...PREVIEW, dry_run: false, deleted: true })
+    renderPage()
+
+    await screen.findByText("Danger Zone — Per-source Purge")
+    await screen.findByRole("option", { name: "thaqalayn" })
+    await user.selectOptions(screen.getByLabelText("Source corpus"), "thaqalayn")
+    await user.click(screen.getByRole("button", { name: "Preview removal" }))
+    await screen.findByText("Dry-run preview")
+
+    const purgeBtn = screen.getByRole("button", { name: "Purge graph data" })
+    expect(purgeBtn).toBeDisabled()
+
+    // A wrong token keeps it disabled.
+    const confirm = screen.getByLabelText(/to confirm/)
+    await user.type(confirm, "wrong")
+    expect(purgeBtn).toBeDisabled()
+
+    await user.clear(confirm)
+    await user.type(confirm, "thaqalayn")
+    expect(purgeBtn).toBeEnabled()
+
+    await user.click(purgeBtn)
+    await screen.findByText("Purge complete")
+    // The real run carries the typed confirmation token.
+    expect(purgeSource).toHaveBeenLastCalledWith("thaqalayn", false, "thaqalayn")
+  })
+
+  it("surfaces a backend error from the preview call", async () => {
+    const user = userEvent.setup()
+    vi.mocked(purgeSource).mockRejectedValue(new Error("purge boom"))
+    renderPage()
+
+    await screen.findByText("Danger Zone — Per-source Purge")
+    await screen.findByRole("option", { name: "sunnah" })
+    await user.selectOptions(screen.getByLabelText("Source corpus"), "sunnah")
+    await user.click(screen.getByRole("button", { name: "Preview removal" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Error: purge boom")
+    })
   })
 })

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -75,6 +75,29 @@ export interface DataSources {
   distinct_sources: number
 }
 
+// --- Per-source graph purge (ig#989) ---
+// GRAPH-level DETACH DELETE scoped to one source_corpus, served by isnad-graph's
+// own /api/v1/admin/data/purge (NOT the cross-service ingest-platform reset).
+// Two-phase: a dry run previews the node/edge counts that would be removed; a
+// real run requires `confirmation` to echo `source_corpus` exactly.
+
+export interface PurgeRequest {
+  source_corpus: string
+  dry_run: boolean
+  // Required only on a real run; must equal `source_corpus` to execute.
+  confirmation?: string
+}
+
+export interface PurgeResult {
+  source_corpus: string
+  node_counts: NodeCount[]
+  relationship_counts: RelationshipCount[]
+  total_nodes: number
+  total_relationships: number
+  dry_run: boolean
+  deleted: boolean
+}
+
 // --- Pipeline reset (ingest-platform cross-service contract, ingest#73) ---
 // The reset endpoints live in the ingest-platform service, NOT isnad-graph's
 // /api/v1/admin. These types mirror the wire contract the UI consumes.

--- a/src/api/routes/admin/data.py
+++ b/src/api/routes/admin/data.py
@@ -2,21 +2,32 @@
 
 Read-only views over the loaded graph for administrators: a node/edge
 inventory ("what is loaded") and a provenance breakdown by source corpus
-("where did it come from").  Write operations — pipeline reset, reprocess,
-and per-source purge — are intentionally out of scope here and live behind
-their own confirmation-gated surfaces.
+("where did it come from").
 
-All queries degrade gracefully to empty results when Neo4j is unavailable,
-matching the analytics/reports admin endpoints.
+This module also hosts the **per-source graph purge** (ig#989) — a
+destructive, admin-only DETACH DELETE of every node carrying a given
+``source_corpus`` provenance, behind a dry-run preview and a typed-confirmation
+gate.  This is GRAPH-level removal, distinct from the cross-service
+ingest-platform pipeline reset (ig#970, ``/admin/reset/*`` on the ingest
+origin): the reset wipes the staging/pipeline store, this wipes loaded Neo4j
+nodes/edges.  The two surfaces do not overlap.
+
+The read-only views degrade gracefully to empty results when Neo4j is
+unavailable, matching the analytics/reports admin endpoints.  The purge's
+real-run DETACH DELETE deliberately does NOT swallow Neo4j errors — a failed
+destructive write surfaces as 503 rather than silently reporting success.
 """
 
 from __future__ import annotations
 
 import structlog
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 
+from src.api.auth import User
 from src.api.deps import get_neo4j
+from src.api.middleware import require_admin
+from src.api.routes.admin.audit import create_audit_entry
 from src.utils.neo4j_client import Neo4jClient
 
 router = APIRouter(prefix="/data")
@@ -199,4 +210,196 @@ def data_sources(
         total_hadiths=sum(hadith_by_source.values()),
         total_collections=sum(collection_by_source.values()),
         distinct_sources=len(all_sources),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-source graph purge (ig#989) — destructive, admin-only.
+# ---------------------------------------------------------------------------
+
+
+class PurgeRequest(BaseModel):
+    """Request to purge all graph data carrying a single source corpus.
+
+    ``dry_run`` (the default) returns a preview of what WOULD be removed and
+    touches nothing.  A real run additionally requires ``confirmation`` to echo
+    ``source_corpus`` exactly — the per-source analogue of the ig#970 reset's
+    typed OBLITERATE token (a destructive action must be deliberately confirmed,
+    never fired by a single click).  ``extra="forbid"`` rejects unknown fields
+    so a malformed body 422s before the handler runs.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_corpus: str
+    dry_run: bool = True
+    confirmation: str | None = None
+
+
+class PurgeResult(BaseModel):
+    """Preview (dry run) or outcome (real run) of a per-source purge.
+
+    ``node_counts`` / ``relationship_counts`` describe the graph data scoped to
+    ``source_corpus`` — what would be removed on a dry run, or what was removed
+    on a real run.  ``deleted`` is False for a dry run and True once the
+    DETACH DELETE has executed.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source_corpus: str
+    node_counts: list[NodeCount]
+    relationship_counts: list[RelationshipCount]
+    total_nodes: int
+    total_relationships: int
+    dry_run: bool
+    deleted: bool
+
+
+def _purge_node_counts(neo4j: Neo4jClient, corpus: str) -> list[NodeCount]:
+    """Count, per label, the nodes carrying ``source_corpus == corpus``.
+
+    Provenance is matched on the ``source_corpus`` property — the same property
+    the inventory groups on — so the purge removes exactly the nodes the
+    ``/data/sources`` breakdown attributes to this corpus.  Degrades to an empty
+    list when Neo4j is unavailable.
+    """
+    try:
+        records = neo4j.execute_read(
+            """
+            MATCH (n)
+            WHERE n.source_corpus = $corpus
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            """,
+            {"corpus": corpus},
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("data_purge_node_count_failed", source_corpus=corpus)
+        return []
+
+    counts = [NodeCount(label=r["label"], count=r["c"]) for r in records if r.get("c")]
+    counts.sort(key=lambda c: c.count, reverse=True)
+    return counts
+
+
+def _purge_relationship_counts(neo4j: Neo4jClient, corpus: str) -> list[RelationshipCount]:
+    """Count, per type, the relationships incident to purged nodes.
+
+    DETACH DELETE removes every edge touching a deleted node, so we count edges
+    with at least one endpoint carrying ``source_corpus == corpus``.  The
+    undirected match plus ``count(DISTINCT r)`` avoids double-counting an edge
+    whose BOTH endpoints belong to the corpus.  Degrades to an empty list when
+    Neo4j is unavailable.
+    """
+    try:
+        records = neo4j.execute_read(
+            """
+            MATCH (n)-[r]-()
+            WHERE n.source_corpus = $corpus
+            RETURN type(r) AS rel_type, count(DISTINCT r) AS c
+            """,
+            {"corpus": corpus},
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("data_purge_rel_count_failed", source_corpus=corpus)
+        return []
+
+    counts = [
+        RelationshipCount(rel_type=r["rel_type"], count=r["c"])
+        for r in records
+        if r.get("c") and r.get("rel_type")
+    ]
+    counts.sort(key=lambda c: c.count, reverse=True)
+    return counts
+
+
+@router.post("/purge", response_model=PurgeResult)
+def purge_source(
+    body: PurgeRequest,
+    admin: User = Depends(require_admin),
+    neo4j: Neo4jClient = Depends(get_neo4j),
+) -> PurgeResult:
+    """Purge all graph data for a single source corpus.
+
+    Two-phase, mirroring the reset UX:
+
+    * **Dry run** (``dry_run=True``, the default) — returns the node/edge counts
+      that WOULD be removed and touches nothing.
+    * **Real run** (``dry_run=False``) — requires ``confirmation`` to equal
+      ``source_corpus`` exactly, then ``DETACH DELETE``s every node carrying
+      that provenance (and, via DETACH, all their edges) and writes an audit
+      entry.
+
+    Admin-only (the router group is gated by ``require_admin``; the explicit
+    dependency here also supplies the actor identity for the audit trail).
+    """
+    corpus = body.source_corpus.strip()
+    if not corpus:
+        raise HTTPException(status_code=422, detail="source_corpus is required")
+
+    node_counts = _purge_node_counts(neo4j, corpus)
+    relationship_counts = _purge_relationship_counts(neo4j, corpus)
+    total_nodes = sum(c.count for c in node_counts)
+    total_relationships = sum(c.count for c in relationship_counts)
+
+    if body.dry_run:
+        return PurgeResult(
+            source_corpus=corpus,
+            node_counts=node_counts,
+            relationship_counts=relationship_counts,
+            total_nodes=total_nodes,
+            total_relationships=total_relationships,
+            dry_run=True,
+            deleted=False,
+        )
+
+    # Real run — typed-confirmation gate: the caller must echo the exact corpus.
+    if body.confirmation != corpus:
+        raise HTTPException(
+            status_code=400,
+            detail="Confirmation does not match source_corpus; purge aborted.",
+        )
+
+    try:
+        neo4j.execute_write(
+            "MATCH (n) WHERE n.source_corpus = $corpus DETACH DELETE n",
+            {"corpus": corpus},
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Unlike the read-only views, a destructive write must NOT degrade to a
+        # silent "success" — surface the failure so the admin knows the graph
+        # was not modified.
+        log.error("data_purge_failed", source_corpus=corpus, error=str(exc))
+        raise HTTPException(
+            status_code=503,
+            detail="Graph store unavailable; purge was not completed.",
+        ) from exc
+
+    create_audit_entry(
+        neo4j,
+        action="data.purge_source",
+        actor_id=admin.id,
+        actor_name=admin.name,
+        details=(
+            f"Purged source_corpus '{corpus}': "
+            f"{total_nodes} nodes, {total_relationships} relationships removed."
+        ),
+    )
+    log.info(
+        "data_purge_executed",
+        source_corpus=corpus,
+        nodes=total_nodes,
+        relationships=total_relationships,
+        actor_id=admin.id,
+    )
+
+    return PurgeResult(
+        source_corpus=corpus,
+        node_counts=node_counts,
+        relationship_counts=relationship_counts,
+        total_nodes=total_nodes,
+        total_relationships=total_relationships,
+        dry_run=False,
+        deleted=True,
     )

--- a/tests/test_api/test_admin_auth.py
+++ b/tests/test_api/test_admin_auth.py
@@ -110,6 +110,13 @@ class TestAllEndpoints401:
         resp = noauth_client.patch("/api/v1/admin/users/u1", json={"is_admin": True})
         assert resp.status_code == 401
 
+    def test_post_data_purge_401(self, noauth_client: TestClient) -> None:
+        resp = noauth_client.post(
+            "/api/v1/admin/data/purge",
+            json={"source_corpus": "thaqalayn", "dry_run": True},
+        )
+        assert resp.status_code == 401
+
 
 class TestAllEndpoints404:
     """Verify every admin endpoint returns 404 (not 403) for non-admin users.
@@ -141,6 +148,13 @@ class TestAllEndpoints404:
 
     def test_patch_user_404(self, regular_client: TestClient) -> None:
         resp = regular_client.patch("/api/v1/admin/users/u1", json={"is_admin": True})
+        assert resp.status_code == 404
+
+    def test_post_data_purge_404(self, regular_client: TestClient) -> None:
+        resp = regular_client.post(
+            "/api/v1/admin/data/purge",
+            json={"source_corpus": "thaqalayn", "dry_run": True},
+        )
         assert resp.status_code == 404
 
 

--- a/tests/test_api/test_admin_data.py
+++ b/tests/test_api/test_admin_data.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-from src.api.routes.admin.data import data_overview, data_sources
+import pytest
+from fastapi import HTTPException
+
+from src.api.auth import User
+from src.api.routes.admin.data import PurgeRequest, data_overview, data_sources, purge_source
 
 
 def _loaded_read(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
@@ -111,9 +115,129 @@ class TestDataSources:
 
 
 def test_data_router_is_registered() -> None:
-    """The data sub-router is mounted under the admin group with both routes."""
+    """The data sub-router is mounted under the admin group with its routes."""
     from src.api.routes.admin import router as admin_router
 
     paths = {route.path for route in admin_router.routes}  # type: ignore[attr-defined]
     assert "/data/overview" in paths
     assert "/data/sources" in paths
+    assert "/data/purge" in paths
+
+
+def _admin() -> User:
+    return User(id="admin-1", email="admin@example.com", name="Admin One", role="admin")
+
+
+def _purge_read(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Stand-in for execute_read against a graph holding one purgeable corpus."""
+    q = " ".join(query.split())
+    corpus = (params or {}).get("corpus")
+    if corpus != "thaqalayn":
+        # An unknown corpus matches nothing — preview counts are all zero.
+        return []
+    if "UNWIND labels(n) AS label" in q:
+        return [
+            {"label": "Hadith", "c": 7},
+            {"label": "Collection", "c": 1},
+        ]
+    if "count(DISTINCT r)" in q:
+        return [
+            {"rel_type": "APPEARS_IN", "c": 7},
+            {"rel_type": "NARRATED", "c": 12},
+        ]
+    return []
+
+
+def _purge_client() -> MagicMock:
+    client = MagicMock()
+    client.execute_read.side_effect = _purge_read
+    client.execute_write.return_value = []
+    return client
+
+
+class TestPurgeSource:
+    def test_dry_run_previews_without_writing(self) -> None:
+        client = _purge_client()
+        resp = purge_source(
+            body=PurgeRequest(source_corpus="thaqalayn", dry_run=True),
+            admin=_admin(),
+            neo4j=client,
+        )
+
+        assert resp.dry_run is True
+        assert resp.deleted is False
+        assert resp.total_nodes == 8
+        assert resp.total_relationships == 19
+        by_label = {n.label: n.count for n in resp.node_counts}
+        assert by_label == {"Hadith": 7, "Collection": 1}
+        # Counts are sorted by descending count.
+        assert [n.label for n in resp.node_counts] == ["Hadith", "Collection"]
+        # A dry run NEVER writes to the graph.
+        client.execute_write.assert_not_called()
+
+    def test_real_run_requires_matching_confirmation(self) -> None:
+        client = _purge_client()
+        with pytest.raises(HTTPException) as exc:
+            purge_source(
+                body=PurgeRequest(source_corpus="thaqalayn", dry_run=False, confirmation="wrong"),
+                admin=_admin(),
+                neo4j=client,
+            )
+        assert exc.value.status_code == 400
+        # Aborted before any destructive write.
+        client.execute_write.assert_not_called()
+
+    def test_real_run_missing_confirmation_aborts(self) -> None:
+        client = _purge_client()
+        with pytest.raises(HTTPException) as exc:
+            purge_source(
+                body=PurgeRequest(source_corpus="thaqalayn", dry_run=False),
+                admin=_admin(),
+                neo4j=client,
+            )
+        assert exc.value.status_code == 400
+        client.execute_write.assert_not_called()
+
+    def test_real_run_deletes_and_audits(self) -> None:
+        client = _purge_client()
+        resp = purge_source(
+            body=PurgeRequest(source_corpus="thaqalayn", dry_run=False, confirmation="thaqalayn"),
+            admin=_admin(),
+            neo4j=client,
+        )
+
+        assert resp.dry_run is False
+        assert resp.deleted is True
+        assert resp.total_nodes == 8
+        assert resp.total_relationships == 19
+
+        writes = [c.args[0] for c in client.execute_write.call_args_list]
+        # First write is the DETACH DELETE scoped to the corpus...
+        assert "DETACH DELETE" in writes[0]
+        assert client.execute_write.call_args_list[0].args[1] == {"corpus": "thaqalayn"}
+        # ...followed by an audit-log CREATE.
+        assert any("AUDIT_LOG" in w for w in writes)
+
+    def test_blank_corpus_is_rejected(self) -> None:
+        client = _purge_client()
+        with pytest.raises(HTTPException) as exc:
+            purge_source(
+                body=PurgeRequest(source_corpus="   ", dry_run=True),
+                admin=_admin(),
+                neo4j=client,
+            )
+        assert exc.value.status_code == 422
+        client.execute_write.assert_not_called()
+
+    def test_write_failure_surfaces_503(self) -> None:
+        client = _purge_client()
+        client.execute_write.side_effect = RuntimeError("neo4j down")
+        with pytest.raises(HTTPException) as exc:
+            purge_source(
+                body=PurgeRequest(
+                    source_corpus="thaqalayn", dry_run=False, confirmation="thaqalayn"
+                ),
+                admin=_admin(),
+                neo4j=client,
+            )
+        assert exc.value.status_code == 503


### PR DESCRIPTION
## Summary

Adds an admin-only, confirmation-gated **per-source graph purge** to the admin data panel (deferred from ig#806). It removes all graph data attributed to a single `source_corpus` — `DETACH DELETE` of every Neo4j node carrying that provenance and, via DETACH, their edges.

### Backend — `src/api/routes/admin/data.py`
- `POST /api/v1/admin/data/purge`, two-phase:
  - `dry_run: true` (default) — returns the node/edge counts (by label / type) that **would** be removed; touches nothing.
  - `dry_run: false` — requires `confirmation` to equal `source_corpus` **exactly** (the per-source analogue of ig#970's typed `OBLITERATE` gate), then `DETACH DELETE`s and writes an audit-log entry (`data.purge_source`).
- RBAC: admin-only (router-group `require_admin`; the explicit dependency also supplies the audit actor identity).
- A failed destructive write surfaces **503** rather than degrading to a silent success (unlike the read-only views).

### Frontend — admin data panel danger zone
- `purgeSource()` client against isnad-graph's own same-origin admin API.
- "Danger Zone — Per-source Purge" section in `DataManagementPage`: source dropdown, dry-run **Preview removal** (shows the per-label breakdown), and a typed-confirmation gate that keeps the destructive button disabled until the exact corpus name is typed. On success the inventory + provenance panels are invalidated/refreshed.

### Overlap check (required by the issue)
ig#970's `/admin/reset/source` is a **cross-service** pipeline-store reset on the **ingest-platform** origin. This purge is **graph-level** on isnad-graph's own Neo4j. The two surfaces are distinct and do not overlap — documented in the module docstring and the client comment.

## Test Plan
- **Backend** `tests/test_api/test_admin_data.py` (13 passed locally): dry-run preview + per-label breakdown, confirmation-mismatch and missing-confirmation abort (400, no write), real-run delete + audit entry, blank-corpus 422, write-failure → 503, and `/data/purge` route registration.
- **Backend** `tests/test_api/test_admin_auth.py`: `POST /data/purge` returns 401 (no auth) and 404 (non-admin, ig#804 hide-existence). Collected locally; the TestClient suite runs in CI (it OOMs the in-sandbox runner — see the module docstring).
- **Frontend** `DataManagementPage.test.tsx` (8 passed locally): dry-run preview renders the breakdown, purge disabled until exact corpus typed then executes with the confirmation token, and backend error surfacing.
- Local: `ruff format`/`check` clean, `mypy` clean, `eslint` clean, `tsc --noEmit` clean.

## Review focus
- Purge scope correctness: `n.source_corpus = $corpus` matches the same property the inventory groups on; narrators (no `source_corpus` in the read model) are intentionally not deleted unless tagged. Confirm this matches the intended removability guarantee.
- Confirmation-gate semantics (typed corpus name == token) and the 503-on-write-failure choice.

Closes #989
