### PR TITLE
fix(frontend): make /compare actually compare — controlled tabs, readable identity, real diff/analysis (#1037)

### DIFF
--- a/frontend/src/lib/__tests__/textDiff.test.ts
+++ b/frontend/src/lib/__tests__/textDiff.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import { diffTokens } from "../textDiff"
+
+describe("diffTokens", () => {
+  it("marks every token shared for identical text", () => {
+    const d = diffTokens("Actions are by intentions", "Actions are by intentions")
+    expect(d.a.every((t) => t.shared)).toBe(true)
+    expect(d.b.every((t) => t.shared)).toBe(true)
+    expect(d.sharedCount).toBe(4)
+    expect(d.overlap).toBe(1)
+  })
+
+  it("marks nothing shared for disjoint text", () => {
+    const d = diffTokens("alpha beta gamma", "delta epsilon")
+    expect(d.a.some((t) => t.shared)).toBe(false)
+    expect(d.b.some((t) => t.shared)).toBe(false)
+    expect(d.sharedCount).toBe(0)
+    expect(d.overlap).toBe(0)
+  })
+
+  it("identifies the shared subsequence and the divergent tokens", () => {
+    const d = diffTokens(
+      "the prophet said actions are by intention",
+      "the messenger said deeds are by intention",
+    )
+    // "the", "said", "are", "by", "intention" align as the common subsequence.
+    const sharedA = d.a.filter((t) => t.shared).map((t) => t.text)
+    expect(sharedA).toEqual(["the", "said", "are", "by", "intention"])
+    const divergentA = d.a.filter((t) => !t.shared).map((t) => t.text)
+    expect(divergentA).toEqual(["prophet", "actions"])
+    expect(d.sharedCount).toBe(5)
+  })
+
+  it("matches case-insensitively and ignores surrounding punctuation", () => {
+    const d = diffTokens("Allah, the Most Merciful.", "allah the most merciful")
+    expect(d.a.every((t) => t.shared)).toBe(true)
+    expect(d.sharedCount).toBe(4)
+  })
+
+  it("never treats pure punctuation as a shared token", () => {
+    const d = diffTokens("peace -- be", "war -- gone")
+    const shared = d.a.filter((t) => t.shared)
+    expect(shared).toHaveLength(0)
+  })
+
+  it("handles Arabic script tokens", () => {
+    const d = diffTokens("إنما الأعمال بالنيات", "إنما الأعمال بالنية")
+    const sharedA = d.a.filter((t) => t.shared).map((t) => t.text)
+    expect(sharedA).toEqual(["إنما", "الأعمال"])
+    expect(d.sharedCount).toBe(2)
+  })
+
+  it("is empty-input safe", () => {
+    const d = diffTokens("", "")
+    expect(d.a).toEqual([])
+    expect(d.b).toEqual([])
+    expect(d.overlap).toBe(0)
+  })
+})

--- a/frontend/src/lib/textDiff.ts
+++ b/frontend/src/lib/textDiff.ts
@@ -1,0 +1,87 @@
+// Word-level diff for comparing two hadith texts (matn or isnad). Each token is
+// classified as shared — part of the longest common subsequence of the two token
+// streams — or unique to one side, so the comparison view can highlight where two
+// parallel narrations agree and where they diverge. Works for both Latin and
+// Arabic script (matching is Unicode-letter/number aware). (#1037)
+
+export type DiffToken = {
+  text: string
+  shared: boolean
+}
+
+export type TokenDiff = {
+  a: DiffToken[]
+  b: DiffToken[]
+  sharedCount: number
+  // Shared tokens as a fraction of the longer side, in [0, 1]. A purely local
+  // signal; the API-provided similarity_score is preferred when known.
+  overlap: number
+}
+
+const NON_WORD = /[^\p{L}\p{N}]+/gu
+
+// Normalize a token for matching only: lowercase + strip non-word characters so
+// "Allah," and "allah" align. Display always uses the original token.
+function normalize(token: string): string {
+  return token.toLowerCase().replace(NON_WORD, '')
+}
+
+function tokenize(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean)
+}
+
+// Longest-common-subsequence alignment over normalized tokens. Tokens that
+// normalize to empty (pure punctuation) never count as shared.
+export function diffTokens(textA: string, textB: string): TokenDiff {
+  const tokensA = tokenize(textA)
+  const tokensB = tokenize(textB)
+  const normA = tokensA.map(normalize)
+  const normB = tokensB.map(normalize)
+
+  const m = normA.length
+  const n = normB.length
+
+  // dp[i][j] = LCS length of normA[i:] and normB[j:]. Indices are loop-bounded,
+  // so the non-null assertions below are safe (noUncheckedIndexedAccess).
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0))
+  for (let i = m - 1; i >= 0; i--) {
+    const row = dp[i]!
+    const nextRow = dp[i + 1]!
+    const ai = normA[i]!
+    for (let j = n - 1; j >= 0; j--) {
+      if (ai && ai === normB[j]) {
+        row[j] = nextRow[j + 1]! + 1
+      } else {
+        row[j] = Math.max(nextRow[j]!, row[j + 1]!)
+      }
+    }
+  }
+
+  const sharedA = new Array<boolean>(m).fill(false)
+  const sharedB = new Array<boolean>(n).fill(false)
+  let i = 0
+  let j = 0
+  let sharedCount = 0
+  while (i < m && j < n) {
+    const ai = normA[i]!
+    if (ai && ai === normB[j]) {
+      sharedA[i] = true
+      sharedB[j] = true
+      sharedCount++
+      i++
+      j++
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      i++
+    } else {
+      j++
+    }
+  }
+
+  const longer = Math.max(m, n)
+  return {
+    a: tokensA.map((text, idx) => ({ text, shared: sharedA[idx]! })),
+    b: tokensB.map((text, idx) => ({ text, shared: sharedB[idx]! })),
+    sharedCount,
+    overlap: longer === 0 ? 0 : sharedCount / longer,
+  }
+}

--- a/frontend/src/pages/ComparativePage.tsx
+++ b/frontend/src/pages/ComparativePage.tsx
@@ -1,12 +1,90 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { fetchParallelPairs, fetchHadith, searchAll } from '../api/client'
+import {
+  fetchParallelPairs,
+  fetchHadith,
+  fetchHadithParallels,
+  searchAll,
+} from '../api/client'
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
 import { Badge } from '../components/ui/Badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/Tabs'
