### PR TITLE
feat(frontend): carry SSO cookie on admin Grafana link click (ig#1081)

### DIFF
--- a/frontend/src/api/__tests__/sso-client.test.ts
+++ b/frontend/src/api/__tests__/sso-client.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mintSsoCookie } from '../sso-client'
+
+// Fetch-boundary tests for the SSO-cookie mint (ig#1081 / user-service#171).
+// The helper POSTs /auth/sso-cookie with the current access token and, mirroring
+// the shared #1016/#1021 recovery, retries ONCE behind a token refresh on a 401
+// before failing. These drive the REAL client against a stubbed `fetch`.
+
+const REFRESH_URL = '/auth/token/refresh'
+// Origin resolves to '' (same-origin) in the test env, so the URL is bare.
+const SSO_URL = '/auth/sso-cookie'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    url: 'http://localhost' + SSO_URL,
+    json: async () => body,
+  } as Response
+}
+
+const fetchMock = vi.fn()
+
+function callsTo(substr: string): Array<{ url: string; init: RequestInit | undefined }> {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: c[1] as RequestInit | undefined }))
+    .filter((c) => c.url.includes(substr))
+}
+
+function authHeader(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.Authorization
+}
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'app-token')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('mintSsoCookie', () => {
+  it('POSTs /auth/sso-cookie with credentials:include and the bearer token', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ status: 'ok', cookie_name: 'nl_sso', expires_in: 300 }),
+    )
+
+    const result = await mintSsoCookie()
+
+    expect(result).toMatchObject({ cookie_name: 'nl_sso', expires_in: 300 })
+    const calls = callsTo(SSO_URL)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.init?.method).toBe('POST')
+    // credentials:include is mandatory so the browser stores the Set-Cookie.
+    expect(calls[0]?.init?.credentials).toBe('include')
+    expect(authHeader(calls[0]?.init)).toBe('Bearer app-token')
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+  })
+
+  it('on 401, refreshes once and retries with the fresh token', async () => {
+    let mintCalls = 0
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes(REFRESH_URL)) {
+        return Promise.resolve(jsonResponse({ access_token: 'fresh-token' }))
+      }
+      mintCalls += 1
+      return Promise.resolve(
+        mintCalls === 1
+          ? jsonResponse({ detail: 'token expired' }, 401)
+          : jsonResponse({ status: 'ok', cookie_name: 'nl_sso', expires_in: 300 }),
+      )
+    })
+
+    const result = await mintSsoCookie()
+
+    expect(result).toMatchObject({ cookie_name: 'nl_sso' })
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    const mints = callsTo(SSO_URL)
+    expect(mints).toHaveLength(2)
+    expect(authHeader(mints[0]?.init)).toBe('Bearer app-token')
+    expect(authHeader(mints[1]?.init)).toBe('Bearer fresh-token')
+  })
+
+  it('throws an ApiError when the refresh fails (401 stands)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauth' }, 401))
+
+    await expect(mintSsoCookie()).rejects.toMatchObject({ status: 401 })
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(1)
+    // Only the original attempt — no retry once the refresh fails.
+    expect(callsTo(SSO_URL)).toHaveLength(1)
+  })
+
+  it('throws an ApiError on a 403 without attempting a refresh', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'forbidden' }, 403))
+
+    await expect(mintSsoCookie()).rejects.toMatchObject({ status: 403 })
+
+    expect(callsTo(REFRESH_URL)).toHaveLength(0)
+    expect(callsTo(SSO_URL)).toHaveLength(1)
+  })
+})

