### PR TITLE
feat(profile): sync theme/language prefs to server; reconcile profile client (#1044, #1013)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './hooks/useAuth'
+import { ThemeProvider } from './hooks/useTheme'
+import PreferencesSync from './components/PreferencesSync'
 import Layout from './components/Layout'
 import AdminLayout from './components/AdminLayout'
 import ProtectedRoute from './components/ProtectedRoute'
@@ -51,58 +53,61 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <SessionExpiredModal />
-        <BrowserRouter>
-          <Routes>
-            {/* Public routes */}
-            <Route path="login" element={<LoginPage />} />
-            <Route path="auth/callback/:provider" element={<AuthCallbackPage />} />
-            <Route path="pricing" element={<PricingPage />} />
-            <Route path="billing/checkout" element={<CheckoutPage />} />
-            <Route path="trial-expired" element={<TrialExpiredPage />} />
-            <Route path="check-email" element={<CheckEmailPage />} />
-            <Route path="verify" element={<VerifyEmailPage />} />
+        <ThemeProvider>
+          <PreferencesSync />
+          <SessionExpiredModal />
+          <BrowserRouter>
+            <Routes>
+              {/* Public routes */}
+              <Route path="login" element={<LoginPage />} />
+              <Route path="auth/callback/:provider" element={<AuthCallbackPage />} />
+              <Route path="pricing" element={<PricingPage />} />
+              <Route path="billing/checkout" element={<CheckoutPage />} />
+              <Route path="trial-expired" element={<TrialExpiredPage />} />
+              <Route path="check-email" element={<CheckEmailPage />} />
+              <Route path="verify" element={<VerifyEmailPage />} />
 
-            {/* Authenticated routes */}
-            <Route element={<ProtectedRoute />}>
-              <Route element={<Layout />}>
-                <Route index element={<HomePage />} />
-                <Route path="narrators" element={<NarratorsPage />} />
-                <Route path="narrators/:id" element={<NarratorDetailPage />} />
-                <Route path="hadiths" element={<HadithsPage />} />
-                <Route path="hadiths/:id" element={<HadithDetailPage />} />
-                <Route path="collections" element={<CollectionsPage />} />
-                <Route path="collections/:id" element={<CollectionDetailPage />} />
-                <Route path="search" element={<SearchPage />} />
-                <Route path="timeline" element={<TimelinePage />} />
-                <Route path="compare" element={<ComparativePage />} />
-                <Route path="graph" element={<GraphExplorerPage />} />
-                <Route path="profile" element={<ProfilePage />} />
-              </Route>
+              {/* Authenticated routes */}
+              <Route element={<ProtectedRoute />}>
+                <Route element={<Layout />}>
+                  <Route index element={<HomePage />} />
+                  <Route path="narrators" element={<NarratorsPage />} />
+                  <Route path="narrators/:id" element={<NarratorDetailPage />} />
+                  <Route path="hadiths" element={<HadithsPage />} />
+                  <Route path="hadiths/:id" element={<HadithDetailPage />} />
+                  <Route path="collections" element={<CollectionsPage />} />
+                  <Route path="collections/:id" element={<CollectionDetailPage />} />
+                  <Route path="search" element={<SearchPage />} />
+                  <Route path="timeline" element={<TimelinePage />} />
+                  <Route path="compare" element={<ComparativePage />} />
+                  <Route path="graph" element={<GraphExplorerPage />} />
+                  <Route path="profile" element={<ProfilePage />} />
+                </Route>
 
-              {/* Admin routes — require isAdmin */}
-              <Route element={<AdminRoute />}>
-                <Route path="admin" element={<AdminLayout />}>
-                  <Route index element={<Navigate to="/admin/dashboard" replace />} />
-                  <Route path="dashboard" element={<DashboardPage />} />
-                  <Route path="users" element={<UserManagementPage />} />
-                  <Route path="health" element={<SystemHealthPage />} />
-                  <Route path="stats" element={<ContentStatsPage />} />
-                  <Route path="data" element={<DataManagementPage />} />
-                  <Route path="analytics" element={<UsageAnalyticsPage />} />
-                  <Route path="moderation" element={<ModerationPage />} />
-                  <Route path="reports" element={<ReportsPage />} />
-                  <Route path="config" element={<ConfigPage />} />
-                  <Route path="audit" element={<AuditLogPage />} />
-                  <Route path="reset" element={<ResetPage />} />
+                {/* Admin routes — require isAdmin */}
+                <Route element={<AdminRoute />}>
+                  <Route path="admin" element={<AdminLayout />}>
+                    <Route index element={<Navigate to="/admin/dashboard" replace />} />
+                    <Route path="dashboard" element={<DashboardPage />} />
+                    <Route path="users" element={<UserManagementPage />} />
+                    <Route path="health" element={<SystemHealthPage />} />
+                    <Route path="stats" element={<ContentStatsPage />} />
+                    <Route path="data" element={<DataManagementPage />} />
+                    <Route path="analytics" element={<UsageAnalyticsPage />} />
+                    <Route path="moderation" element={<ModerationPage />} />
+                    <Route path="reports" element={<ReportsPage />} />
+                    <Route path="config" element={<ConfigPage />} />
+                    <Route path="audit" element={<AuditLogPage />} />
+                    <Route path="reset" element={<ResetPage />} />
+                  </Route>
                 </Route>
               </Route>
-            </Route>
 
-            {/* Catch-all 404 */}
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
-        </BrowserRouter>
+              {/* Catch-all 404 */}
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </BrowserRouter>
+        </ThemeProvider>
       </AuthProvider>
     </QueryClientProvider>
   )