+import { gradeColor } from '../lib/grades'
+import { diffTokens, type DiffToken } from '../lib/textDiff'
+import type { Hadith } from '../types/api'
+
+function corpusLabel(corpus: string): string {
+  if (!corpus) return ''
+  return corpus.charAt(0).toUpperCase() + corpus.slice(1)
+}
+
+// Render a token stream with divergent tokens highlighted; shared tokens render
+// plainly so agreement reads as the calm baseline and differences draw the eye.
+function DiffText({
+  tokens,
+  dir,
+  lang,
+  className,
+}: {
+  tokens: DiffToken[]
+  dir?: 'rtl' | 'ltr'
+  lang?: string
+  className?: string
+}) {
+  return (
+    <span dir={dir} lang={lang} className={className}>
+      {tokens.map((t, i) => (
+        <span key={i} className={t.shared ? undefined : 'diff-unique'}>
+          {t.text}
+          {i < tokens.length - 1 ? ' ' : ''}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function GradePill({ hadith }: { hadith: Hadith }) {
+  if (!hadith.grade_composite) return null
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${gradeColor(hadith.grade_normalized)}`}
+    >
+      {hadith.grade_composite}
+    </span>
+  )
+}
+
+// Selected-hadith chip: shows the human-readable title + matn preview + grade
+// (fetched by ID), instead of an opaque raw-ID badge. (#1037)
+function HadithChip({ id, onClear }: { id: string; onClear: () => void }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['hadith', id],
+    queryFn: () => fetchHadith(id),
+    enabled: !!id,
+  })
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap rounded-md border border-border bg-muted/30 p-2">
+      <div className="flex flex-col min-w-0">
+        <span className="font-medium text-sm">
+          {data?.display_title ?? (isLoading ? 'Loading…' : id)}
+        </span>
+        {data?.matn_en && (
+          <small className="text-muted-foreground truncate" style={{ maxWidth: '34ch' }}>
+            {data.matn_en}
+          </small>
+        )}
+      </div>
+      {data && <GradePill hadith={data} />}
+      <Button variant="ghost" size="sm" onClick={onClear}>
+        Clear
+      </Button>
+    </div>
+  )
+}
 
 function HadithSearchSelect({
   label,
@@ -33,14 +111,7 @@ function HadithSearchSelect({
     <div style={{ position: 'relative', flex: 1 }}>
       <label className="text-sm font-medium text-muted-foreground mb-1 block">{label}</label>
       {value ? (
-        <div className="flex items-center gap-2">
-          <Badge variant="secondary" className="text-sm py-1 px-3">
-            {value}
-          </Badge>
-          <Button variant="ghost" size="sm" onClick={() => onChange('')}>
-            Clear
-          </Button>
-        </div>
+        <HadithChip id={value} onClear={() => onChange('')} />
       ) : (
         <>
           <Input
@@ -66,9 +137,13 @@ function HadithSearchSelect({
                     setOpen(false)
                   }}
                 >
-                  <span className="font-medium">{r.id}</span>
+                  {/* Lead with readable title; keep the ID as secondary metadata. */}
+                  <span className="font-medium">{r.title || r.id}</span>
+                  {r.collection && (
+                    <span className="text-muted-foreground text-xs"> · {r.collection}</span>
+                  )}
                   <br />
-                  <small className="text-muted-foreground">{r.title}</small>
+                  <small className="text-muted-foreground">{r.id}</small>
                 </div>
               ))}
             </div>
@@ -76,6 +151,79 @@ function HadithSearchSelect({
         </>
       )}
     </div>
+  )
+}
+
+function AnalysisStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="analysis-stat">
+      <span className="analysis-stat-label">{label}</span>
+      <span className="analysis-stat-value">{value}</span>
+    </div>
+  )
+}
+
+type SideDiffs = {
+  matnAr: DiffToken[]
+  matnEn: DiffToken[] | null
+  isnadAr: DiffToken[] | null
+  isnadEn: DiffToken[] | null
+}
+
+function ComparisonCard({ hadith, diffs }: { hadith: Hadith; diffs: SideDiffs }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{hadith.display_title ?? hadith.id}</CardTitle>
+        <div className="flex flex-wrap items-center gap-2 mt-1">
+          <Badge variant="secondary">{corpusLabel(hadith.source_corpus)}</Badge>
+          {hadith.collection_name && (
+            <span className="text-xs text-muted-foreground">{hadith.collection_name}</span>
+          )}
+          <GradePill hadith={hadith} />
+        </div>
+      </CardHeader>
+      <CardContent>
+        {diffs.isnadAr && (
+          <div
+            dir="rtl"
+            lang="ar"
+            className="font-arabic text-sm leading-[1.8] mb-1 text-muted-foreground"
+          >
+            <DiffText tokens={diffs.isnadAr} dir="rtl" lang="ar" />
+          </div>
+        )}
+        <div
+          dir="rtl"
+          lang="ar"
+          className="font-arabic text-base leading-[1.8] mb-4 p-3 rounded-md bg-muted/30"
+        >
+          <DiffText tokens={diffs.matnAr} dir="rtl" lang="ar" />
+        </div>
+
+        {(diffs.matnEn || diffs.isnadEn) && (
+          <>
+            <hr className="border-border my-3" />
+            <div className="text-sm leading-relaxed">
+              {diffs.isnadEn && (
+                <DiffText tokens={diffs.isnadEn} className="text-muted-foreground" />
+              )}{' '}
+              {diffs.matnEn && <DiffText tokens={diffs.matnEn} />}
+            </div>
+          </>
+        )}
+
+        {hadith.topic_tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-3">
+            {hadith.topic_tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -92,6 +240,34 @@ function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
     enabled: !!idB,
   })
 
+  // The similarity score / variant type live on the PARALLEL_OF edge, so look the
+  // pair up via A's parallels. Surfaces the metric even on direct navigation, not
+  // only when arriving from a Browse row. (#1037)
+  const { data: parallels } = useQuery({
+    queryKey: ['hadith-parallels', idA],
+    queryFn: () => fetchHadithParallels(idA),
+    enabled: !!idA && !!idB,
+  })
+  const pairMeta = parallels?.parallels.find((p) => p.id === idB)
+
+  const diffs = useMemo(() => {
+    if (!hadithA || !hadithB) return null
+    const matnAr = diffTokens(hadithA.matn_ar, hadithB.matn_ar)
+    const matnEn =
+      hadithA.matn_en && hadithB.matn_en
+        ? diffTokens(hadithA.matn_en, hadithB.matn_en)
+        : null
+    const isnadAr =
+      hadithA.isnad_raw_ar && hadithB.isnad_raw_ar
+        ? diffTokens(hadithA.isnad_raw_ar, hadithB.isnad_raw_ar)
+        : null
+    const isnadEn =
+      hadithA.isnad_raw_en && hadithB.isnad_raw_en
+        ? diffTokens(hadithA.isnad_raw_en, hadithB.isnad_raw_en)
+        : null
+    return { matnAr, matnEn, isnadAr, isnadEn }
+  }, [hadithA, hadithB])
+
   if (loadingA || loadingB) {
     return (
       <div>
@@ -102,54 +278,80 @@ function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
     )
   }
 
-  if (!hadithA || !hadithB) {
+  if (!hadithA || !hadithB || !diffs) {
     return <p className="error-text">One or both hadiths could not be found.</p>
   }
 
+  const matnOverlap = diffs.matnEn?.overlap ?? diffs.matnAr.overlap
+  const sharedNarrators = diffs.isnadEn?.sharedCount ?? diffs.isnadAr?.sharedCount ?? null
+
+  const sideA: SideDiffs = {
+    matnAr: diffs.matnAr.a,
+    matnEn: diffs.matnEn?.a ?? null,
+    isnadAr: diffs.isnadAr?.a ?? null,
+    isnadEn: diffs.isnadEn?.a ?? null,
+  }
+  const sideB: SideDiffs = {
+    matnAr: diffs.matnAr.b,
+    matnEn: diffs.matnEn?.b ?? null,
+    isnadAr: diffs.isnadAr?.b ?? null,
+    isnadEn: diffs.isnadEn?.b ?? null,
+  }
+
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      {[hadithA, hadithB].map((h) => (
-        <Card key={h.id}>
-          <CardHeader>
-            <CardTitle className="text-base">
-              {h.source_corpus} &mdash; {h.id}
-            </CardTitle>
-            {h.grade_composite && (
-              <Badge variant={h.grade_composite.toLowerCase() === 'sahih' ? 'sahih' : 'outline'}>
-                {h.grade_composite}
-              </Badge>
-            )}
-          </CardHeader>
-          <CardContent>
-            <div
-              dir="rtl"
-              lang="ar"
-              className="font-arabic text-base leading-[1.8] mb-4 p-3 rounded-md bg-muted/30"
-            >
-              {h.isnad_raw_ar && (
-                <span className="text-muted-foreground">{h.isnad_raw_ar} </span>
-              )}
-              {h.matn_ar}
-            </div>
-            {h.matn_en && (
-              <>
-                <hr className="border-border my-3" />
-                <div className="text-sm leading-relaxed">
-                  {h.isnad_raw_en && (
-                    <span className="text-muted-foreground">{h.isnad_raw_en} </span>
-                  )}
-                  {h.matn_en}
-                </div>
-              </>
-            )}
-          </CardContent>
-        </Card>
-      ))}
+    <div>
+      <div className="analysis-bar" aria-label="Comparison summary">
+        <AnalysisStat
+          label="Similarity"
+          value={
+            pairMeta?.similarity_score != null
+              ? `${(pairMeta.similarity_score * 100).toFixed(1)}%`
+              : `~${Math.round(matnOverlap * 100)}% word overlap`
+          }
+        />
+        {pairMeta?.variant_type && (
+          <AnalysisStat label="Variant" value={pairMeta.variant_type.replace(/_/g, ' ')} />
+        )}
+        <AnalysisStat
+          label="Sect pairing"
+          value={
+            pairMeta
+              ? pairMeta.cross_sect
+                ? 'Cross-sect'
+                : 'Within-sect'
+              : hadithA.source_corpus === hadithB.source_corpus
+                ? 'Same corpus'
+                : 'Different corpora'
+          }
+        />
+        {sharedNarrators != null && (
+          <AnalysisStat label="Shared isnad words" value={String(sharedNarrators)} />
+        )}
+        {!pairMeta && (
+          <span className="text-xs text-muted-foreground">
+            No recorded parallel link — showing direct text comparison.
+          </span>
+        )}
+      </div>
+
+      <div className="diff-legend" aria-hidden="true">
+        <span>
+          <span className="diff-legend-swatch" style={{ background: 'var(--color-hasan-bg)' }} />
+          Differs
+        </span>
+        <span>Unhighlighted text is shared by both narrations</span>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <ComparisonCard hadith={hadithA} diffs={sideA} />
+        <ComparisonCard hadith={hadithB} diffs={sideB} />
+      </div>
     </div>
   )
 }
 
 type SectFilter = 'all' | 'cross' | 'intra'
+type SortDir = 'desc' | 'asc'
 
 const SECT_FILTERS: { value: SectFilter; label: string; crossSect?: boolean }[] = [
   { value: 'all', label: 'All parallels', crossSect: undefined },
@@ -160,11 +362,18 @@ const SECT_FILTERS: { value: SectFilter; label: string; crossSect?: boolean }[] 
 export default function ComparativePage() {
   const [page, setPage] = useState(1)
   const [sectFilter, setSectFilter] = useState<SectFilter>('all')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
 
   const compareA = searchParams.get('a') ?? ''
   const compareB = searchParams.get('b') ?? ''
+  const hasComparison = Boolean(compareA && compareB)
+
+  // Controlled tabs so the Browse "Compare" button can actually switch the view —
+  // an uncontrolled defaultValue only applies on mount, making the button a
+  // visual no-op. (#1037)
+  const [tab, setTab] = useState<'browse' | 'compare'>(hasComparison ? 'compare' : 'browse')
 
   const crossSect = SECT_FILTERS.find((f) => f.value === sectFilter)?.crossSect
 
@@ -181,6 +390,14 @@ export default function ComparativePage() {
     [searchParams, setSearchParams],
   )
 
+  const compareFromBrowse = useCallback(
+    (aId: string, bId: string) => {
+      setSearchParams({ a: aId, b: bId })
+      setTab('compare')
+    },
+    [setSearchParams],
+  )
+
   const { data, isLoading, error } = useQuery({
     queryKey: ['parallel-pairs', page, sectFilter],
     queryFn: () => fetchParallelPairs(page, 20, crossSect),
@@ -191,9 +408,23 @@ export default function ComparativePage() {
     setPage(1)
   }, [])
 
+  // Client-side sort of the current page by similarity. Nulls sort last either way.
+  const sortedItems = useMemo(() => {
+    if (!data) return []
+    const items = [...data.items]
+    items.sort((x, y) => {
+      const a = x.similarity_score
+      const b = y.similarity_score
+      if (a == null && b == null) return 0
+      if (a == null) return 1
+      if (b == null) return -1
+      return sortDir === 'desc' ? b - a : a - b
+    })
+    return items
+  }, [data, sortDir])
+
   const totalPages = data ? Math.ceil(data.total / data.limit) : 0
-  const hasParallels = data && data.items.length > 0
-  const hasComparison = compareA && compareB
+  const hasParallels = sortedItems.length > 0
 
   return (
     <div>
@@ -203,7 +434,7 @@ export default function ComparativePage() {
         (sunni-sunni, shia-shia) and across the Sunni and Shia corpora.
       </p>
 
-      <Tabs defaultValue={hasComparison ? 'compare' : 'browse'}>
+      <Tabs value={tab} onValueChange={(value) => setTab(value as 'browse' | 'compare')}>
         <TabsList>
           <TabsTrigger value="browse">Browse Parallels</TabsTrigger>
           <TabsTrigger value="compare">Compare Hadiths</TabsTrigger>
@@ -241,8 +472,9 @@ export default function ComparativePage() {
                   </div>
                   <h3 className="empty-state-heading">Select two hadiths to compare</h3>
                   <p className="empty-state-body">
-                    Search for hadiths above and select one for each side to view
-                    them side by side with their Arabic text, translations, and grades.
+                    Search for hadiths above and select one for each side to view a
+                    side-by-side analysis — Arabic text, translations, grades, and a
+                    word-level diff highlighting where the two narrations diverge.
                   </p>
                 </div>
               )}
@@ -301,30 +533,54 @@ export default function ComparativePage() {
                   <tr>
                     <th>Hadith A</th>
                     <th>Hadith B</th>
-                    <th>Similarity</th>
+                    <th
+                      className="th-sortable"
+                      onClick={() => setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))}
+                      role="button"
+                      tabIndex={0}
+                      aria-sort={sortDir === 'desc' ? 'descending' : 'ascending'}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
+                        }
+                      }}
+                    >
+                      Similarity {sortDir === 'desc' ? '↓' : '↑'}
+                    </th>
                     <th>Variant Type</th>
                     <th>Sect Pairing</th>
                     <th></th>
                   </tr>
                 </thead>
                 <tbody>
-                  {data.items.map((pair, idx) => (
+                  {sortedItems.map((pair, idx) => (
                     <tr key={`${pair.hadith_a_id}-${pair.hadith_b_id}-${idx}`}>
                       <td
-                        style={{ cursor: 'pointer', color: 'var(--color-primary)' }}
+                        style={{ cursor: 'pointer', color: 'var(--color-primary)', maxWidth: '22rem' }}
                         onClick={() => navigate(`/hadiths/${pair.hadith_a_id}`)}
                       >
-                        <span className="font-medium">{pair.hadith_a_id}</span>
+                        <span className="font-medium">
+                          {pair.hadith_a_title || pair.hadith_a_id}
+                        </span>
                         <br />
-                        <small className="text-muted-foreground">{pair.hadith_a_corpus}</small>
+                        <small className="text-muted-foreground">
+                          {corpusLabel(pair.hadith_a_corpus)}
+                          {pair.hadith_a_snippet ? ` — ${pair.hadith_a_snippet}` : ''}
+                        </small>
                       </td>
                       <td
-                        style={{ cursor: 'pointer', color: 'var(--color-primary)' }}
+                        style={{ cursor: 'pointer', color: 'var(--color-primary)', maxWidth: '22rem' }}
                         onClick={() => navigate(`/hadiths/${pair.hadith_b_id}`)}
                       >
-                        <span className="font-medium">{pair.hadith_b_id}</span>
+                        <span className="font-medium">
+                          {pair.hadith_b_title || pair.hadith_b_id}
+                        </span>
                         <br />
-                        <small className="text-muted-foreground">{pair.hadith_b_corpus}</small>
+                        <small className="text-muted-foreground">
+                          {corpusLabel(pair.hadith_b_corpus)}
+                          {pair.hadith_b_snippet ? ` — ${pair.hadith_b_snippet}` : ''}
+                        </small>
                       </td>
                       <td>
                         {pair.similarity_score != null ? (
@@ -341,9 +597,7 @@ export default function ComparativePage() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => {
-                            setSearchParams({ a: pair.hadith_a_id, b: pair.hadith_b_id })
-                          }}
+                          onClick={() => compareFromBrowse(pair.hadith_a_id, pair.hadith_b_id)}
                         >
                           Compare
                         </Button>
@@ -358,7 +612,7 @@ export default function ComparativePage() {
                   Previous
                 </button>
                 <span>
-                  Page {data.page} of {totalPages}
+                  Page {data?.page} of {totalPages}
                 </span>
                 <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
                   Next

--- a/frontend/src/pages/__tests__/ComparativePage.test.tsx
+++ b/frontend/src/pages/__tests__/ComparativePage.test.tsx
@@ -1,33 +1,74 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter } from "react-router-dom"
 import ComparativePage from "../ComparativePage"
+import {
+  fetchParallelPairs,
+  fetchHadith,
+  fetchHadithParallels,
+  searchAll,
+} from "../../api/client"
+import type { Hadith } from "../../types/api"
 
 vi.mock("../../api/client", () => ({
-  fetchParallelPairs: vi.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 }),
-  fetchHadith: vi.fn().mockResolvedValue(null),
-  searchAll: vi.fn().mockImplementation((query: string) => {
+  fetchParallelPairs: vi.fn(),
+  fetchHadith: vi.fn(),
+  fetchHadithParallels: vi.fn(),
+  searchAll: vi.fn(),
+}))
+
+const mockPairs = vi.mocked(fetchParallelPairs)
+const mockHadith = vi.mocked(fetchHadith)
+const mockParallels = vi.mocked(fetchHadithParallels)
+const mockSearch = vi.mocked(searchAll)
+
+function makeHadith(over: Partial<Hadith> & { id: string }): Hadith {
+  return {
+    matn_ar: "نص عربي",
+    matn_en: null,
+    isnad_raw_ar: null,
+    isnad_raw_en: null,
+    grade_composite: null,
+    grade_normalized: null,
+    topic_tags: [],
+    source_corpus: "sunni",
+    collection_name: null,
+    display_title: null,
+    has_shia_parallel: false,
+    has_sunni_parallel: false,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPairs.mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 })
+  mockHadith.mockResolvedValue(null as unknown as Hadith)
+  mockParallels.mockResolvedValue({ hadith_id: "", parallels: [], total: 0 })
+  mockSearch.mockImplementation((query: string) => {
     if (query === "test") {
       return Promise.resolve({
+        query,
+        total: 2,
         results: [
-          { id: "bukhari:1", type: "hadith", title: "First hadith" },
-          { id: "bukhari:2", type: "hadith", title: "Second hadith" },
+          { id: "bukhari:1", type: "hadith", title: "First hadith", title_ar: "", score: 1 },
+          { id: "bukhari:2", type: "hadith", title: "Second hadith", title_ar: "", score: 1 },
         ],
       })
     }
-    return Promise.resolve({ results: [] })
-  }),
-}))
+    return Promise.resolve({ query, total: 0, results: [] })
+  })
+})
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/compare"]) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <ComparativePage />
       </MemoryRouter>
     </QueryClientProvider>,
@@ -39,24 +80,17 @@ describe("HadithSearchSelect", () => {
     const user = userEvent.setup()
     renderPage()
 
-    // Navigate to compare tab
     await user.click(screen.getByText("Compare Hadiths"))
 
     const input = screen.getAllByPlaceholderText("Search by hadith text or ID...")[0]!
-
-    // Type to trigger search and open dropdown
     await user.type(input, "test")
 
-    // Wait for search results to appear
     await waitFor(() => {
       expect(screen.getByText("bukhari:1")).toBeInTheDocument()
     })
 
-    // Click on a dropdown item — with onPointerDown + preventDefault,
-    // the blur won't fire before the selection is processed
     await user.click(screen.getByText("bukhari:1"))
 
-    // The item should be selected (shown as a badge)
     await waitFor(() => {
       expect(screen.getByText("bukhari:1")).toBeInTheDocument()
     })
@@ -69,19 +103,215 @@ describe("HadithSearchSelect", () => {
     await user.click(screen.getByText("Compare Hadiths"))
 
     const input = screen.getAllByPlaceholderText("Search by hadith text or ID...")[0]!
-
     await user.type(input, "test")
 
     await waitFor(() => {
       expect(screen.getByText("bukhari:1")).toBeInTheDocument()
     })
 
-    // Click outside the input to trigger blur
     await user.click(document.body)
 
-    // Dropdown should close — dropdown items should no longer be visible
     await waitFor(() => {
       expect(screen.queryByText("bukhari:1")).not.toBeInTheDocument()
     })
+  })
+
+  it("leads the dropdown with the readable title, ID secondary", async () => {
+    const user = userEvent.setup()
+    const { container } = renderPage()
+    await user.click(screen.getByText("Compare Hadiths"))
+    const input = screen.getAllByPlaceholderText("Search by hadith text or ID...")[0]!
+    await user.type(input, "test")
+
+    await waitFor(() => {
+      expect(container.querySelector(".search-dropdown")).not.toBeNull()
+    })
+    // Within the dropdown, the readable title leads and the opaque ID is secondary.
+    const dropdown = container.querySelector(".search-dropdown") as HTMLElement
+    expect(within(dropdown).getByText("First hadith")).toBeInTheDocument()
+    expect(within(dropdown).getByText("bukhari:1")).toBeInTheDocument()
+  })
+})
+
+describe("Browse tab", () => {
+  const PAIR_A = {
+    hadith_a_id: "hdt:sunni:bukhari:1:1",
+    hadith_a_corpus: "bukhari",
+    hadith_a_title: "Sahih al-Bukhari 1:1",
+    hadith_a_snippet: "Actions are but by intentions.",
+    hadith_b_id: "hdt:sunni:muslim:1:1",
+    hadith_b_corpus: "muslim",
+    hadith_b_title: "Sahih Muslim 1:1",
+    hadith_b_snippet: "Deeds are by intentions.",
+    similarity_score: 0.95,
+    variant_type: "verbatim",
+    cross_sect: false,
+  }
+  const PAIR_B = {
+    hadith_a_id: "hdt:sunni:bukhari:2:9",
+    hadith_a_corpus: "bukhari",
+    hadith_a_title: "Sahih al-Bukhari 2:9",
+    hadith_a_snippet: "A weaker parallel.",
+    hadith_b_id: "hdt:shia:kafi:5",
+    hadith_b_corpus: "kafi",
+    hadith_b_title: "Al-Kafi, Hadith 5",
+    hadith_b_snippet: "Shia parallel text.",
+    similarity_score: 0.7,
+    variant_type: "paraphrase",
+    cross_sect: true,
+  }
+
+  it("renders human-readable titles and matn snippets, not opaque IDs", async () => {
+    mockPairs.mockResolvedValue({ items: [PAIR_A], total: 1, page: 1, limit: 20 })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Sahih al-Bukhari 1:1")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Sahih Muslim 1:1")).toBeInTheDocument()
+    expect(screen.getByText(/Actions are but by intentions\./)).toBeInTheDocument()
+  })
+
+  it("Compare button switches to the Compare tab (controlled Tabs)", async () => {
+    const user = userEvent.setup()
+    mockPairs.mockResolvedValue({ items: [PAIR_A], total: 1, page: 1, limit: 20 })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Sahih al-Bukhari 1:1")).toBeInTheDocument()
+    })
+
+    // Compare tab content is unmounted while Browse is active.
+    expect(screen.queryByText("Select Hadiths to Compare")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Compare" }))
+
+    // The active tab actually switched — compare panel is now mounted.
+    await waitFor(() => {
+      expect(screen.getByText("Select Hadiths to Compare")).toBeInTheDocument()
+    })
+  })
+
+  it("sorts the table by similarity when the header is toggled", async () => {
+    const user = userEvent.setup()
+    mockPairs.mockResolvedValue({ items: [PAIR_B, PAIR_A], total: 2, page: 1, limit: 20 })
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("95.0%")).toBeInTheDocument()
+    })
+
+    // Default descending: 95% precedes 70%.
+    const descScores = screen.getAllByText(/^\d+\.\d%$/).map((el) => el.textContent)
+    expect(descScores).toEqual(["95.0%", "70.0%"])
+
+    await user.click(screen.getByText(/^Similarity/))
+
+    await waitFor(() => {
+      const ascScores = screen.getAllByText(/^\d+\.\d%$/).map((el) => el.textContent)
+      expect(ascScores).toEqual(["70.0%", "95.0%"])
+    })
+  })
+})
+
+describe("ComparisonView", () => {
+  const HADITH_A = makeHadith({
+    id: "hdt:sunni:bukhari:1:1",
+    matn_en: "actions are by intention",
+    matn_ar: "إنما الأعمال بالنيات",
+    grade_composite: "Sahih",
+    grade_normalized: "sahih",
+    collection_name: "Sahih al-Bukhari",
+    display_title: "Sahih al-Bukhari 1:1",
+    topic_tags: ["ikhlas"],
+  })
+  const HADITH_B = makeHadith({
+    id: "hdt:sunni:muslim:1:1",
+    matn_en: "deeds are by intention",
+    matn_ar: "الأعمال بالنية",
+    grade_composite: "Sahih",
+    grade_normalized: "sahih",
+    collection_name: "Sahih Muslim",
+    display_title: "Sahih Muslim 1:1",
+  })
+
+  beforeEach(() => {
+    mockHadith.mockImplementation((id: string) =>
+      Promise.resolve(id === HADITH_A.id ? HADITH_A : HADITH_B),
+    )
+    mockParallels.mockResolvedValue({
+      hadith_id: HADITH_A.id,
+      parallels: [
+        {
+          id: HADITH_B.id,
+          matn_ar: HADITH_B.matn_ar,
+          matn_en: HADITH_B.matn_en,
+          source_corpus: "muslim",
+          grade: "sahih",
+          similarity_score: 0.92,
+          variant_type: "close_paraphrase",
+          cross_sect: false,
+        },
+      ],
+      total: 1,
+    })
+  })
+
+  it("shows human-readable titles instead of opaque IDs", async () => {
+    renderPage(["/compare?a=hdt:sunni:bukhari:1:1&b=hdt:sunni:muslim:1:1"])
+
+    // The readable title appears in both the selected chip and the comparison card.
+    await waitFor(() => {
+      expect(screen.getAllByText("Sahih al-Bukhari 1:1").length).toBeGreaterThanOrEqual(1)
+    })
+    expect(screen.getAllByText("Sahih Muslim 1:1").length).toBeGreaterThanOrEqual(1)
+    // The opaque ID is never the primary label.
+    expect(screen.queryByText("hdt:sunni:bukhari:1:1")).not.toBeInTheDocument()
+  })
+
+  it("surfaces the pair's similarity score and variant type", async () => {
+    renderPage(["/compare?a=hdt:sunni:bukhari:1:1&b=hdt:sunni:muslim:1:1"])
+
+    await waitFor(() => {
+      expect(screen.getByText("92.0%")).toBeInTheDocument()
+    })
+    expect(screen.getByText("close paraphrase")).toBeInTheDocument()
+  })
+
+  it("highlights divergent tokens in a word-level diff", async () => {
+    const { container } = renderPage([
+      "/compare?a=hdt:sunni:bukhari:1:1&b=hdt:sunni:muslim:1:1",
+    ])
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Sahih al-Bukhari 1:1").length).toBeGreaterThanOrEqual(1)
+    })
+
+    const highlighted = Array.from(container.querySelectorAll(".diff-unique")).map((el) =>
+      el.textContent?.trim(),
+    )
+    // "actions" (A only) and "deeds" (B only) diverge; the shared tail does not.
+    expect(highlighted).toContain("actions")
+    expect(highlighted).toContain("deeds")
+    expect(highlighted).not.toContain("intention")
+  })
+
+  it("falls back to a word-overlap metric when no parallel link is recorded", async () => {
+    // B is not among A's recorded parallels → pairMeta is undefined.
+    mockParallels.mockResolvedValue({ hadith_id: HADITH_A.id, parallels: [], total: 0 })
+    renderPage(["/compare?a=hdt:sunni:bukhari:1:1&b=hdt:sunni:muslim:1:1"])
+
+    await waitFor(() => {
+      expect(screen.getByText(/word overlap/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/No recorded parallel link/)).toBeInTheDocument()
+  })
+
+  it("renders the grade and topic tags on the compared hadith", async () => {
+    renderPage(["/compare?a=hdt:sunni:bukhari:1:1&b=hdt:sunni:muslim:1:1"])
+    await waitFor(() => {
+      expect(screen.getAllByText("Sahih").length).toBeGreaterThanOrEqual(2)
+    })
+    expect(screen.getByText("ikhlas")).toBeInTheDocument()
   })
 })

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -1109,3 +1109,76 @@
 .oauth-button-github:hover {
   background-color: var(--color-oauth-github-bg-hover);
 }
+
+/* ============================================================
+ * COMPARATIVE ANALYSIS — matn diff + analysis summary (#1037)
+ * ============================================================ */
+
+/* Summary strip above the side-by-side cards: similarity, variant, overlap. */
+.analysis-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2) var(--spacing-5);
+  align-items: center;
+  padding: var(--spacing-3) var(--spacing-4);
+  border: var(--border-width-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-muted);
+  margin-bottom: var(--spacing-6);
+}
+
+.analysis-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.analysis-stat-label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted-foreground);
+}
+
+.analysis-stat-value {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+/* Divergent tokens are highlighted; shared tokens render plainly so agreement
+   reads as the calm baseline and only the differences draw the eye. */
+.diff-unique {
+  background: var(--color-hasan-bg);
+  border-radius: var(--radius-sm);
+  padding: 0 0.15rem;
+}
+
+.diff-legend {
+  display: flex;
+  gap: var(--spacing-4);
+  align-items: center;
+  font-size: var(--text-xs);
+  color: var(--color-muted-foreground);
+  margin-bottom: var(--spacing-2);
+}
+
+.diff-legend-swatch {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: var(--radius-sm);
+  vertical-align: middle;
+  margin-right: 0.3rem;
+}
+
+/* Sortable Browse-table header cell. */
+.th-sortable {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.th-sortable:hover {
+  color: var(--color-primary);
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -145,8 +145,13 @@ export interface ParallelsResponse {
 export interface ParallelPair {
   hadith_a_id: string
   hadith_a_corpus: string
+  // Human-readable title + short matn preview for readable Browse rows (#1037).
+  hadith_a_title?: string | null
+  hadith_a_snippet?: string | null
   hadith_b_id: string
   hadith_b_corpus: string
+  hadith_b_title?: string | null
+  hadith_b_snippet?: string | null
   similarity_score: number | null
   variant_type: string | null
   cross_sect: boolean

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -340,8 +340,14 @@ class ParallelPair(BaseModel):
 
     hadith_a_id: str
     hadith_a_corpus: str
+    # Human-readable title (e.g. "Sahih al-Bukhari 1:1") and a short matn preview,
+    # so the Browse table renders readable rows instead of opaque IDs. (#1037)
+    hadith_a_title: str | None = None
+    hadith_a_snippet: str | None = None
     hadith_b_id: str
     hadith_b_corpus: str
+    hadith_b_title: str | None = None
+    hadith_b_snippet: str | None = None
     similarity_score: float | None = None
     variant_type: str | None = None
     cross_sect: bool = False

--- a/src/api/routes/parallels.py
+++ b/src/api/routes/parallels.py
@@ -13,9 +13,28 @@ from src.api.models import (
     ParallelPairsResponse,
     ParallelsResponse,
 )
+from src.api.routes.hadiths import _format_display_title
 from src.utils.neo4j_client import Neo4jClient
 
 router = APIRouter()
+
+# Maximum characters of matn surfaced as a Browse-row preview.
+_SNIPPET_CHARS = 140
+
+
+def _matn_snippet(matn_en: str | None, matn_ar: str | None) -> str | None:
+    """Build a short, single-line matn preview, preferring the English translation.
+
+    Returns ``None`` when neither translation is available so the frontend can
+    fall back to title-only rendering.
+    """
+    text = (matn_en or matn_ar or "").strip()
+    if not text:
+        return None
+    text = " ".join(text.split())
+    if len(text) <= _SNIPPET_CHARS:
+        return text
+    return text[:_SNIPPET_CHARS].rstrip() + "…"
 
 
 @router.get("/parallels", response_model=ParallelPairsResponse)
@@ -51,7 +70,11 @@ def list_parallels(
         MATCH (a:Hadith)-[r:PARALLEL_OF]->(b:Hadith)
         {where}
         RETURN a.id AS a_id, a.source_corpus AS a_corpus,
+               a.collection_name AS a_collection,
+               a.matn_en AS a_matn_en, a.matn_ar AS a_matn_ar,
                b.id AS b_id, b.source_corpus AS b_corpus,
+               b.collection_name AS b_collection,
+               b.matn_en AS b_matn_en, b.matn_ar AS b_matn_ar,
                r.similarity_score AS similarity_score,
                r.variant_type AS variant_type,
                r.cross_sect AS cross_sect
@@ -66,8 +89,12 @@ def list_parallels(
         ParallelPair(
             hadith_a_id=r["a_id"],
             hadith_a_corpus=r.get("a_corpus", ""),
+            hadith_a_title=_format_display_title(r["a_id"], r.get("a_collection")),
+            hadith_a_snippet=_matn_snippet(r.get("a_matn_en"), r.get("a_matn_ar")),
             hadith_b_id=r["b_id"],
             hadith_b_corpus=r.get("b_corpus", ""),
+            hadith_b_title=_format_display_title(r["b_id"], r.get("b_collection")),
+            hadith_b_snippet=_matn_snippet(r.get("b_matn_en"), r.get("b_matn_ar")),
             similarity_score=r.get("similarity_score"),
             variant_type=r.get("variant_type"),
             cross_sect=bool(r.get("cross_sect", False)),

--- a/tests/test_api/test_parallels.py
+++ b/tests/test_api/test_parallels.py
@@ -15,19 +15,31 @@ from .routes import PARALLELS
 # An intra-sect (sunni-sunni) pair and a cross-sect (sunni-shia) pair, proving the
 # Browse feed is not restricted to cross-sect pairings.
 INTRA_PAIR = {
-    "a_id": "hadith:bukhari:1",
+    "a_id": "hdt:sunni:bukhari:1:1",
     "a_corpus": "bukhari",
-    "b_id": "hadith:muslim:1",
+    "a_collection": "Sahih al-Bukhari",
+    "a_matn_en": "Actions are but by intentions.",
+    "a_matn_ar": "إنما الأعمال بالنيات",
+    "b_id": "hdt:sunni:muslim:1:1",
     "b_corpus": "muslim",
+    "b_collection": "Sahih Muslim",
+    "b_matn_en": "Deeds are by intentions.",
+    "b_matn_ar": "الأعمال بالنية",
     "similarity_score": 0.97,
     "variant_type": "verbatim",
     "cross_sect": False,
 }
 CROSS_PAIR = {
-    "a_id": "hadith:bukhari:2",
+    "a_id": "hdt:sunni:bukhari:2:9",
     "a_corpus": "bukhari",
-    "b_id": "hadith:kafi:5",
+    "a_collection": "Sahih al-Bukhari",
+    "a_matn_en": None,
+    "a_matn_ar": None,
+    "b_id": "hdt:shia:kafi:5",
     "b_corpus": "kafi",
+    "b_collection": "Al-Kafi",
+    "b_matn_en": None,
+    "b_matn_ar": None,
     "similarity_score": 0.88,
     "variant_type": "close_paraphrase",
     "cross_sect": True,
@@ -54,8 +66,42 @@ def test_list_parallels_spans_both_sects(client: TestClient, mock_neo4j: MagicMo
     assert body["total"] == 2
     assert {p["cross_sect"] for p in body["items"]} == {False, True}
     intra = next(p for p in body["items"] if not p["cross_sect"])
-    assert intra["hadith_a_id"] == "hadith:bukhari:1"
+    assert intra["hadith_a_id"] == "hdt:sunni:bukhari:1:1"
     assert intra["hadith_b_corpus"] == "muslim"
+
+
+def test_list_parallels_enriches_rows_with_title_and_snippet(
+    client: TestClient, mock_neo4j: MagicMock
+) -> None:
+    """Each Browse row carries a human-readable title and a matn preview (#1037)."""
+    mock_neo4j.execute_read.side_effect = [[{"total": 2}], [INTRA_PAIR, CROSS_PAIR]]
+    resp = client.get(PARALLELS)
+    assert resp.status_code == 200
+    intra = next(p for p in resp.json()["items"] if not p["cross_sect"])
+    # Title derived from collection_name + the book:hadith tail of the ID.
+    assert intra["hadith_a_title"] == "Sahih al-Bukhari 1:1"
+    assert intra["hadith_b_title"] == "Sahih Muslim 1:1"
+    # Snippet prefers the English translation.
+    assert intra["hadith_a_snippet"] == "Actions are but by intentions."
+
+    # When a hadith has neither translation, the snippet is null (title-only row).
+    cross = next(p for p in resp.json()["items"] if p["cross_sect"])
+    assert cross["hadith_a_snippet"] is None
+    assert cross["hadith_a_title"] == "Sahih al-Bukhari 2:9"
+
+
+def test_list_parallels_truncates_long_snippet(client: TestClient, mock_neo4j: MagicMock) -> None:
+    """A long matn is clipped to a single-line preview with an ellipsis (#1037)."""
+    long_pair = {
+        **INTRA_PAIR,
+        "a_matn_en": "word " * 80,  # ~400 chars
+    }
+    mock_neo4j.execute_read.side_effect = [[{"total": 1}], [long_pair]]
+    resp = client.get(PARALLELS)
+    snippet = resp.json()["items"][0]["hadith_a_snippet"]
+    assert snippet is not None
+    assert snippet.endswith("…")
+    assert len(snippet) <= 141  # 140 chars + ellipsis
 
 
 def test_list_parallels_no_facet_omits_where_clause(


### PR DESCRIPTION
## Summary
Fixes `/compare` (ComparativePage, "Comparative Analysis") usability across both tabs — addresses isnad-graph#1037.

1. **Compare-tab switch no longer a no-op.** The DS `Tabs` re-export is uncontrolled, so `defaultValue` only applied on mount and the Browse-row "Compare" button silently did nothing. `Tabs` is now controlled (`value`/`onValueChange`); the button switches to the Compare view (and direct `?a=&b=` navigation opens on Compare).
2. **Human-readable hadith identity, not opaque IDs.** The selected-hadith chip fetches the hadith and shows its `display_title` + matn preview + grade. The search dropdown leads with the readable title; the ID is secondary.
3. **Real analysis.** The Compare view surfaces the pair's **similarity score + variant type** (resolved via the hadith's `PARALLEL_OF` parallels, so it works even on direct navigation), a **word-level matn diff** that highlights where the two narrations diverge (LCS token alignment, Arabic + English), and **shared-isnad highlighting**. When no parallel link is recorded it falls back to a computed word-overlap metric.
4. **Browse table is no longer text-light.** Rows now show readable titles + a matn snippet and a client-side **sort-by-similarity** toggle. The backend `/parallels` list is enriched with `hadith_a/b_title` (display title reused from the hadiths route) and `hadith_a/b_snippet` (English-preferred matn preview, clipped to 140 chars; null when no translation).

i18n (#1035) is intentionally out of scope, per the issue.

## Changes
- `frontend/src/pages/ComparativePage.tsx` — controlled tabs, `HadithChip`, readable dropdown, analysis bar + diff cards, browse enrichment + sort.
- `frontend/src/lib/textDiff.ts` (new) — LCS word-diff utility (Latin + Arabic aware).
- `frontend/src/types/api.ts` — optional `hadith_a/b_title` + `hadith_a/b_snippet` on `ParallelPair`.
- `frontend/src/styles/common.css` — analysis-bar, diff-highlight, sortable-header styles (design tokens).
- `src/api/models.py`, `src/api/routes/parallels.py` — enrich Browse rows with title + matn snippet.

## Test Plan
- **Frontend** — `npx vitest run`: **285/285 pass** (new `lib/__tests__/textDiff.test.ts` 7 tests; `ComparativePage.test.tsx` covers controlled-tab switch, readable identity, diff highlighting, similarity/variant surfacing, browse sort). `tsc --noEmit` clean. ESLint clean.
- **Backend** — `pytest tests/test_api/test_parallels.py`: **9/9 pass** (new cases: title/snippet enrichment, null-translation snippet, long-snippet truncation). `mypy` + `ruff` (format + lint) clean.
  - Note: the API pytest only completes locally with the `RateLimitMiddleware` Redis ping neutralized — in this network-less sandbox the per-request `redis.ping()` blocks on a connection timeout. This is environmental (affects every API test equally, not this change); CI has Redis. The route behavior was additionally verified end-to-end against the real `/api/v1/parallels` endpoint with a mocked Neo4j (title/snippet/truncation/sect-spanning all confirmed).

## Review focus
- @Ravi-Wickramasinghe — UX of the analysis bar + diff highlighting (shared = calm baseline, divergent = highlighted), readable identity in chip/dropdown/browse.
- @Marisol-Vega-Cruz — test coverage of the controlled-tab fix and the diff/enrichment; the offline-Redis test caveat above.

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