--- a/frontend/src/api/sso-client.ts
+++ b/frontend/src/api/sso-client.ts
@@ -1,0 +1,69 @@
+// Mint a short-lived parent-domain SSO cookie so an admin can cross from the app
+// (isnad-graph.{base}) into the Grafana/observability subdomain without hitting
+// Grafana's own login wall. This is the frontend third of the admin-gated-Grafana
+// SSO feature (noorinalabs-deploy#458 / user-service#171).
+//
+// Flow: POST /auth/sso-cookie (authenticated with the current app access token),
+// the user-service responds with a `Set-Cookie` for `nl_sso`
+// (Domain=noorinalabs.com, HttpOnly, Secure, SameSite=Lax, Max-Age=300). Because
+// it is HttpOnly the frontend can never READ it — the only job here is to TRIGGER
+// the mint and let the browser store it. The caller then does a top-level
+// `window.location` navigation to the observability URL; SameSite=Lax lets the
+// browser carry the parent-domain cookie on that cross-subdomain top-level nav,
+// and forward_auth on the Grafana vhost validates it.
+//
+// `credentials: 'include'` is MANDATORY: without it the browser discards the
+// `Set-Cookie` from the fetch response and the subsequent navigation carries no
+// credential.
+
+import { getAuthHeaders } from './auth-headers'
+import { refreshAccessToken } from './token-refresh'
+import { apiError } from './api-error'
+
+// Absolute URL targeting the user-service vhost (`users.{base}`). Resolved at
+// runtime from `window.RUNTIME_CONFIG` (injected by the container entrypoint via
+// /runtime-config.js), falling back to the build-time `VITE_USER_SERVICE_ORIGIN`
+// for local `npm run dev`, then '' (same-origin). Mirrors token-refresh.ts /
+// useAuth.ts (isnad-graph#932) — kept duplicated to avoid a barrel-export
+// refactor inside this PR.
+const USER_SERVICE_ORIGIN =
+  (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
+  import.meta.env.VITE_USER_SERVICE_ORIGIN ||
+  ''
+const AUTH_BASE = `${USER_SERVICE_ORIGIN}/auth`
+
+export interface SsoCookieResult {
+  status: string
+  cookie_name: string
+  expires_in: number
+}
+
+/**
+ * Mint the `nl_sso` parent-domain cookie (POST /auth/sso-cookie). Mirrors the
+ * shared #1016/#1021 recovery: on a 401 attempt ONE token refresh (via the
+ * httpOnly refresh cookie) and retry once before failing. Throws an
+ * {@link ApiError} on a non-OK response (or a network failure) so the caller can
+ * surface an inline error and skip the navigation. The cookie itself is HttpOnly
+ * and never visible to JS; the resolved value is only the JSON acknowledgement.
+ */
+export async function mintSsoCookie(): Promise<SsoCookieResult> {
+  const send = () =>
+    fetch(`${AUTH_BASE}/sso-cookie`, {
+      method: 'POST',
+      // Required so the browser stores the parent-domain Set-Cookie response.
+      credentials: 'include',
+      headers: { ...getAuthHeaders() },
+    })
+
+  let res = await send()
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await send()
+    }
+  }
+  if (!res.ok) {
+    throw apiError(res)
+  }
+  return res.json() as Promise<SsoCookieResult>
+}

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchDashboardStats } from '../../api/admin-client'
+import { useAuth } from '../../hooks/useAuth'
+import { mintSsoCookie } from '../../api/sso-client'
 
 function StatCard({ label, value }: { label: string; value: string | number }) {
   return (
@@ -58,14 +61,49 @@ const OBS_LINKS: ObsLink[] = [
   },
 ]
 
-// Gated OFF until the app-session → Grafana SSO bridge ships (forward_auth RBAC
-// admin-gating — noorinalabs-deploy#458). Until then these links dead-end at
-// Grafana's own login wall (no single-sign-on), so we hide them rather than
-// ship a dead-end. Flip to `true` once deploy#458 lands (ig#1073).
-const OBSERVABILITY_LINKS_ENABLED = false
-
-// Exported for unit testing while the section is gated off the page (ig#1073).
+// Re-enabled with the app-session → Grafana SSO bridge (ig#1081), reversing the
+// ig#1073 hide. A bare top-level navigation to `/grafana` would dead-end at
+// Grafana's own login wall, so on click we first mint a short-lived parent-domain
+// `nl_sso` cookie (POST /auth/sso-cookie — user-service#171) and only then
+// navigate. forward_auth on the Grafana vhost validates that cookie and admin-
+// gates access (noorinalabs-deploy#458). HARD CUTOVER: the live carry only works
+// once user-service#171 is deployed on the target env. Admin-gated by the caller
+// (DashboardPage renders this only when `isAdmin`).
 export function ObservabilitySection() {
+  // Which link is currently minting (drives the disabled/busy affordance); null
+  // when idle. `error` holds the inline failure copy for the most recent attempt.
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleNavigate(
+    e: React.MouseEvent<HTMLAnchorElement>,
+    href: string,
+  ) {
+    // Always intercept: a default navigation would skip the cookie mint and
+    // dead-end at Grafana's login.
+    e.preventDefault()
+    if (pendingHref) return // a mint is already in flight
+    setError(null)
+    setPendingHref(href)
+    try {
+      // Await the mint (the browser stores the HttpOnly parent-domain cookie),
+      // THEN do a top-level navigation so SameSite=Lax carries it cross-subdomain.
+      await mintSsoCookie()
+      window.location.assign(href)
+      // On success the page is navigating away — leave `pendingHref` set so the
+      // links stay inert during the unload.
+    } catch (err) {
+      // 401/403/network: do NOT navigate (would dead-end at Grafana's login).
+      // ApiError carries a friendly, localized message; fall back for anything else.
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Could not start an observability session. Please try again.',
+      )
+      setPendingHref(null)
+    }
+  }
+
   return (
     <section style={{ marginTop: 'var(--spacing-6)' }}>
       <h3
@@ -77,6 +115,11 @@ export function ObservabilitySection() {
       >
         Observability
       </h3>
+      {error && (
+        <p className="error-text" role="alert" style={{ marginBottom: 'var(--spacing-3)' }}>
+          {error}
+        </p>
+      )}
       <div
         style={{
           display: 'grid',
@@ -84,48 +127,55 @@ export function ObservabilitySection() {
           gap: 'var(--spacing-4)',
         }}
       >
-        {OBS_LINKS.map(({ label, description, href }) => (
-          <a
-            key={href}
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              display: 'block',
-              padding: 'var(--spacing-4)',
-              background: 'var(--color-card)',
-              border: 'var(--border-width-thin) solid var(--color-border)',
-              borderRadius: 'var(--radius-lg)',
-              textDecoration: 'none',
-              color: 'var(--color-foreground)',
-            }}
-          >
-            <div
+        {OBS_LINKS.map(({ label, description, href }) => {
+          const busy = pendingHref === href
+          return (
+            <a
+              key={href}
+              href={href}
+              onClick={(e) => handleNavigate(e, href)}
+              aria-busy={busy}
+              aria-disabled={pendingHref !== null}
               style={{
-                fontSize: 'var(--text-sm)',
-                fontWeight: 600,
-                fontFamily: 'var(--font-heading)',
-                marginBottom: 'var(--spacing-1)',
+                display: 'block',
+                padding: 'var(--spacing-4)',
+                background: 'var(--color-card)',
+                border: 'var(--border-width-thin) solid var(--color-border)',
+                borderRadius: 'var(--radius-lg)',
+                textDecoration: 'none',
+                color: 'var(--color-foreground)',
+                opacity: pendingHref !== null && !busy ? 0.6 : 1,
+                cursor: pendingHref !== null ? 'progress' : 'pointer',
               }}
             >
-              {label}
-            </div>
-            <div
-              style={{
-                fontSize: 'var(--text-xs)',
-                color: 'var(--color-muted-foreground)',
-              }}
-            >
-              {description}
-            </div>
-          </a>
-        ))}
+              <div
+                style={{
+                  fontSize: 'var(--text-sm)',
+                  fontWeight: 600,
+                  fontFamily: 'var(--font-heading)',
+                  marginBottom: 'var(--spacing-1)',
+                }}
+              >
+                {busy ? `${label}…` : label}
+              </div>
+              <div
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--color-muted-foreground)',
+                }}
+              >
+                {description}
+              </div>
+            </a>
+          )
+        })}
       </div>
     </section>
   )
 }
 
 export default function DashboardPage() {
+  const { isAdmin } = useAuth()
   const { data, isLoading, error } = useQuery({
     queryKey: ['admin-dashboard-stats'],
     queryFn: fetchDashboardStats,
@@ -185,7 +235,7 @@ export default function DashboardPage() {
         </>
       )}
 
-      {OBSERVABILITY_LINKS_ENABLED && <ObservabilitySection />}
+      {isAdmin && <ObservabilitySection />}
     </div>
   )
 }