--- a/frontend/src/api/__tests__/profile-client-refresh.test.ts
+++ b/frontend/src/api/__tests__/profile-client-refresh.test.ts
@@ -14,7 +14,8 @@ import { SESSION_EXPIRED_EVENT } from '../../hooks/useAuth'
 const REFRESH_URL = '/auth/token/refresh'
 // Origin resolves to '' (same-origin) in the test env, so the profile URLs are bare.
 const PROFILE_URL = '/api/v1/users/me/profile'
-const SESSIONS_URL = '/api/v1/users/me/sessions'
+// Sessions are a sibling collection, NOT under /users/me (matches sessions.py).
+const SESSIONS_URL = '/api/v1/sessions'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {

--- a/frontend/src/api/__tests__/profile-client.test.ts
+++ b/frontend/src/api/__tests__/profile-client.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchSessions,
+  replacePreferences,
+  updateDisplayName,
+  type UserPreferences,
+} from '../profile-client'
+
+// Endpoint-shape regression tests reconciling the client with the merged
+// user-service contract (us#165 + sessions US#7): preferences are REPLACED via
+// PUT /users/me/profile, the display name is a PATCH on /users/me, and sessions
+// live at /api/v1/sessions returning `{ sessions, count }` — not under /users/me.
+
+const fetchMock = vi.fn()
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+  } as Response
+}
+
+beforeEach(() => {
+  localStorage.setItem('access_token', 'tok')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('profile-client endpoints', () => {
+  it('replacePreferences PUTs the full blob to /users/me/profile', async () => {
+    const prefs: UserPreferences = { theme: 'dark', language: 'ar', custom_key: 'keep' }
+    fetchMock.mockResolvedValue(jsonResponse({ user_id: 'u1', preferences: prefs }))
+
+    const result = await replacePreferences(prefs)
+
+    expect(result).toMatchObject({ user_id: 'u1' })
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toBe('/api/v1/users/me/profile')
+    expect((init as RequestInit).method).toBe('PUT')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ preferences: prefs })
+  })
+
+  it('updateDisplayName PATCHes /users/me (not the preferences blob)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'u1', display_name: 'New' }))
+
+    await updateDisplayName('New')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toBe('/api/v1/users/me')
+    expect((init as RequestInit).method).toBe('PATCH')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ display_name: 'New' })
+  })
+
+  it('fetchSessions hits /api/v1/sessions and unwraps the rows', async () => {
+    const rows = [
+      {
+        id: 's1',
+        ip_address: '1.2.3.4',
+        user_agent: 'x',
+        created_at: 'c',
+        last_active: 'l',
+        expires_at: 'e',
+        is_current: true,
+      },
+    ]
+    fetchMock.mockResolvedValue(jsonResponse({ sessions: rows, count: 1 }))
+
+    const result = await fetchSessions()
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('/api/v1/sessions')
+    expect(result).toEqual(rows)
+  })
+})

--- a/frontend/src/api/profile-client.ts
+++ b/frontend/src/api/profile-client.ts
@@ -3,7 +3,7 @@ import { getAuthHeaders } from './auth-headers'
 import { refreshAccessToken } from './token-refresh'
 import { apiError } from './api-error'
 
-// Absolute URL targeting the user-service vhost (`users.{base}`). See
+// Absolute URLs targeting the user-service vhost (`users.{base}`). See
 // useAuth.ts for the full BASE-constant set and the runtime-vs-build-time
 // resolution rationale; kept duplicated here to avoid a barrel-export refactor
 // inside this PR.
@@ -11,7 +11,11 @@ const USER_SERVICE_ORIGIN =
   (typeof window !== 'undefined' && window.RUNTIME_CONFIG?.USER_SERVICE_ORIGIN) ||
   import.meta.env.VITE_USER_SERVICE_ORIGIN ||
   ''
