### PR TITLE
feat(search): canonical topic-facet vocabulary (#1061)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -135,6 +135,13 @@ Sunnah
 Bukhari
 Muslim
 sectarian
+# topic facet vocabulary (#1061) — cspell is case-insensitive, lowercase covers both
+akhlaq
+aqidah
+fiqh
+ibadah
+sira
+tafsir
 ontology
 Pydantic
 structlog

--- a/docs/search-topic-vocabulary.md
+++ b/docs/search-topic-vocabulary.md
@@ -1,0 +1,67 @@
+# Search topic facet — canonical vocabulary
+
+The search/hadith **topic facet** filters hadiths by subject. Hadith documents
+carry a free-text `topic_tags` list that is sparse and unnormalized (it comes
+from heterogeneous upstream sources), so the facet used to be "best-effort": a
+hardcoded label list fuzzy-matched against whatever tags happened to exist. That
+was noisy, incomplete, and drifted from the data (isnad-graph#1061).
+
+This document describes the canonical vocabulary that replaced it.
+
+## Single source of truth
+
+`src/utils/topics.py` is the **only** place the vocabulary is defined. Adding,
+removing, or renaming a topic is a deliberate edit to `TOPIC_LABELS` there. Both
+the backend facet aggregation and the frontend facet UI consume that one
+definition — the frontend never hardcodes topic labels; it reads them from the
+API (`/api/v1/hadiths/facets`).
+
+## Canonical topics
+
+| Token | Display label |
+|-------|---------------|
+| `aqidah` | Theology (Aqidah) |
+| `ibadah` | Worship (Ibadah) |
+| `fiqh` | Jurisprudence (Fiqh) |
+| `akhlaq` | Ethics (Akhlaq) |
+| `quran` | Qur'an & Tafsir |
+| `sira` | History & Biography (Sira) |
+| `knowledge` | Knowledge ('Ilm) |
+| `eschatology` | Eschatology |
+| `uncategorized` | Uncategorized (synthetic bucket) |
+
+## How tags map onto the vocabulary
+
+`normalize_topic(tag)` folds a free-text tag (lowercase, underscore/hyphen →
+space, apostrophe-stripped) and returns the first canonical token whose keyword
+group matches a substring of it, or `None`. The keyword groups (`_KEYWORDS`) are
+ordered by priority, so specific topics (eschatology, qur'an, sira) are checked
+before the broad legal catch-all (fiqh).
+
+- A hadith maps to the **distinct set** of canonical tokens its tags resolve to
+  (a hadith can appear under several topics).
+- A hadith whose tags resolve to **nothing** — or that carries no tags at all —
+  falls into the `uncategorized` bucket. Documents are never dropped, so the
+  facet counts always cover the full corpus.
+
+## API & UI surface
+
+- `GET /api/v1/hadiths/facets` returns `topics: [{value, label, count}]`. The
+  **full** vocabulary is always returned (including zero-count topics) so the
+  facet is stable regardless of how sparse the tags are; the `uncategorized`
+  bucket is always appended last.
+- Search results (`GET /api/v1/search`) carry `topics` as the canonical tokens
+  the hadith maps onto, so the search page's client-side filtering matches on a
+  stable token set rather than fuzzy substrings. An empty `topics` is treated
+  permissively (kept visible under any filter) so tag-less hadiths and semantic
+  hits don't disappear; selecting only the `uncategorized` bucket isolates them.
+
+## Follow-up — denser, source-of-truth topics
+
+The keyword mapping is a deterministic bridge over the *currently sparse* tags.
+The durable improvement is upstream: real per-hadith topic classification in the
+enrich stage (see `src/enrich/__init__.py` and `models.enrich.TopicResult`,
+tracked as future work). When that lands, hadiths would carry a stored canonical
+topic and this module would normalize/validate against the same vocabulary
+rather than infer it from sparse tags. Densifying `topic_tags` is therefore a
+**data/ingest follow-up**, out of scope for the facet itself.

--- a/frontend/src/lib/__tests__/searchFacets.test.ts
+++ b/frontend/src/lib/__tests__/searchFacets.test.ts
@@ -127,23 +127,29 @@ describe('matchesFacets', () => {
   })
 
   describe('topic facet', () => {
-    it('matches a topic tag against the parenthetical token of the label', () => {
-      const r = result({ type: 'hadith', topics: ['fiqh', 'prayer'] })
-      expect(matchesFacets(r, { ...NO_FACETS, topics: ['Jurisprudence (fiqh)'] })).toBe(true)
+    // `topics` holds canonical tokens (the backend maps free-text tags onto the
+    // vocabulary); the selection holds the same tokens. (#1061)
+    it('matches when a selected canonical token is present', () => {
+      const r = result({ type: 'hadith', topics: ['fiqh', 'ibadah'] })
+      expect(matchesFacets(r, { ...NO_FACETS, topics: ['fiqh'] })).toBe(true)
     })
 
-    it('matches a single-word label with no parenthetical', () => {
-      const r = result({ type: 'hadith', topics: ['eschatology'] })
-      expect(matchesFacets(r, { ...NO_FACETS, topics: ['Eschatology'] })).toBe(true)
+    it('drops a hadith with no overlapping canonical topic', () => {
+      const r = result({ type: 'hadith', topics: ['fiqh'] })
+      expect(matchesFacets(r, { ...NO_FACETS, topics: ['aqidah'] })).toBe(false)
     })
 
-    it('drops a hadith with no overlapping topic', () => {
-      const r = result({ type: 'hadith', topics: ['inheritance'] })
-      expect(matchesFacets(r, { ...NO_FACETS, topics: ['Theology (aqidah)'] })).toBe(false)
+    it('keeps a hadith with no topics under any topic filter (permissive)', () => {
+      expect(
+        matchesFacets(result({ type: 'hadith', topics: [] }), { ...NO_FACETS, topics: ['aqidah'] }),
+      ).toBe(true)
     })
 
-    it('keeps a hadith with no topic tags', () => {
-      expect(matchesFacets(result({ type: 'hadith', topics: [] }), { ...NO_FACETS, topics: ['Theology (aqidah)'] })).toBe(true)
+    it('uncategorized selection isolates empty-topic results, dropping categorized ones', () => {
+      const empty = result({ type: 'hadith', topics: [] })
+      const categorized = result({ type: 'hadith', topics: ['fiqh'] })
+      expect(matchesFacets(empty, { ...NO_FACETS, topics: ['uncategorized'] })).toBe(true)
+      expect(matchesFacets(categorized, { ...NO_FACETS, topics: ['uncategorized'] })).toBe(false)
     })
   })
 
@@ -154,7 +160,7 @@ describe('matchesFacets', () => {
         collections: ['Sahih al-Bukhari'],
         gradings: ['Sahih'],
         centuries: [],
-        topics: ['Jurisprudence (fiqh)'],
+        topics: ['fiqh'],
       }),
     ).toBe(true)
     expect(
@@ -162,7 +168,7 @@ describe('matchesFacets', () => {
         collections: ['Sahih al-Bukhari'],
         gradings: ['Hasan'], // grade mismatch fails the whole result
         centuries: [],
-        topics: ['Jurisprudence (fiqh)'],
+        topics: ['fiqh'],
       }),
     ).toBe(false)
   })

--- a/frontend/src/lib/searchFacets.ts
+++ b/frontend/src/lib/searchFacets.ts
@@ -99,29 +99,23 @@ function matchesCentury(value: number | null | undefined, selected: number[]): b
 }
 
 /**
- * Tokens a topic facet label can match against a hadith's `topic_tags`, e.g.
- * "Jurisprudence (fiqh)" -> ["fiqh", "jurisprudence"], "Eschatology" ->
- * ["eschatology"]. A tag matches if it contains, or is contained by, any token.
+ * Topic matching is against the canonical topic vocabulary (#1061): a result's
+ * `topics` already holds canonical tokens (the backend maps the sparse free-text
+ * `topic_tags` onto the vocabulary in `src/utils/topics.py`), and the facet
+ * selection holds those same tokens. A hadith matches when any of its canonical
+ * tokens is selected.
+ *
+ * An empty `topics` is "uncategorized/unknown" and stays *permissive* — it is
+ * not excluded by an active topic filter — so genuinely tag-less hadiths and
+ * semantic hits (which carry no graph-derived metadata) remain visible rather
+ * than silently disappearing. Selecting only the `uncategorized` bucket
+ * therefore surfaces exactly these empty-topic results while categorized ones
+ * drop out (no categorized result carries the `uncategorized` token).
  */
-function topicTokens(label: string): string[] {
-  const tokens: string[] = []
-  const captured = label.match(/\(([^)]+)\)/)?.[1]
-  if (captured) tokens.push(norm(captured))
-  const lead = norm(label.replace(/\([^)]*\)/, ''))
-  if (lead) tokens.push(lead)
-  return tokens
-}
-
 function matchesTopic(values: string[] | undefined, selected: string[]): boolean {
   if (selected.length === 0) return true
   if (!values || values.length === 0) return true
-  const tags = values.map(norm).filter(Boolean)
-  if (tags.length === 0) return true
-  return selected.some((label) =>
-    topicTokens(label).some((token) =>
-      tags.some((tag) => tag.includes(token) || token.includes(tag)),
-    ),
-  )
+  return selected.some((token) => values.includes(token))
 }
 
 /**

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -5,6 +5,7 @@ import {
   searchAll,
   searchSemantic,
   fetchCollections,
+  fetchHadithFacets,
   SEARCH_MAX_LIMIT,
   SEMANTIC_SEARCH_MAX_LIMIT,
 } from '../api/client'
@@ -53,14 +54,10 @@ interface SearchFilters {
 // the compound "hasan_sahih" matches (its label "Hasan Sahih" would not). (#1062)
 const GRADINGS = GRADE_TOKENS
 const CENTURIES = [1, 2, 3, 4, 5]
-const TOPICS = [
-  'Jurisprudence (fiqh)',
-  'Theology (aqidah)',
-  'Ethics (akhlaq)',
-  'Worship (ibadah)',
-  'History (sira)',
-  'Eschatology',
-]
+// Topic facet options are derived from the live `/hadiths/facets` response (the
+// canonical topic vocabulary + per-bucket counts), not hardcoded — so the filter
+// always presents the same vocabulary the backend aggregates against, and never
+// drifts from it. The filter value is the canonical token. (#1061)
 
 const SUGGESTED_QUERIES = [
   'Abu Hurayra',
@@ -152,6 +149,16 @@ export default function SearchPage() {
   const collectionOptions = (collectionsData?.items ?? [])
     .map((c) => c.name_en)
     .sort((a, b) => a.localeCompare(b))
+
+  // Topic facet options, derived from the live `/hadiths/facets` response so the
+  // filter presents exactly the canonical vocabulary the backend aggregates
+  // against (incl. the uncategorized bucket), with per-bucket counts. (#1061)
+  const { data: hadithFacets } = useQuery({
+    queryKey: ['hadith-facets'],
+    queryFn: fetchHadithFacets,
+    staleTime: 5 * 60 * 1000,
+  })
+  const topicOptions = hadithFacets?.topics ?? []
 
   // Close typeahead on outside click
   useEffect(() => {
@@ -376,17 +383,25 @@ export default function SearchPage() {
           <h4 id="filter-topic" className="text-sm font-semibold mb-2 uppercase tracking-wide text-muted-foreground">
             Topic
           </h4>
-          {TOPICS.map((t) => (
-            <label key={t} className="flex items-center gap-2 py-1 cursor-pointer text-sm">
-              <input
-                type="checkbox"
-                checked={filters.topics.includes(t)}
-                onChange={() => toggleFilter('topics', t)}
-                className="rounded"
-              />
-              {t}
-            </label>
-          ))}
+          {topicOptions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No topics available</p>
+          ) : (
+            topicOptions.map((t) => (
+              <label
+                key={t.value}
+                className="flex items-center gap-2 py-1 cursor-pointer text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={filters.topics.includes(t.value)}
+                  onChange={() => toggleFilter('topics', t.value)}
+                  className="rounded"
+                />
+                <span className="flex-1">{t.label}</span>
+                <span className="text-muted-foreground tabular-nums">{t.count}</span>
+              </label>
+            ))
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/__tests__/HadithsPage.test.tsx
+++ b/frontend/src/pages/__tests__/HadithsPage.test.tsx
@@ -103,7 +103,7 @@ describe("HadithsPage narrator-in-isnad filter (#1050)", () => {
     vi.clearAllMocks()
     vi.mocked(fetchHadiths).mockResolvedValue(hadithsPage(false))
     vi.mocked(fetchCollections).mockResolvedValue(emptyCollections)
-    vi.mocked(fetchHadithFacets).mockResolvedValue({ source_corpus: [], grades: [] })
+    vi.mocked(fetchHadithFacets).mockResolvedValue({ source_corpus: [], grades: [], topics: [] })
     vi.mocked(fetchNarrators).mockResolvedValue(narratorPage())
   })
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -45,9 +45,18 @@ export interface Hadith {
   has_sunni_parallel: boolean
 }
 
+export interface TopicFacet {
+  /** Canonical topic token, or "uncategorized". */
+  value: string
+  label: string
+  count: number
+}
+
 export interface HadithFacetsResponse {
   source_corpus: string[]
   grades: string[]
+  /** Canonical topic vocabulary with per-bucket counts (incl. uncategorized). */
+  topics: TopicFacet[]
 }
 
 export interface Collection {

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -113,6 +113,20 @@ class HadithResponse(BaseModel):
     has_sunni_parallel: bool = False
 
 
+class TopicFacet(BaseModel):
+    """A canonical topic facet bucket with its document count.
+
+    ``value`` is the canonical token (see ``src.utils.topics.TOPIC_LABELS``) or
+    ``"uncategorized"`` for hadiths whose tags map to no canonical topic.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    value: str
+    label: str
+    count: int
+
+
 class HadithFacetsResponse(BaseModel):
     """Distinct facet values available for filtering hadiths."""
 
@@ -120,6 +134,10 @@ class HadithFacetsResponse(BaseModel):
 
     source_corpus: list[str]
     grades: list[str] = []
+    # Canonical topic vocabulary with per-bucket document counts, including the
+    # ``uncategorized`` bucket. The full vocabulary is always present so the
+    # facet is stable regardless of how sparse ``topic_tags`` are (#1061).
+    topics: list[TopicFacet] = []
 
 
 class CollectionResponse(BaseModel):
@@ -279,7 +297,10 @@ class SearchResult(BaseModel):
     populated only for the result types it applies to and left null/empty
     otherwise: ``collection`` + ``grade`` + ``topics`` for hadiths, ``century``
     for narrators. ``grade`` is the canonical normalized token (see
-    ``src.utils.grades.normalize_grade``), not the raw scholar string. (#1036)
+    ``src.utils.grades.normalize_grade``), not the raw scholar string. ``topics``
+    is the canonical topic tokens the hadith's free-text tags map onto (see
+    ``src.utils.topics.canonical_topics_for_tags``); an empty list means
+    uncategorized/unknown. (#1036, #1061)
     """
 
     model_config = ConfigDict(frozen=True)

--- a/src/api/routes/hadiths.py
+++ b/src/api/routes/hadiths.py
@@ -7,9 +7,10 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.api.deps import get_neo4j
-from src.api.models import HadithFacetsResponse, HadithResponse, PaginatedResponse
+from src.api.models import HadithFacetsResponse, HadithResponse, PaginatedResponse, TopicFacet
 from src.utils.grades import GRADE_TOKENS, grade_filter_clause, normalize_grade
 from src.utils.neo4j_client import Neo4jClient
+from src.utils.topics import aggregate_topic_facets
 
 # Cypher expression for the effective raw grade: prefer the traversed Grading node,
 # fall back to any legacy flat property on the Hadith node.
@@ -119,9 +120,19 @@ def get_hadith_facets(
     # ``munkar``/``shadh``/``hasan_sahih`` were unreachable in the UI even though
     # the filter (:func:`grade_filter_clause`) fully supports them (#1062). Every
     # token here filters correctly via the ``?grade=`` param on the list endpoint.
+    # Topic facet: pull every hadith's raw topic_tags (including those with none)
+    # and aggregate onto the canonical vocabulary. Scanning all hadiths is what
+    # lets the uncategorized bucket count tag-less documents rather than dropping
+    # them; the per-hadith payload is just a small string list. (#1061)
+    topic_rows = neo4j.execute_read("MATCH (h:Hadith) RETURN h.topic_tags AS topic_tags")
+    topics = [
+        TopicFacet(value=fc.value, label=fc.label, count=fc.count)
+        for fc in aggregate_topic_facets([row.get("topic_tags") for row in topic_rows])
+    ]
     return HadithFacetsResponse(
         source_corpus=[row["corpus"] for row in rows],
         grades=sorted(GRADE_TOKENS),
+        topics=topics,
     )
 
 

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -14,6 +14,7 @@ from src.enrich.embeddings import get_embedder, to_pgvector_literal
 from src.utils.grades import normalize_grade
 from src.utils.neo4j_client import Neo4jClient
 from src.utils.pg_client import PgClient
+from src.utils.topics import canonical_topics_for_tags
 
 router = APIRouter()
 
@@ -83,7 +84,10 @@ def search(
                     score=r["score"],
                     collection=r.get("collection_name"),
                     grade=normalize_grade(r.get("grade")),
-                    topics=r.get("topic_tags") or [],
+                    # Map the sparse free-text topic_tags onto the canonical topic
+                    # vocabulary so the facet filters against a stable token set
+                    # rather than fuzzy substrings. Empty = uncategorized/unknown.
+                    topics=canonical_topics_for_tags(r.get("topic_tags")),
                 )
             )
 

--- a/src/utils/topics.py
+++ b/src/utils/topics.py
@@ -1,0 +1,336 @@
+"""Canonical hadith topic vocabulary.
+
+Hadith documents carry a free-text ``topic_tags`` list (e.g. ``["intentions",
+"sincerity"]``, ``["prayer"]``, ``["day_of_judgment"]``). Those tags are sparse
+and unnormalized — they come from heterogeneous upstream sources, so the search
+page's topic facet was "best-effort": it matched a hardcoded label list against
+the raw tags with fuzzy substring logic, which is noisy and drifts from whatever
+tags actually exist (isnad-graph#1061).
+
+This module is the single source of truth for the topic facet. It defines a
+small, **version-controlled canonical vocabulary** of topic tokens, maps the
+free-text tags onto it via keyword groups, and aggregates document counts per
+canonical topic. Tags that map to nothing (or hadiths with no tags at all) fall
+into the ``uncategorized`` bucket rather than being dropped, so the facet's
+counts always sum to the full corpus.
+
+The long-term home for a stored, per-hadith canonical topic is the data layer
+(topic classification in the enrich stage — see ``src/enrich/__init__.py`` and
+``models.enrich.TopicResult``, tracked as future work). Until that lands, this
+keyword mapping is the deterministic bridge between sparse tags and the facet.
+The keyword groups deliberately favour transliterations + plain-English glosses
+that co-occur in the source tags.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+# Canonical token -> human-readable display label. This is THE topic vocabulary:
+# adding/removing/renaming a topic is a deliberate, reviewed change to this map.
+TOPIC_LABELS: Final[dict[str, str]] = {
+    "aqidah": "Theology (Aqidah)",
+    "ibadah": "Worship (Ibadah)",
+    "fiqh": "Jurisprudence (Fiqh)",
+    "akhlaq": "Ethics (Akhlaq)",
+    "quran": "Qur'an & Tafsir",
+    "sira": "History & Biography (Sira)",
+    "knowledge": "Knowledge ('Ilm)",
+    "eschatology": "Eschatology",
+}
+
+# The bucket for tags that map to no canonical topic (and for hadiths carrying no
+# tags at all). Surfaced as a facet so documents are never silently dropped.
+UNCATEGORIZED_TOPIC: Final[str] = "uncategorized"
+UNCATEGORIZED_LABEL: Final[str] = "Uncategorized"
+
+# Keyword groups: a normalized tag belongs to a canonical topic if its text
+# CONTAINS any of the group's substrings. The dict is ordered by match priority —
+# ``normalize_topic`` returns the first matching token, so more specific topics
+# (eschatology, qur'an, sira) are checked before the broad legal catch-all
+# (fiqh). Substrings are lower-cased and apostrophe/underscore-folded to match
+# ``_normalize_tag`` output.
+_KEYWORDS: Final[dict[str, tuple[str, ...]]] = {
+    "eschatology": (
+        "eschatolog",
+        "hereafter",
+        "afterlife",
+        "akhirah",
+        "akhira",
+        "resurrection",
+        "judgment",
+        "judgement",
+        "day of",
+        "the hour",
+        "signs of the hour",
+        "paradise",
+        "jannah",
+        "hellfire",
+        "hell",
+        "jahannam",
+        "dajjal",
+        "antichrist",
+        "doomsday",
+        "qiyamah",
+        "qiyamat",
+        "barzakh",
+        "the grave",
+    ),
+    "quran": (
+        "quran",
+        "koran",
+        "tafsir",
+        "tafseer",
+        "exegesis",
+        "revelation",
+        "ayah",
+        "ayat",
+        "verse",
+        "surah",
+        "sura ",
+        "recitation",
+        "tilawah",
+    ),
+    "sira": (
+        "sira",
+        "seerah",
+        "biograph",
+        "history",
+        "battle",
+        "expedition",
+        "ghazwa",
+        "maghazi",
+        "migration",
+        "hijra",
+        "companion",
+        "sahaba",
+        "sahabah",
+    ),
+    "ibadah": (
+        "ibadah",
+        "ibada",
+        "worship",
+        "prayer",
+        "salah",
+        "salat",
+        "salaah",
+        "fasting",
+        "fast",
+        "sawm",
+        "siyam",
+        "ramadan",
+        "ablution",
+        "wudu",
+        "purification",
+        "tahara",
+        "pilgrimage",
+        "hajj",
+        "umrah",
+        "zakat",
+        "zakah",
+        "alms",
+        "charity",
+        "sadaqah",
+        "dhikr",
+        "supplication",
+        "dua",
+        "invocation",
+        "adhan",
+        "azan",
+        "mosque",
+        "masjid",
+    ),
+    "aqidah": (
+        "aqidah",
+        "aqeedah",
+        "aqida",
+        "theolog",
+        "belief",
+        "creed",
+        "faith",
+        "iman",
+        "tawhid",
+        "tawheed",
+        "monotheism",
+        "oneness",
+        "divine",
+        "angel",
+        "predestination",
+        "qadar",
+        "destiny",
+    ),
+    "akhlaq": (
+        "akhlaq",
+        "akhlaaq",
+        "ethic",
+        "moral",
+        "manner",
+        "character",
+        "virtue",
+        "sincerity",
+        "intention",
+        "ikhlas",
+        "patience",
+        "sabr",
+        "honesty",
+        "truthfulness",
+        "humility",
+        "gratitude",
+        "kindness",
+        "mercy",
+        "compassion",
+        "forgiveness",
+        "repentance",
+        "tawbah",
+        "backbiting",
+        "envy",
+        "anger",
+        "modesty",
+        "haya",
+    ),
+    "knowledge": (
+        "knowledge",
+        "ilm",
+        "learning",
+        "scholar",
+        "teaching",
+        "education",
+        "wisdom",
+        "hikmah",
+        "student",
+    ),
+    "fiqh": (
+        "fiqh",
+        "jurisprudence",
+        "law",
+        "legal",
+        "ruling",
+        "hukm",
+        "permissible",
+        "halal",
+        "haram",
+        "forbidden",
+        "lawful",
+        "unlawful",
+        "transaction",
+        "trade",
+        "business",
+        "commerce",
+        "marriage",
+        "nikah",
+        "divorce",
+        "talaq",
+        "inheritance",
+        "mirath",
+        "contract",
+        "oath",
+        "vow",
+        "punishment",
+        "hudud",
+        "dietary",
+        "food",
+        "drink",
+        "clothing",
+    ),
+}
+
+# Canonical tokens in their vocabulary/priority order. Facet output and
+# ``canonical_topics_for_tags`` preserve this order for stable presentation.
+TOPIC_TOKENS: Final[tuple[str, ...]] = tuple(TOPIC_LABELS.keys())
+
+_WS_RE: Final = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class TopicFacetCount:
+    """A canonical topic and the number of documents mapped to it."""
+
+    value: str
+    label: str
+    count: int
+
+
+def _normalize_tag(raw: str) -> str:
+    """Fold a free-text tag for tolerant keyword matching.
+
+    Lower-cases, replaces underscores/hyphens with spaces (so ``day_of_judgment``
+    matches ``"day of"``), drops apostrophe/hamza glyphs, and collapses runs of
+    whitespace. Mirrors the frontend ``norm`` helper so both ends agree.
+    """
+    text = raw.lower().replace("_", " ").replace("-", " ")
+    text = re.sub(r"['’ʼʿ`´‘]", "", text)
+    return _WS_RE.sub(" ", text).strip()
+
+
+def normalize_topic(raw: str | None) -> str | None:
+    """Map a single free-text topic tag to a canonical token, or ``None``.
+
+    Priority follows ``_KEYWORDS`` insertion order: the first group whose keyword
+    is contained in the normalized tag wins. Returns ``None`` for blank input or
+    a tag that matches no canonical topic (the caller buckets those as
+    :data:`UNCATEGORIZED_TOPIC`).
+    """
+    if not raw or not raw.strip():
+        return None
+    text = _normalize_tag(raw)
+    if not text:
+        return None
+    for token, keywords in _KEYWORDS.items():
+        if any(kw in text for kw in keywords):
+            return token
+    return None
+
+
+def canonical_topics_for_tags(tags: list[str] | None) -> list[str]:
+    """Map a hadith's free-text ``topic_tags`` to its distinct canonical tokens.
+
+    Returns the canonical tokens (in :data:`TOPIC_TOKENS` order, de-duplicated)
+    that any of ``tags`` resolve to. An empty list means the hadith is
+    *uncategorized* — either it has no tags or none of them map onto the
+    vocabulary. The empty case is preserved (not coerced to ``uncategorized``) so
+    result-level facet matching can keep treating "no topics" as permissive.
+    """
+    if not tags:
+        return []
+    matched: set[str] = set()
+    for tag in tags:
+        token = normalize_topic(tag)
+        if token is not None:
+            matched.add(token)
+    return [t for t in TOPIC_TOKENS if t in matched]
+
+
+def aggregate_topic_facets(tag_lists: list[list[str] | None]) -> list[TopicFacetCount]:
+    """Aggregate per-hadith ``topic_tags`` into canonical topic-facet counts.
+
+    ``tag_lists`` is one entry per hadith (its ``topic_tags``, possibly empty or
+    ``None``). A hadith contributes one count to *each* distinct canonical topic
+    its tags map to; a hadith that maps to no topic contributes to the
+    ``uncategorized`` bucket. Document counts therefore sum to at least the corpus
+    size (a multi-topic hadith is counted under each of its topics).
+
+    The full canonical vocabulary is always returned in :data:`TOPIC_TOKENS`
+    order — including zero-count topics — so the facet presents a stable
+    vocabulary independent of how sparse the underlying tags are. The
+    ``uncategorized`` bucket is always appended last.
+    """
+    counts: dict[str, int] = {token: 0 for token in TOPIC_TOKENS}
+    uncategorized = 0
+    for tags in tag_lists:
+        tokens = canonical_topics_for_tags(tags)
+        if not tokens:
+            uncategorized += 1
+            continue
+        for token in tokens:
+            counts[token] += 1
+
+    facets = [
+        TopicFacetCount(value=token, label=TOPIC_LABELS[token], count=counts[token])
+        for token in TOPIC_TOKENS
+    ]
+    facets.append(
+        TopicFacetCount(value=UNCATEGORIZED_TOPIC, label=UNCATEGORIZED_LABEL, count=uncategorized)
+    )
+    return facets

--- a/tests/test_api/test_hadiths.py
+++ b/tests/test_api/test_hadiths.py
@@ -27,26 +27,58 @@ def test_get_hadith_facets_empty(client: TestClient) -> None:
     # any hadiths are loaded — it no longer collapses to empty on a sparse corpus
     # (#1062), so every valid grade stays reachable as a filter.
     assert body["grades"] == sorted(GRADE_TOKENS)
+    # The canonical topic vocabulary is always present (stable facet), with zero
+    # counts and a zero uncategorized bucket when there are no hadiths (#1061).
+    values = [t["value"] for t in body["topics"]]
+    assert values == [
+        "aqidah",
+        "ibadah",
+        "fiqh",
+        "akhlaq",
+        "quran",
+        "sira",
+        "knowledge",
+        "eschatology",
+        "uncategorized",
+    ]
+    assert all(t["count"] == 0 for t in body["topics"])
 
 
 def test_get_hadith_facets_with_data(client: TestClient, mock_neo4j: MagicMock) -> None:
-    """Corpus facets come from the data; the grade facet is the full canonical vocabulary."""
-    # Only the corpus query hits Neo4j now — grades are sourced from the canonical
-    # enum, not a per-corpus DISTINCT scan that silently dropped absent grades.
-    mock_neo4j.execute_read.return_value = [
-        {"corpus": "lk"},
-        {"corpus": "sunnah"},
-        {"corpus": "thaqalayn"},
+    """Corpus facets from data; grade facet = full canonical vocab; topic facet aggregated."""
+    # Grades are sourced from the canonical enum (#1062), so the only DB reads are
+    # the corpus query and the per-hadith topic_tags scan (#1061).
+    mock_neo4j.execute_read.side_effect = [
+        # First call: corpus facets.
+        [{"corpus": "lk"}, {"corpus": "sunnah"}, {"corpus": "thaqalayn"}],
+        # Second call: per-hadith topic_tags for the canonical topic facet.
+        [
+            {"topic_tags": ["intentions", "prayer"]},  # akhlaq + ibadah
+            {"topic_tags": ["inheritance"]},  # fiqh
+            {"topic_tags": ["something obscure"]},  # uncategorized (no match)
+            {"topic_tags": []},  # uncategorized (no tags)
+            {"topic_tags": None},  # uncategorized (missing property)
+        ],
     ]
     resp = client.get("/api/v1/hadiths/facets")
     assert resp.status_code == 200
     body = resp.json()
     assert body["source_corpus"] == ["lk", "sunnah", "thaqalayn"]
+    # Grade facet = full canonical vocabulary (#1062); grades a sparse corpus used
+    # to hide are now facetable — see test_utils/test_grades.py for the predicate proof.
     assert body["grades"] == sorted(GRADE_TOKENS)
-    # The grades a sparse corpus used to hide are now facetable (#1062). Each one
-    # filters correctly — see test_utils/test_grades.py for the predicate proof.
     for previously_unreachable in ("munkar", "shadh", "hasan_sahih"):
         assert previously_unreachable in body["grades"]
+    # Topic facet: counts keyed by canonical token, incl. the uncategorized bucket (#1061).
+    counts = {t["value"]: t["count"] for t in body["topics"]}
+    assert counts["akhlaq"] == 1
+    assert counts["ibadah"] == 1
+    assert counts["fiqh"] == 1
+    assert counts["uncategorized"] == 3  # obscure tag + empty + missing
+    # Topics with no documents still appear (stable vocabulary).
+    assert counts["eschatology"] == 0
+    # Every bucket carries a human-readable label.
+    assert all(t["label"] for t in body["topics"])
 
 
 def test_list_hadiths_empty(client: TestClient) -> None:

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -100,7 +100,8 @@ def test_search_populates_facet_metadata(client: TestClient, mock_neo4j: MagicMo
     hadith = next(r for r in results if r["type"] == "hadith")
     assert hadith["collection"] == "Sahih al-Bukhari"
     assert hadith["grade"] == "sahih"  # normalized from "Sahih - Authentic"
-    assert hadith["topics"] == ["intentions"]
+    # Raw tag "intentions" maps onto the canonical "akhlaq" topic (#1061).
+    assert hadith["topics"] == ["akhlaq"]
     assert hadith["century"] is None
 
 

--- a/tests/test_utils/test_topics.py
+++ b/tests/test_utils/test_topics.py
@@ -1,0 +1,103 @@
+"""Tests for the canonical hadith topic vocabulary (ig#1061).
+
+Exercises the free-text -> canonical-token mapping, multi-tag de-duplication,
+the uncategorized bucket, and the always-present vocabulary in facet aggregation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.topics import (
+    TOPIC_LABELS,
+    TOPIC_TOKENS,
+    UNCATEGORIZED_LABEL,
+    UNCATEGORIZED_TOPIC,
+    aggregate_topic_facets,
+    canonical_topics_for_tags,
+    normalize_topic,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("intentions", "akhlaq"),
+        ("sincerity", "akhlaq"),
+        ("prayer", "ibadah"),
+        ("Fasting", "ibadah"),
+        ("zakat", "ibadah"),
+        ("inheritance", "fiqh"),
+        ("Business transactions", "fiqh"),
+        ("belief", "aqidah"),
+        ("tawhid", "aqidah"),
+        ("tafsir", "quran"),
+        ("the battle of Badr", "sira"),
+        ("seeking knowledge", "knowledge"),
+        ("Day of Judgment", "eschatology"),
+        ("paradise", "eschatology"),
+        ("day_of_judgment", "eschatology"),  # underscore-folded
+    ],
+)
+def test_normalize_topic_maps_freeform_tags(raw: str, expected: str) -> None:
+    assert normalize_topic(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "   ", None, "completely unrelated gibberish"])
+def test_normalize_topic_returns_none_for_unmapped(raw: str | None) -> None:
+    assert normalize_topic(raw) is None
+
+
+def test_every_canonical_token_has_a_label() -> None:
+    assert set(TOPIC_TOKENS) == set(TOPIC_LABELS)
+    assert all(TOPIC_LABELS[t] for t in TOPIC_TOKENS)
+
+
+def test_canonical_topics_dedupes_and_orders() -> None:
+    # "prayer" and "supplication" both map to ibadah; "intentions" to akhlaq.
+    tags = ["prayer", "supplication", "intentions"]
+    result = canonical_topics_for_tags(tags)
+    assert result == ["ibadah", "akhlaq"]  # de-duped, in TOPIC_TOKENS order
+    # Order is vocabulary order regardless of tag order.
+    assert canonical_topics_for_tags(["intentions", "prayer"]) == ["ibadah", "akhlaq"]
+
+
+@pytest.mark.parametrize("tags", [None, [], ["zzz nonsense"]])
+def test_canonical_topics_empty_for_uncategorizable(tags: list[str] | None) -> None:
+    assert canonical_topics_for_tags(tags) == []
+
+
+def test_aggregate_always_returns_full_vocabulary_plus_uncategorized() -> None:
+    facets = aggregate_topic_facets([])
+    values = [f.value for f in facets]
+    assert values == [*TOPIC_TOKENS, UNCATEGORIZED_TOPIC]
+    assert all(f.count == 0 for f in facets)
+    assert facets[-1].label == UNCATEGORIZED_LABEL
+
+
+def test_aggregate_counts_per_document_and_uncategorized() -> None:
+    facets = aggregate_topic_facets(
+        [
+            ["intentions", "prayer"],  # akhlaq + ibadah
+            ["inheritance"],  # fiqh
+            ["prayer"],  # ibadah
+            ["obscure tag"],  # uncategorized
+            [],  # uncategorized
+            None,  # uncategorized
+        ]
+    )
+    counts = {f.value: f.count for f in facets}
+    assert counts["ibadah"] == 2
+    assert counts["akhlaq"] == 1
+    assert counts["fiqh"] == 1
+    assert counts["uncategorized"] == 3
+    assert counts["eschatology"] == 0
+
+
+def test_aggregate_counts_a_multi_topic_hadith_once_per_topic() -> None:
+    # A single hadith tagged with two synonyms of the same topic counts once
+    # for that topic (set semantics), not twice.
+    facets = aggregate_topic_facets([["prayer", "salah", "fasting"]])
+    counts = {f.value: f.count for f in facets}
+    assert counts["ibadah"] == 1
+    assert counts["uncategorized"] == 0


### PR DESCRIPTION
## Summary

The search **topic facet** was best-effort: a hardcoded label list fuzzy-matched against sparse free-text `topic_tags`, with no canonical vocabulary and nowhere for documents whose tags matched nothing. This makes the facet noisy and prone to drift from the data (#1061).

This PR introduces a **single source of truth** for the topic vocabulary and wires the facet to present and aggregate against it.

### Backend
- **`src/utils/topics.py`** — version-controlled canonical vocabulary (`TOPIC_LABELS`: aqidah, ibadah, fiqh, akhlaq, quran, sira, knowledge, eschatology), a keyword mapping (`normalize_topic` / `canonical_topics_for_tags`) that folds sparse tags onto it, and `aggregate_topic_facets` which counts documents per canonical topic plus an always-present **`uncategorized`** bucket. Tag-less / unmappable documents are bucketed, never dropped — counts always cover the full corpus. Mirrors the existing `src/utils/grades.py` pattern.
- **`GET /hadiths/facets`** now returns `topics: [{value, label, count}]` over the **full** vocabulary (stable regardless of how sparse the tags are), uncategorized last.
- **`GET /search`** results carry the canonical topic tokens (`SearchResult.topics`) the hadith maps onto, so client filtering matches a stable token set instead of fuzzy substrings.

### Frontend
- `SearchPage` derives the topic facet options + counts from the live `/hadiths/facets` response (no hardcoded list) — mirroring how collections are already derived from `/collections`.
- `searchFacets.matchesTopic` is now canonical set-membership; an empty `topics` stays permissive (keeps tag-less hadiths and semantic hits visible), and selecting only the `uncategorized` bucket isolates exactly those.

### Docs / follow-up
- `docs/search-topic-vocabulary.md` documents the vocabulary, mapping, and API surface.
- Densifying `topic_tags` / real per-hadith topic classification in the enrich stage is noted as an **upstream data follow-up**, out of scope here.

## Test Plan
- `tests/test_utils/test_topics.py` — **27 passed** (mapping, multi-tag de-dup, uncategorized bucket, full-vocabulary aggregation). Run locally: `ENVIRONMENT=test uv run pytest tests/test_utils/test_topics.py` ✅
- Frontend vitest — **27 passed**: `searchFacets.test.ts` (18, incl. new canonical-token + uncategorized cases) + `HadithsPage`/`SearchPage` (9). ✅
- `mypy src/` ✅, `ruff check`/`format` ✅, frontend `tsc --noEmit` ✅, `eslint` ✅.
- `tests/test_api/test_hadiths.py` + `tests/test_api/test_search.py` were updated to cover the new topic aggregation (3rd `execute_read`, canonical `topics` on results, uncategorized counts). **These could not be executed in the local sandbox**: the app's stacked `BaseHTTPMiddleware` chain deadlocks under `starlette.testclient` with the installed `httpx` (a trivial FastAPI TestClient returns in 0.02s, but the full app hangs at `await call_next` — reproduced on an *untouched* test, so it is pre-existing and unrelated to this change). They run in CI, which has the proper environment/services.

Closes #1061
