### PR TITLE
search: expose full grade vocabulary in the grade facet (#1062)

### DIFF
--- a/frontend/src/lib/__tests__/grades.test.ts
+++ b/frontend/src/lib/__tests__/grades.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest'
-import { gradeLabel, gradeColor, gradeBarColor, gradeBarWidth } from '../grades'
+import { GRADE_TOKENS, GRADE_LABELS, gradeLabel, gradeColor, gradeBarColor, gradeBarWidth } from '../grades'
+
+describe('GRADE_TOKENS', () => {
+  it('exposes the full canonical grade vocabulary, not a subset (#1062)', () => {
+    expect(new Set(GRADE_TOKENS)).toEqual(
+      new Set(['sahih', 'hasan', 'hasan_sahih', 'daif', 'mawdu', 'munkar', 'shadh']),
+    )
+  })
+
+  it('includes the grades the old hardcoded facet dropped', () => {
+    for (const token of ['munkar', 'shadh', 'hasan_sahih']) {
+      expect(GRADE_TOKENS).toContain(token)
+    }
+  })
+
+  it('stays in sync with the label map (single source of truth)', () => {
+    expect(GRADE_TOKENS).toEqual(Object.keys(GRADE_LABELS))
+  })
+})
 
 describe('grade helpers', () => {
   it('maps canonical tokens to display labels', () => {

--- a/frontend/src/lib/__tests__/searchFacets.test.ts
+++ b/frontend/src/lib/__tests__/searchFacets.test.ts
@@ -68,6 +68,24 @@ describe('matchesFacets', () => {
       ).toBe(true)
     })
 
+    it('matches the previously-unreachable compound and defect grades by canonical token (#1062)', () => {
+      // The search facet now stores canonical tokens, so the compound grade and
+      // the defect grades that the old 4-label list omitted are selectable.
+      expect(
+        matchesFacets(result({ grade: 'hasan_sahih' }), { ...NO_FACETS, gradings: ['hasan_sahih'] }),
+      ).toBe(true)
+      expect(
+        matchesFacets(result({ grade: 'munkar' }), { ...NO_FACETS, gradings: ['munkar'] }),
+      ).toBe(true)
+      expect(
+        matchesFacets(result({ grade: 'shadh' }), { ...NO_FACETS, gradings: ['shadh'] }),
+      ).toBe(true)
+      // A compound-grade hadith is not caught by a plain "sahih" selection.
+      expect(
+        matchesFacets(result({ grade: 'hasan_sahih' }), { ...NO_FACETS, gradings: ['sahih'] }),
+      ).toBe(false)
+    })
+
     it('drops a hadith whose grade token does not match', () => {
       expect(
         matchesFacets(result({ grade: 'sahih' }), { ...NO_FACETS, gradings: ['Hasan'] }),

--- a/frontend/src/lib/grades.ts
+++ b/frontend/src/lib/grades.ts
@@ -12,6 +12,12 @@ export const GRADE_LABELS: Record<string, string> = {
   shadh: 'Shadh',
 }
 
+// The full canonical grade vocabulary, in display order. Drives the search
+// page's grade facet so it can never silently drop a valid grade or drift out of
+// sync with the colour/label maps (#1062). Derived from GRADE_LABELS so a new
+// grade is added in exactly one place.
+export const GRADE_TOKENS: string[] = Object.keys(GRADE_LABELS)
+
 export function gradeLabel(token: string): string {
   return GRADE_LABELS[token] ?? token
 }

--- a/frontend/src/lib/searchFacets.ts
+++ b/frontend/src/lib/searchFacets.ts
@@ -79,8 +79,10 @@ function matchesCollection(value: string | null | undefined, selected: string[])
 function matchesGrade(value: string | null | undefined, selected: string[]): boolean {
   if (selected.length === 0) return true
   if (!value) return true
-  // `value` is already a canonical token (e.g. "sahih", "daif", "hasan_sahih");
-  // the facet labels normalize to the same tokens for the simple grades.
+  // `value` is already a canonical token (e.g. "sahih", "daif", "hasan_sahih").
+  // The search facet now stores canonical tokens too, so the compound
+  // "hasan_sahih" matches (its display label "Hasan Sahih" would normalize to
+  // "hasan sahih" and miss); plain display labels still match for simple grades.
   const v = norm(value)
   return selected.some((label) => v === norm(label))
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -27,6 +27,7 @@ import {
   DialogTrigger,
 } from '../components/ui/Dialog'
 import { matchesFacets } from '../lib/searchFacets'
+import { GRADE_TOKENS, gradeLabel } from '../lib/grades'
 
 type SearchMode = 'fulltext' | 'semantic'
 type SortOption = 'relevance' | 'date-asc' | 'date-desc' | 'name-en' | 'name-ar'
@@ -45,7 +46,12 @@ interface SearchFilters {
 // unloaded Shia collections (al-Kafi, Bihar al-Anwar) and omitted loaded ones
 // (e.g. riyadussalihin). (#1026)
 
-const GRADINGS = ['Sahih', 'Hasan', "Da'if", "Mawdu'"]
+// Grade facet options are the full canonical grade vocabulary (canonical tokens,
+// displayed via gradeLabel), not a hardcoded subset — the previous static list
+// exposed only 4 of 7 grades, leaving munkar/shadh/hasan_sahih unreachable even
+// though the API filters them correctly. Selections store the canonical token so
+// the compound "hasan_sahih" matches (its label "Hasan Sahih" would not). (#1062)
+const GRADINGS = GRADE_TOKENS
 const CENTURIES = [1, 2, 3, 4, 5]
 const TOPICS = [
   'Jurisprudence (fiqh)',
@@ -340,7 +346,7 @@ export default function SearchPage() {
               onChange={() => toggleFilter('gradings', g)}
               className="rounded"
             />
-            {g}
+            {gradeLabel(g)}
           </label>
         ))}
       </div>

--- a/src/api/routes/hadiths.py
+++ b/src/api/routes/hadiths.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
 from src.api.models import HadithFacetsResponse, HadithResponse, PaginatedResponse
-from src.utils.grades import grade_filter_clause, normalize_grade
+from src.utils.grades import GRADE_TOKENS, grade_filter_clause, normalize_grade
 from src.utils.neo4j_client import Neo4jClient
 
 # Cypher expression for the effective raw grade: prefer the traversed Grading node,
@@ -112,18 +112,16 @@ def get_hadith_facets(
         "MATCH (h:Hadith) WHERE h.source_corpus IS NOT NULL "
         "RETURN DISTINCT h.source_corpus AS corpus ORDER BY corpus"
     )
-    # Distinct raw grades across all Grading nodes (bounded ~dozens of free-text
-    # values); normalize each to its canonical token and return the present set.
-    grade_rows = neo4j.execute_read(
-        "MATCH (:Hadith)-[:GRADED_BY]->(g:Grading) "
-        "WHERE g.grade IS NOT NULL RETURN DISTINCT g.grade AS grade"
-    )
-    grades = sorted(
-        {token for row in grade_rows if (token := normalize_grade(row["grade"])) is not None}
-    )
+    # The grade facet exposes the full canonical grade vocabulary — the single
+    # source of truth in ``src.utils.grades`` — rather than only the tokens that
+    # happen to be present in the loaded corpus. Deriving it from live ``Grading``
+    # nodes silently dropped valid grades whenever the data was sparse: e.g.
+    # ``munkar``/``shadh``/``hasan_sahih`` were unreachable in the UI even though
+    # the filter (:func:`grade_filter_clause`) fully supports them (#1062). Every
+    # token here filters correctly via the ``?grade=`` param on the list endpoint.
     return HadithFacetsResponse(
         source_corpus=[row["corpus"] for row in rows],
-        grades=grades,
+        grades=sorted(GRADE_TOKENS),
     )
 
 

--- a/tests/test_api/test_hadiths.py
+++ b/tests/test_api/test_hadiths.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
+from src.utils.grades import GRADE_TOKENS
+
 SAMPLE_HADITH = {
     "id": "hdt:lk:abu_dawud:10:1574",
     "matn_ar": "إنما الأعمال بالنيات",
@@ -16,34 +18,35 @@ SAMPLE_HADITH = {
 
 
 def test_get_hadith_facets_empty(client: TestClient) -> None:
-    """GET /api/v1/hadiths/facets returns empty list when no data."""
+    """Corpus facet is empty with no data, but the grade vocabulary is corpus-independent."""
     resp = client.get("/api/v1/hadiths/facets")
     assert resp.status_code == 200
     body = resp.json()
     assert body["source_corpus"] == []
+    # The grade facet exposes the full canonical vocabulary regardless of whether
+    # any hadiths are loaded — it no longer collapses to empty on a sparse corpus
+    # (#1062), so every valid grade stays reachable as a filter.
+    assert body["grades"] == sorted(GRADE_TOKENS)
 
 
 def test_get_hadith_facets_with_data(client: TestClient, mock_neo4j: MagicMock) -> None:
-    """GET /api/v1/hadiths/facets returns distinct corpus + normalized grade values."""
-    mock_neo4j.execute_read.side_effect = [
-        # First call: corpus facets.
-        [{"corpus": "lk"}, {"corpus": "sunnah"}, {"corpus": "thaqalayn"}],
-        # Second call: raw free-text grades off Grading nodes.
-        [
-            {"grade": "Sahih - Authentic"},
-            {"grade": "Sahih-Authentic"},
-            {"grade": "Hasan Sahih"},
-            {"grade": "Da'if in chain"},
-            {"grade": "totally unknown"},
-        ],
+    """Corpus facets come from the data; the grade facet is the full canonical vocabulary."""
+    # Only the corpus query hits Neo4j now — grades are sourced from the canonical
+    # enum, not a per-corpus DISTINCT scan that silently dropped absent grades.
+    mock_neo4j.execute_read.return_value = [
+        {"corpus": "lk"},
+        {"corpus": "sunnah"},
+        {"corpus": "thaqalayn"},
     ]
     resp = client.get("/api/v1/hadiths/facets")
     assert resp.status_code == 200
     body = resp.json()
     assert body["source_corpus"] == ["lk", "sunnah", "thaqalayn"]
-    # Distinct normalized tokens, sorted; "Sahih - Authentic"/"Sahih-Authentic"
-    # collapse to one, and the unrecognized value is dropped.
-    assert body["grades"] == ["daif", "hasan_sahih", "sahih"]
+    assert body["grades"] == sorted(GRADE_TOKENS)
+    # The grades a sparse corpus used to hide are now facetable (#1062). Each one
+    # filters correctly — see test_utils/test_grades.py for the predicate proof.
+    for previously_unreachable in ("munkar", "shadh", "hasan_sahih"):
+        assert previously_unreachable in body["grades"]
 
 
 def test_list_hadiths_empty(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

The grade facet exposed only ~4 tokens, so valid hadith grades — **munkar**, **shadh**, and the compound **hasan_sahih** — were unreachable as filters even though the backend filter (`grade_filter_clause`) already supports all 7 canonical grades.

Two narrow sources caused the silent drop, both now sourced from the canonical grade vocabulary (the single source of truth) instead of a hardcoded/data-derived subset:

- **Backend** `GET /hadiths/facets` (`src/api/routes/hadiths.py`): `grades` was derived from a `DISTINCT` scan over live `Grading` nodes, so any grade absent from a sparse corpus vanished from the facet. It now returns the full canonical vocabulary `GRADE_TOKENS` (from `src/utils/grades.py`), independent of what is currently loaded. Every token filters correctly via `?grade=` on the list endpoint.
- **Frontend** `SearchPage.tsx`: the grade facet was a hardcoded 4-label list (`['Sahih','Hasan',"Da'if","Mawdu'"]`) and stored display labels — so even if "Hasan Sahih" were added, it would never match the canonical token `hasan_sahih` (space vs underscore). It now derives options from the canonical token list (`frontend/src/lib/grades.ts` `GRADE_TOKENS`), renders via `gradeLabel`, and stores the **token**, so every grade including the compound matches.

This ties both facet surfaces to the canonical enum so a valid grade can't be silently dropped again, and adding a grade happens in exactly one place per layer.

## Test Plan

- Backend `tests/test_api/test_hadiths.py`: facet endpoint now asserts the **full** vocabulary (incl. the previously-hidden `munkar`/`shadh`/`hasan_sahih`) both with and without corpus data. ✅ 43 passed locally (`test_hadiths` facet tests + full `test_utils/test_grades.py`).
- Frontend vitest: `grades.test.ts` asserts `GRADE_TOKENS` completeness + sync with the label map; `searchFacets.test.ts` asserts token-based matching for `hasan_sahih`/`munkar`/`shadh`. ✅ 33 passed.
- Filter-predicate correctness for all 7 tokens (munkar/shadh/hasan_sahih included) was already proven by the parametrized `test_filter_clause_matches_normalize_for_its_token` in `test_utils/test_grades.py`.
- `ruff format --check` + `ruff check` + `mypy` (backend) and `eslint` + `tsc --noEmit` (frontend): all clean.

Closes #1062