-const API_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
+// `/api/v1/users/me` covers the user record (PATCH) and its preferences blob
+// (`/profile`). Sessions are a sibling collection at `/api/v1/sessions` — NOT
+// under `/users/me` — matching the user-service routers (us#165 / sessions US#7).
+const USER_BASE = `${USER_SERVICE_ORIGIN}/api/v1/users/me`
+const SESSIONS_BASE = `${USER_SERVICE_ORIGIN}/api/v1/sessions`
 
 // Issue an authenticated request; on a 401 attempt ONE shared token refresh
 // (POST /auth/token/refresh via the httpOnly refresh cookie) and retry the
@@ -46,54 +50,80 @@ async function fetchProfileJson<T>(url: string, init?: RequestInit): Promise<T> 
   return res.json() as Promise<T>
 }
 
+/**
+ * A user's UI/UX preferences (the JSONB blob behind `/users/me/profile`).
+ *
+ * The user-service type-checks only the two well-known keys — `theme` and
+ * `language` — and round-trips any other key untouched (`extra="allow"`, 8 KB
+ * cap). The index signature models that pass-through: a read-modify-write of the
+ * whole object must preserve keys this client does not know about.
+ */
 export interface UserPreferences {
-  default_search_mode: string
-  results_per_page: number
-  language_preference: string
-  theme_preference: string
+  theme?: 'light' | 'dark' | 'system'
+  language?: string
+  default_search_mode?: string
+  results_per_page?: number
+  [key: string]: unknown
 }
 