--- a/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react"
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import DashboardPage, { ObservabilitySection } from "../DashboardPage"
 import { fetchDashboardStats } from "../../../api/admin-client"
 import type { DashboardStats } from "../../../api/admin-client"
+import { useAuth } from "../../../hooks/useAuth"
+import { mintSsoCookie } from "../../../api/sso-client"
 
 // Role names are kept as variables, NOT literals, so the tests survive the
 // pending UserRole vocab change in #876 (viewer/editor/moderator → trial/reader/researcher).
@@ -16,6 +19,24 @@ const ROLE_ADMIN = "admin"
 vi.mock("../../../api/admin-client", () => ({
   fetchDashboardStats: vi.fn(),
 }))
+
+// The Observability section is admin-gated via useAuth().isAdmin; mock the hook so
+// each test controls the role without standing up an AuthProvider.
+vi.mock("../../../hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}))
+
+// The SSO-cookie mint (POST /auth/sso-cookie) is mocked at the client boundary so
+// the click tests assert the mint→navigate ordering without a real fetch.
+vi.mock("../../../api/sso-client", () => ({
+  mintSsoCookie: vi.fn(),
+}))
+
+function setAdmin(isAdmin: boolean) {
+  vi.mocked(useAuth).mockReturnValue({
+    isAdmin,
+  } as unknown as ReturnType<typeof useAuth>)
+}
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -31,6 +52,8 @@ function renderPage() {
 describe("DashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default to a non-admin context; admin-specific tests opt in via setAdmin(true).
+    setAdmin(false)
   })
 
   it("shows loading state initially", () => {
@@ -136,10 +159,26 @@ describe("DashboardPage", () => {
     expect(container.querySelector("h2")).toBeNull()
   })
 
-  it("does NOT mount the Observability section while gated off (ig#1073)", async () => {
-    // The obs-links are hidden until the Grafana SSO bridge ships (deploy#458):
-    // until then they dead-end at Grafana's login. Assert the section is absent
-    // from the rendered dashboard. Re-enable assertion when deploy#458 lands.
+  it("mounts the Observability section for an admin (ig#1081 re-enable)", async () => {
+    setAdmin(true)
+    const stats: DashboardStats = {
+      total_users: 10,
+      active_users: 10,
+      deactivated_users: 0,
+      new_registrations_7d: 0,
+      active_sessions: 1,
+      users_by_role: [],
+    }
+    vi.mocked(fetchDashboardStats).mockResolvedValue(stats)
+    renderPage()
+
+    await screen.findByText("Admin Dashboard")
+    expect(screen.getByText("Observability")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /^Grafana/i })).toBeInTheDocument()
+  })
+
+  it("hides the Observability section for a non-admin", async () => {
+    setAdmin(false)
     const stats: DashboardStats = {
       total_users: 10,
       active_users: 10,
@@ -158,10 +197,30 @@ describe("DashboardPage", () => {
   })
 })
 
-describe("ObservabilitySection (gated component, ig#1073)", () => {
-  // The section is mounted off-page for now, but its markup must stay correct so
-  // flipping OBSERVABILITY_LINKS_ENABLED back on (when deploy#458 ships) is safe.
-  it("renders three links with relative hrefs, target=_blank, rel=noopener", () => {
+describe("ObservabilitySection (ig#1081 SSO carry)", () => {
+  let assignMock: ReturnType<typeof vi.fn>
+  const realLocation = window.location
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // jsdom's `location.assign` is non-configurable (so it can't be spied
+    // directly) and a real assign would throw "Not implemented: navigation".
+    // Swap window.location for a stub exposing a mockable `assign`.
+    assignMock = vi.fn()
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, assign: assignMock, href: realLocation.href },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    })
+  })
+
+  it("renders three links with relative hrefs (no target=_blank — same-tab top-level nav)", () => {
     render(<ObservabilitySection />)
 
     expect(screen.getByText("Observability")).toBeTruthy()
@@ -170,17 +229,74 @@ describe("ObservabilitySection (gated component, ig#1073)", () => {
     // contains "Grafana").
     const grafanaLink = screen.getByRole("link", { name: /^Grafana/i })
     expect(grafanaLink).toHaveAttribute("href", "/grafana/")
-    expect(grafanaLink).toHaveAttribute("target", "_blank")
-    expect(grafanaLink).toHaveAttribute("rel", "noopener noreferrer")
+    // The carry requires a top-level navigation in the SAME tab so SameSite=Lax
+    // ships the parent-domain cookie — a new tab is no longer used.
+    expect(grafanaLink).not.toHaveAttribute("target", "_blank")
 
-    const logsLink = screen.getByRole("link", { name: /^Logs/i })
-    expect(logsLink).toHaveAttribute("href", "/grafana/explore")
-    expect(logsLink).toHaveAttribute("target", "_blank")
-    expect(logsLink).toHaveAttribute("rel", "noopener noreferrer")
+    expect(screen.getByRole("link", { name: /^Logs/i })).toHaveAttribute(
+      "href",
+      "/grafana/explore",
+    )
+    expect(screen.getByRole("link", { name: /^Alerts/i })).toHaveAttribute(
+      "href",
+      "/grafana/alerting/list",
+    )
+  })
 
-    const alertsLink = screen.getByRole("link", { name: /^Alerts/i })
-    expect(alertsLink).toHaveAttribute("href", "/grafana/alerting/list")
-    expect(alertsLink).toHaveAttribute("target", "_blank")
-    expect(alertsLink).toHaveAttribute("rel", "noopener noreferrer")
+  it("mints the SSO cookie THEN navigates on an admin click", async () => {
+    const user = userEvent.setup()
+    vi.mocked(mintSsoCookie).mockResolvedValue({
+      status: "ok",
+      cookie_name: "nl_sso",
+      expires_in: 300,
+    })
+
+    render(<ObservabilitySection />)
+    await user.click(screen.getByRole("link", { name: /^Grafana/i }))
+
+    await waitFor(() => {
+      expect(assignMock).toHaveBeenCalledWith("/grafana/")
+    })
+    expect(mintSsoCookie).toHaveBeenCalledTimes(1)
+    // Ordering: the mint must be invoked before the navigation fires.
+    const order = (calls: number[]) => calls[0] ?? Infinity
+    expect(order(vi.mocked(mintSsoCookie).mock.invocationCallOrder)).toBeLessThan(
+      order(assignMock.mock.invocationCallOrder),
+    )
+    // No error surfaced.
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("shows an inline error and does NOT navigate when the mint fails", async () => {
+    const user = userEvent.setup()
+    vi.mocked(mintSsoCookie).mockRejectedValue(
+      new Error("Your session has expired. Please sign in again."),
+    )
+
+    render(<ObservabilitySection />)
+    await user.click(screen.getByRole("link", { name: /^Grafana/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /session has expired/i,
+      )
+    })
+    expect(assignMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores a second click while a mint is already in flight", async () => {
+    const user = userEvent.setup()
+    // Never-resolving mint keeps the first click pending.
+    vi.mocked(mintSsoCookie).mockImplementation(() => new Promise(() => {}))
+
+    render(<ObservabilitySection />)
+    const link = screen.getByRole("link", { name: /^Grafana/i })
+    await user.click(link)
+    await user.click(link)
+
+    await waitFor(() => {
+      expect(mintSsoCookie).toHaveBeenCalledTimes(1)
+    })
+    expect(assignMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What & why

Re-enables the admin **Observability** links (Grafana / Logs / Alerts) on the admin dashboard — reversing the `ig#1073` hide — and wires the **app-session → Grafana single-sign-on carry**. This is the frontend third of the admin-gated-Grafana SSO feature (`noorinalabs-deploy#458`), built against the owner-approved parent-domain-cookie approach.

Without the carry a top-level navigation to `/grafana` dead-ends at Grafana's own login wall. Now, on click we:

1. `POST /auth/sso-cookie` (authenticated with the current app access token) → user-service mints a short-lived `nl_sso` cookie (`Domain=noorinalabs.com`, `HttpOnly`, `Secure`, `SameSite=Lax`, `Max-Age=300`).
2. await `200`, **then** do a **same-tab top-level** `window.location.assign(href)` so `SameSite=Lax` carries the parent-domain cookie cross-subdomain. `forward_auth` on the Grafana vhost validates it and admin-gates access.

Re-mint on every click (cookie TTL is 300s). The cookie is HttpOnly — JS never reads it; the frontend only triggers the mint and navigates.

## Changes

- **`api/sso-client.ts`** (new) — `mintSsoCookie()`: `POST /auth/sso-cookie` with `credentials: 'include'` (mandatory so the browser stores the `Set-Cookie`) + bearer token. Mirrors the shared `#1016`/`#1021` recovery (one `401 -> /auth/token/refresh -> retry`), throws `ApiError` on a non-OK/failed response.
- **`pages/admin/DashboardPage.tsx`** — `ObservabilitySection` intercepts the link click (`preventDefault`), mints, then navigates. On mint failure (401/403/network) it surfaces an inline `role="alert"` error and does **NOT** navigate. In-flight guard ignores double-clicks; busy/disabled affordance while minting. The section is admin-gated via `useAuth().isAdmin` (was a hardcoded `OBSERVABILITY_LINKS_ENABLED = false`). Links no longer use `target="_blank"` — the carry needs a same-tab top-level nav.
- **Tests** — `api/__tests__/sso-client.test.ts` (mint happy-path + `credentials:include`/bearer assertions, 401->refresh->retry, 401-stands and 403 throw `ApiError`); `DashboardPage.test.tsx` (admin mounts the section + mints-then-navigates with ordering assertion, non-admin sees no links, failed mint shows error and does not navigate, double-click ignored).

## HARD CUTOVER

The links are re-enabled now, but the **live carry only works once `user-service#171` is deployed on the target env**. Do **not** promote this ahead of us#171 — until then a click mints against an endpoint that isn't live yet and surfaces the inline error.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (`eslint src/`) — 0 errors (12 pre-existing warnings, none in touched files)
- [x] `npx vitest run` — full suite **308 passed** (incl. 4 new sso-client + updated DashboardPage)
- [ ] Post-deploy of us#171 on the target env: admin clicks Grafana -> network shows `POST /auth/sso-cookie` 200 -> top-level nav to `/grafana` lands authenticated (no Grafana login wall); non-admin never sees the links.

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