-export interface UserProfile {
-  id: string
-  email: string
-  name: string
-  provider: string
-  role: string | null
-  is_admin: boolean
-  created_at: string
+export interface ProfileRead {
+  user_id: string
   preferences: UserPreferences
 }
 
 export interface SessionInfo {
   id: string
-  created_at: string
-  last_active: string
   ip_address: string | null
   user_agent: string | null
+  created_at: string
+  last_active: string
+  expires_at: string
   is_current: boolean
 }
 
-export async function fetchProfile(): Promise<UserProfile> {
-  return fetchProfileJson(`${API_BASE}/profile`)
+interface SessionListResponse {
+  sessions: SessionInfo[]
+  count: number
 }
 
-export async function updateProfile(body: {
-  display_name?: string
-  preferences?: UserPreferences
-}): Promise<UserProfile> {
-  return fetchProfileJson(`${API_BASE}/profile`, {
+export async function fetchProfile(): Promise<ProfileRead> {
+  return fetchProfileJson(`${USER_BASE}/profile`)
+}
+
+/**
+ * Replace the preferences blob wholesale. The endpoint is PUT with REPLACE
+ * semantics (us#165) — there is no server-side merge — so callers MUST pass the
+ * full object (read-modify-write) or unrelated keys are dropped.
+ */
+export async function replacePreferences(preferences: UserPreferences): Promise<ProfileRead> {
+  return fetchProfileJson(`${USER_BASE}/profile`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ preferences }),
+  })
+}
+
+/**
+ * Update the display name. This lives on the user record, not the preferences
+ * blob, so it is a PATCH to `/users/me` (UserUpdate) — distinct from the
+ * preferences PUT above.
+ */
+export async function updateDisplayName(displayName: string): Promise<void> {
+  await fetchProfileJson(USER_BASE, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ display_name: displayName }),
   })
 }
 
 export async function fetchSessions(): Promise<SessionInfo[]> {
-  return fetchProfileJson(`${API_BASE}/sessions`)
+  // The list endpoint wraps the rows in `{ sessions, count }`; callers want the rows.
+  const data = await fetchProfileJson<SessionListResponse>(SESSIONS_BASE)
+  return data.sessions
 }
 
 export async function revokeSession(sessionId: string): Promise<void> {
-  const res = await fetchWithRefresh(`${API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+  const res = await fetchWithRefresh(`${SESSIONS_BASE}/${encodeURIComponent(sessionId)}`, {
     method: 'DELETE',
   })
   if (res.status === 401) {

--- a/frontend/src/components/PreferencesSync.tsx
+++ b/frontend/src/components/PreferencesSync.tsx
@@ -1,0 +1,11 @@
+import { useProfilePreferenceSync } from '../hooks/useProfilePreferenceSync'
+
+/**
+ * Headless component: on login it hydrates the live theme + UI locale from the
+ * authenticated user's server-stored preferences (#1044). Renders nothing; it
+ * exists only to host the sync effect inside the Auth/Theme/Query providers.
+ */
+export default function PreferencesSync() {
+  useProfilePreferenceSync()
+  return null
+}

--- a/frontend/src/hooks/__tests__/useProfilePreferenceSync.test.tsx
+++ b/frontend/src/hooks/__tests__/useProfilePreferenceSync.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import i18n from '../../i18n'
+import { ThemeProvider } from '../useTheme'
+
+// Controllable auth + profile mocks. The hook is the server→client bridge that
+// makes login the source of truth for theme/locale (#1044) while leaving the
+// anonymous path on localStorage.
+let mockUser: { id: string } | null = null
+vi.mock('../useAuth', () => ({
+  useAuth: () => ({ user: mockUser }),
+  emitSessionExpired: vi.fn(),
+}))
+
+const fetchProfile = vi.fn()
+vi.mock('../../api/profile-client', () => ({
+  fetchProfile: () => fetchProfile(),
+}))
+
+import { useProfilePreferenceSync } from '../useProfilePreferenceSync'
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: qc },
+      createElement(ThemeProvider, null, children),
+    )
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  )
+  localStorage.clear()
+  fetchProfile.mockReset()
+  mockUser = null
+})
+
+afterEach(async () => {
+  await act(async () => {
+    await i18n.changeLanguage('en')
+  })
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('useProfilePreferenceSync', () => {
+  it('hydrates the live theme + locale from the server on login', async () => {
+    mockUser = { id: 'u1' }
+    fetchProfile.mockResolvedValue({
+      user_id: 'u1',
+      preferences: { theme: 'dark', language: 'ar' },
+    })
+
+    renderHook(() => useProfilePreferenceSync(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(localStorage.getItem('isnad-graph-theme')).toBe('dark'))
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    await waitFor(() => expect(i18n.language).toBe('ar'))
+  })
+
+  it('leaves an anonymous session on localStorage (no fetch, no override)', async () => {
+    mockUser = null
+    localStorage.setItem('isnad-graph-theme', 'light')
+
+    renderHook(() => useProfilePreferenceSync(), { wrapper: makeWrapper() })
+
+    expect(fetchProfile).not.toHaveBeenCalled()
+    expect(localStorage.getItem('isnad-graph-theme')).toBe('light')
+    expect(i18n.language).toBe('en')
+  })
+
+  it('ignores an unsupported server locale rather than switching to it', async () => {
+    mockUser = { id: 'u2' }
+    fetchProfile.mockResolvedValue({
+      user_id: 'u2',
+      preferences: { theme: 'light', language: 'xx-not-a-locale' },
+    })
+
+    renderHook(() => useProfilePreferenceSync(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(localStorage.getItem('isnad-graph-theme')).toBe('light'))
+    expect(i18n.language).toBe('en')
+  })
+})

--- a/frontend/src/hooks/useProfilePreferenceSync.ts
+++ b/frontend/src/hooks/useProfilePreferenceSync.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+
+import { fetchProfile } from '../api/profile-client'
+import { isSupportedLocale } from '../i18n/config'
+import { useAuth } from './useAuth'
+import { useTheme } from './useTheme'
+
+/**
+ * On login, make the server the source of truth for the two cross-device UI
+ * preferences — the color theme and the UI locale — by hydrating `useTheme` and
+ * i18next from the authenticated user's stored preferences.
+ *
+ * Anonymous/offline sessions are untouched (`enabled` is gated on `user`): the
+ * theme hook and i18n keep using their localStorage values, which also act as
+ * the last-writer-wins cache once authenticated.
+ *
+ * Hydration runs once per authenticated user (keyed on user id). A mid-session
+ * change on the Profile page must not be clobbered by a re-render re-applying the
+ * now-stale server value; a fresh login (a different id) re-hydrates.
+ */
+export function useProfilePreferenceSync(): void {
+  const { user } = useAuth()
+  const { setTheme } = useTheme()
+  const { i18n } = useTranslation()
+  const hydratedFor = useRef<string | null>(null)
+
+  const { data } = useQuery({
+    queryKey: ['profile'],
+    queryFn: fetchProfile,
+    enabled: Boolean(user),
+  })
+
+  useEffect(() => {
+    if (!user) {
+      // Logged out — let the next login hydrate afresh.
+      hydratedFor.current = null
+      return
+    }
+    if (!data || hydratedFor.current === user.id) return
+    hydratedFor.current = user.id
+
+    const { theme, language } = data.preferences
+    if (theme === 'light' || theme === 'dark' || theme === 'system') {
+      setTheme(theme)
+    }
+    if (typeof language === 'string' && isSupportedLocale(language)) {
+      void i18n.changeLanguage(language)
+    }
+  }, [user, data, setTheme, i18n])
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,8 +1,23 @@
-import { useState, useEffect, useCallback } from 'react'
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
 
 type Theme = 'light' | 'dark' | 'system'
 
 const STORAGE_KEY = 'isnad-graph-theme'
+
+export interface ThemeContextValue {
+  theme: Theme
+  resolvedTheme: 'light' | 'dark'
+  setTheme: (theme: Theme) => void
+  toggle: () => void
+}
 
 function getSystemTheme(): 'light' | 'dark' {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
@@ -13,12 +28,27 @@ function applyTheme(theme: Theme) {
   document.documentElement.setAttribute('data-theme', resolved)
 }
 
-export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
-    return 'system'
-  })
+function readStoredTheme(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+  return 'system'
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+/**
+ * Holds the single, app-wide theme state. Mounted once near the root so every
+ * consumer — the header toggle, the user menu, the Profile selector, and the
+ * login-time server hydration — reads and writes the same value. Previously each
+ * caller spun up its own `useState`, so the Profile "Theme" control could never
+ * be a real source of truth for the live theme (#1013/#1044).
+ *
+ * localStorage (`isnad-graph-theme`) remains the persistence layer and the
+ * anonymous/offline fallback; server hydration on login simply calls `setTheme`,
+ * which writes through to it (last-writer-wins).
+ */
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme)
 
   const setTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme)
@@ -39,10 +69,30 @@ export function useTheme() {
   }, [theme])
 
   const toggle = useCallback(() => {
-    setTheme(theme === 'dark' ? 'light' : theme === 'light' ? 'dark' : getSystemTheme() === 'dark' ? 'light' : 'dark')
+    setTheme(
+      theme === 'dark'
+        ? 'light'
+        : theme === 'light'
+          ? 'dark'
+          : getSystemTheme() === 'dark'
+            ? 'light'
+            : 'dark',
+    )
   }, [theme, setTheme])
 
   const resolvedTheme = theme === 'system' ? getSystemTheme() : theme
 
-  return { theme, resolvedTheme, setTheme, toggle }
+  return createElement(
+    ThemeContext.Provider,
+    { value: { theme, resolvedTheme, setTheme, toggle } },
+    children,
+  )
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (ctx === null) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return ctx
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,12 +1,18 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
 import {
   fetchProfile,
-  updateProfile,
   fetchSessions,
+  replacePreferences,
   revokeSession,
+  updateDisplayName,
 } from '../api/profile-client'
 import type { UserPreferences } from '../api/profile-client'
+import { useAuth } from '../hooks/useAuth'
+import { useTheme } from '../hooks/useTheme'
+import { useLocale } from '../i18n/useLocale'
+import type { LocaleCode } from '../i18n/config'
 
 function providerLabel(provider: string): string {
   switch (provider) {
@@ -23,7 +29,7 @@ function providerLabel(provider: string): string {
   }
 }
 
-function roleBadgeColor(role: string | null): string {
+function roleBadgeColor(role: string): string {
   switch (role) {
     case 'admin':
       return 'var(--color-destructive)'
@@ -38,10 +44,20 @@ function roleBadgeColor(role: string | null): string {
 
 export default function ProfilePage() {
   const queryClient = useQueryClient()
+  const { user, role, refreshUser } = useAuth()
+  // The live theme + locale are the single source of truth for the controls
+  // below; on login they are hydrated from the server (see PreferencesSync), and
+  // a change here drives the app immediately as well as persisting (#1013/#1044).
+  const { theme, setTheme } = useTheme()
+  const { locale, locales, setLocale } = useLocale()
   const [editingName, setEditingName] = useState(false)
   const [nameInput, setNameInput] = useState('')
 
-  const { data: profile, isLoading, error } = useQuery({
+  // The profile query carries the full preferences blob — needed for a
+  // read-modify-write PUT and for the non-theme/locale prefs (search mode,
+  // results per page). Account info (name/email/role/...) comes from the auth
+  // user, not this endpoint, which returns only `{ user_id, preferences }`.
+  const { data: profile } = useQuery({
     queryKey: ['profile'],
     queryFn: fetchProfile,
   })
@@ -51,17 +67,19 @@ export default function ProfilePage() {
     queryFn: fetchSessions,
   })
 
+  const prefs: UserPreferences = profile?.preferences ?? {}
+
   const updateNameMutation = useMutation({
-    mutationFn: (displayName: string) => updateProfile({ display_name: displayName }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['profile'] })
+    mutationFn: (displayName: string) => updateDisplayName(displayName),
+    onSuccess: async () => {
+      await refreshUser()
       setEditingName(false)
     },
   })
 
-  const updatePrefsMutation = useMutation({
-    mutationFn: (preferences: UserPreferences) => updateProfile({ preferences }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['profile'] }),
+  const replacePrefsMutation = useMutation({
+    mutationFn: (preferences: UserPreferences) => replacePreferences(preferences),
+    onSuccess: (data) => queryClient.setQueryData(['profile'], data),
   })
 
   const revokeSessionMutation = useMutation({
@@ -69,9 +87,24 @@ export default function ProfilePage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['sessions'] }),
   })
 
-  if (isLoading) return <p>Loading profile...</p>
-  if (error) return <p className="error-text">Error: {(error as Error).message}</p>
-  if (!profile) return null
+  // Read-modify-write: PUT replaces the whole blob, so spread the current prefs
+  // and overlay the changed key(s) to avoid dropping the others.
+  function persistPrefs(patch: Partial<UserPreferences>) {
+    replacePrefsMutation.mutate({ ...prefs, ...patch })
+  }
+
+  function handleThemeChange(value: string) {
+    const next = value as 'light' | 'dark' | 'system'
+    setTheme(next)
+    persistPrefs({ theme: next })
+  }
+
+  function handleLanguageChange(value: string) {
+    setLocale(value as LocaleCode)
+    persistPrefs({ language: value })
+  }
+
+  if (!user) return null
 
   const sectionStyle: React.CSSProperties = {
     marginBottom: 'var(--spacing-6)',
@@ -92,6 +125,8 @@ export default function ProfilePage() {
     color: 'var(--color-foreground)',
     fontWeight: 500,
   }
+
+  const displayName = user.display_name ?? user.email
 
   return (
     <div style={{ maxWidth: 720 }}>
@@ -135,11 +170,11 @@ export default function ProfilePage() {
               </div>
             ) : (
               <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-2)' }}>
-                <span style={valueStyle}>{profile.name}</span>
+                <span style={valueStyle}>{displayName}</span>
                 <button
                   className="btn"
                   onClick={() => {
-                    setNameInput(profile.name)
+                    setNameInput(user.display_name ?? '')
                     setEditingName(true)
                   }}
                   style={{ fontSize: 'var(--text-xs)', padding: 'var(--spacing-0_5) var(--spacing-2)' }}
@@ -151,17 +186,15 @@ export default function ProfilePage() {
           </div>
           <div>
             <div style={labelStyle}>Email</div>
-            <div style={valueStyle}>{profile.email}</div>
+            <div style={valueStyle}>{user.email}</div>
           </div>
           <div>
             <div style={labelStyle}>Auth Provider</div>
-            <div style={valueStyle}>{providerLabel(profile.provider)}</div>
+            <div style={valueStyle}>{user.provider ? providerLabel(user.provider) : '—'}</div>
           </div>
           <div>
             <div style={labelStyle}>Member Since</div>
-            <div style={valueStyle}>
-              {new Date(profile.created_at).toLocaleDateString()}
-            </div>
+            <div style={valueStyle}>{new Date(user.created_at).toLocaleDateString()}</div>
           </div>
           <div>
             <div style={labelStyle}>Role</div>
@@ -173,10 +206,10 @@ export default function ProfilePage() {
                 fontWeight: 600,
                 borderRadius: 'var(--radius-full)',
                 color: 'var(--color-primary-foreground)',
-                background: roleBadgeColor(profile.role),
+                background: roleBadgeColor(role),
               }}
             >
-              {(profile.role ?? 'trial').toUpperCase()}
+              {role.toUpperCase()}
             </span>
           </div>
         </div>
@@ -198,13 +231,8 @@ export default function ProfilePage() {
             <div style={labelStyle}>Default Search Mode</div>
             <select
               className="form-input"
-              value={profile.preferences.default_search_mode}
-              onChange={(e) =>
-                updatePrefsMutation.mutate({
-                  ...profile.preferences,
-                  default_search_mode: e.target.value,
-                })
-              }
+              value={prefs.default_search_mode ?? 'fulltext'}
+              onChange={(e) => persistPrefs({ default_search_mode: e.target.value })}
             >
               <option value="fulltext">Full Text</option>
               <option value="semantic">Semantic</option>
@@ -214,13 +242,8 @@ export default function ProfilePage() {
             <div style={labelStyle}>Results Per Page</div>
             <select
               className="form-input"
-              value={profile.preferences.results_per_page}
-              onChange={(e) =>
-                updatePrefsMutation.mutate({
-                  ...profile.preferences,
-                  results_per_page: Number(e.target.value),
-                })
-              }
+              value={prefs.results_per_page ?? 20}
+              onChange={(e) => persistPrefs({ results_per_page: Number(e.target.value) })}
             >
               {[10, 20, 50, 100].map((n) => (
                 <option key={n} value={n}>
@@ -230,32 +253,25 @@ export default function ProfilePage() {
             </select>
           </div>
           <div>
-            <div style={labelStyle}>Language (stub)</div>
+            <div style={labelStyle}>Language</div>
             <select
               className="form-input"
-              value={profile.preferences.language_preference}
-              onChange={(e) =>
-                updatePrefsMutation.mutate({
-                  ...profile.preferences,
-                  language_preference: e.target.value,
-                })
-              }
+              value={locale}
+              onChange={(e) => handleLanguageChange(e.target.value)}
             >
-              <option value="en">English</option>
-              <option value="ar">Arabic</option>
+              {locales.map((l) => (
+                <option key={l.code} value={l.code} lang={l.code}>
+                  {l.nativeName}
+                </option>
+              ))}
             </select>
           </div>
           <div>
-            <div style={labelStyle}>Theme (stub)</div>
+            <div style={labelStyle}>Theme</div>
             <select
               className="form-input"
-              value={profile.preferences.theme_preference}
-              onChange={(e) =>
-                updatePrefsMutation.mutate({
-                  ...profile.preferences,
-                  theme_preference: e.target.value,
-                })
-              }
+              value={theme}
+              onChange={(e) => handleThemeChange(e.target.value)}
             >
               <option value="system">System</option>
               <option value="light">Light</option>
@@ -263,7 +279,7 @@ export default function ProfilePage() {
             </select>
           </div>
         </div>
-        {updatePrefsMutation.isPending && (
+        {replacePrefsMutation.isPending && (
           <p style={{ marginTop: 'var(--spacing-2)', fontSize: 'var(--text-xs)' }}>Saving...</p>
         )}
       </div>
@@ -299,9 +315,9 @@ export default function ProfilePage() {
                     <button
                       className="btn-action btn-action-suspend"
                       onClick={() => revokeSessionMutation.mutate(s.id)}
-                      disabled={revokeSessionMutation.isPending}
+                      disabled={revokeSessionMutation.isPending || s.is_current}
                     >
-                      Revoke
+                      {s.is_current ? 'Current' : 'Revoke'}
                     </button>
                   </td>
                 </tr>

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createElement, type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import i18n from '../../i18n'
+import { ThemeProvider } from '../../hooks/useTheme'
+
+const mockRefreshUser = vi.fn()
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'u1',
+      email: 'a@b.c',
+      display_name: 'Aisha',
+      provider: 'google',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    role: 'researcher',
+    refreshUser: mockRefreshUser,
+  }),
+  emitSessionExpired: vi.fn(),
+}))
+
+const fetchProfile = vi.fn()
+const fetchSessions = vi.fn()
+const replacePreferences = vi.fn()
+const updateDisplayName = vi.fn()
+vi.mock('../../api/profile-client', () => ({
+  fetchProfile: () => fetchProfile(),
+  fetchSessions: () => fetchSessions(),
+  replacePreferences: (p: unknown) => replacePreferences(p),
+  updateDisplayName: (n: string) => updateDisplayName(n),
+}))
+
+import ProfilePage from '../ProfilePage'
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: qc },
+      createElement(ThemeProvider, null, children),
+    )
+  }
+}
+
+// The full server-stored blob, including a key this client does not model — a
+// read-modify-write PUT must preserve it.
+const BASE_PREFS = {
+  theme: 'light',
+  language: 'en',
+  default_search_mode: 'semantic',
+  results_per_page: 50,
+  custom_key: 'keep',
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  )
+  localStorage.clear()
+  localStorage.setItem('isnad-graph-theme', 'light')
+  fetchProfile.mockResolvedValue({ user_id: 'u1', preferences: { ...BASE_PREFS } })
+  fetchSessions.mockResolvedValue([
+    {
+      id: 's1',
+      ip_address: '1.2.3.4',
+      user_agent: 'x',
+      created_at: '2026-01-01T00:00:00Z',
+      last_active: '2026-01-02T00:00:00Z',
+      expires_at: '2026-02-01T00:00:00Z',
+      is_current: false,
+    },
+  ])
+  replacePreferences.mockImplementation((p) => Promise.resolve({ user_id: 'u1', preferences: p }))
+})
+
+afterEach(async () => {
+  await act(async () => {
+    await i18n.changeLanguage('en')
+  })
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('ProfilePage', () => {
+  it('renders account info and drops the (stub) labels', async () => {
+    render(<ProfilePage />, { wrapper: makeWrapper() })
+
+    expect(await screen.findByText('Aisha')).toBeInTheDocument()
+    expect(screen.getByText('a@b.c')).toBeInTheDocument()
+    expect(screen.getByText('Google')).toBeInTheDocument()
+    expect(screen.getByText('RESEARCHER')).toBeInTheDocument()
+    // Controls are wired through, not stubs.
+    expect(screen.getByText('Theme')).toBeInTheDocument()
+    expect(screen.getByText('Language')).toBeInTheDocument()
+    expect(screen.queryByText(/stub/i)).not.toBeInTheDocument()
+  })
+
+  it('Theme select reflects the live theme; a change drives it and persists the full blob', async () => {
+    const user = userEvent.setup()
+    render(<ProfilePage />, { wrapper: makeWrapper() })
+
+    await screen.findByText('Aisha')
+    // value=theme='light' (from localStorage) → selected option text "Light".
+    const themeSelect = screen.getByDisplayValue('Light')
+
+    await user.selectOptions(themeSelect, 'dark')
+
+    // Drives the live theme immediately (single source of truth).
+    await waitFor(() => expect(document.documentElement.getAttribute('data-theme')).toBe('dark'))
+    // Persists the FULL blob with only `theme` changed (custom_key preserved).
+    await waitFor(() => expect(replacePreferences).toHaveBeenCalled())
+    expect(replacePreferences).toHaveBeenLastCalledWith({ ...BASE_PREFS, theme: 'dark' })
+  })
+
+  it('Language select reflects the locale; a change switches i18n and persists', async () => {
+    const user = userEvent.setup()
+    render(<ProfilePage />, { wrapper: makeWrapper() })
+
+    await screen.findByText('Aisha')
+    const languageSelect = screen.getByDisplayValue('English')
+
+    await user.selectOptions(languageSelect, 'ar')
+
+    await waitFor(() => expect(i18n.language).toBe('ar'))
+    expect(replacePreferences).toHaveBeenLastCalledWith({ ...BASE_PREFS, language: 'ar' })
+  })
+
+  it('renders active sessions from the sessions endpoint', async () => {
+    render(<ProfilePage />, { wrapper: makeWrapper() })
+    expect(await screen.findByText('1.2.3.4')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Makes the Profile **Theme** and **Language** controls real, server-backed preferences and reconciles the profile/session client with the merged user-service contract (us#165 / PR#170).

- **ig#1013 (bug):** the Profile Theme/Language selects were inert stubs — they wrote to a persisted `preferences` blob nothing consumed, while the live theme/locale were driven independently by `useTheme`/i18next. The `(stub)` labels are gone; the selects now drive the live theme/locale.
- **ig#1044 (feature):** on login the live theme + UI locale are **hydrated from the server** (`GET /users/me/profile`), and a change **persists** back. Server is source-of-truth when authenticated; localStorage stays the anonymous/offline fallback (last-writer-wins).

Done together because they touch the same files (`ProfilePage.tsx`, `profile-client.ts`, the theme hook).

## Key changes

- **`useTheme` -> `ThemeProvider` context.** Previously every caller spun its own `useState`, so the Profile control could never be a real source of truth. Now one app-wide state backs the header toggle, user menu, Profile selector, and login hydration. (3 call sites; no behavior change for `ThemeToggle`/`UserMenu`.)
- **`useProfilePreferenceSync` + headless `<PreferencesSync />`** (mounted in `App`): hydrates theme + locale from the server once per authenticated user id (a mid-session toggle isn't clobbered; a fresh login re-hydrates). Disabled for anonymous sessions.
- **`ProfilePage`**: Theme/Language selectors drive the live theme/locale **and** persist via read-modify-write of the whole blob (PUT replaces wholesale, so unrelated keys are preserved). Account info (name/email/role/provider/created) now comes from the **auth user**, since `/users/me/profile` returns only `{ user_id, preferences }`.
- **`profile-client` reconciliation with the real backend (no more 404s):**
  - `updateProfile` PATCH -> **`replacePreferences` PUT `/users/me/profile`** (us#165 replace semantics).
  - Sessions: **`/api/v1/sessions`** (was `/users/me/sessions` -> 404), unwrapped from `{ sessions, count }`.
  - Display name: **PATCH `/users/me`** (UserUpdate), distinct from the preferences blob.

## Test Plan

- `npx tsc --noEmit` — clean.
- `npx eslint src/` — clean (exit 0; only pre-existing warnings in unrelated files).
- `npx vitest run` — **310 passed**. New/updated specs:
  - `api/__tests__/profile-client.test.ts` — PUT body shape, PATCH `/users/me`, sessions path + `{sessions,count}` unwrap.
  - `api/__tests__/profile-client-refresh.test.ts` — updated sessions path to `/api/v1/sessions`.
  - `hooks/__tests__/useProfilePreferenceSync.test.tsx` — login hydration (restores), anonymous stays on localStorage, unsupported locale ignored.
  - `pages/__tests__/ProfilePage.test.tsx` — renders against mocked endpoints, no `(stub)` labels, Theme/Language drive the live value + persist the full blob, sessions render.

### Manual / runtime (post-merge, needs a live user-service)
- Log in -> confirm Profile Theme/Language reflect server prefs; toggle -> page theme/locale changes immediately and reloads persist.
- Confirm Active Sessions table populates (no 404 on `/api/v1/sessions`).

Closes #1044
Closes #1013
