### PR TITLE
fix(ig#1070): saturating relevance transform for absolute confidence

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -840,11 +840,16 @@ export default function SearchPage() {
  * Result card components
  * ─────────────────────────────────────────── */
 
-// Exported for unit testing (ig#1065).
+// Exported for unit testing (ig#1065, ig#1070).
 export function RelevanceBadge({ score }: { score: number }) {
+  // The API now applies a saturating transform `score / (score + k)` (ig#1070)
+  // so these thresholds read as ABSOLUTE confidence: a weak top hit no longer
+  // renders 100% the way the old within-result-set max-normalisation forced.
+  // TODO(ig#1071 calibration): these cutoffs must be re-tuned jointly with the
+  // backend `SEARCH_RELEVANCE_SATURATION_K` once a real BM25 distribution exists.
   const level =
     score >= 0.9 ? 'text-sahih' : score >= 0.7 ? 'text-warning' : 'text-muted-foreground'
-  // Defensive clamp: the API normalises scores to [0,1] (ig#1065), but guard
+  // Defensive clamp: the API bounds scores to [0,1) (ig#1065/#1070), but guard
   // here too so a stale or out-of-range value never renders >100% or negative.
   const pct = Math.min(100, Math.max(0, score * 100)).toFixed(0)
   return (

--- a/frontend/src/pages/__tests__/SearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/SearchPage.test.tsx
@@ -28,3 +28,23 @@ describe('RelevanceBadge (ig#1065)', () => {
     expect(screen.getByText('0%')).toBeTruthy()
   })
 })
+
+describe('RelevanceBadge absolute-confidence thresholds (ig#1070)', () => {
+  // Under the saturating API transform the badge colour reads as absolute
+  // confidence, so a weak top hit is muted rather than promoted to sahih green.
+  it('colours a strong score (>=0.9) as sahih', () => {
+    const { container } = render(<RelevanceBadge score={0.92} />)
+    expect(container.querySelector('.text-sahih')).toBeTruthy()
+  })
+
+  it('colours a mid score (>=0.7) as warning', () => {
+    const { container } = render(<RelevanceBadge score={0.75} />)
+    expect(container.querySelector('.text-warning')).toBeTruthy()
+  })
+
+  it('colours a weak score (<0.7) as muted, not sahih', () => {
+    const { container } = render(<RelevanceBadge score={0.3} />)
+    expect(container.querySelector('.text-muted-foreground')).toBeTruthy()
+    expect(container.querySelector('.text-sahih')).toBeNull()
+  })
+})

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from src.api.deps import get_neo4j, get_pg
 from src.api.models import SearchResult, SearchResultsResponse
+from src.config import get_settings
 from src.enrich.embeddings import get_embedder, to_pgvector_literal
 from src.utils.grades import normalize_grade
 from src.utils.neo4j_client import Neo4jClient
@@ -30,6 +31,27 @@ def _death_year_to_century(death_year_ah: object) -> int | None:
     if isinstance(death_year_ah, int) and death_year_ah > 0:
         return (death_year_ah - 1) // 100 + 1
     return None
+
+
+def saturate_relevance(score: float, k: float) -> float:
+    """Map a raw BM25-style score onto a badge-friendly [0, 1) confidence.
+
+    Uses the saturating transform ``score / (score + k)``: strictly monotonic in
+    ``score`` (preserves relative ranking), bounded to ``[0, 1)`` for any
+    non-negative input, and — unlike the within-result-set max-normalisation it
+    replaces (ig#1065) — it does NOT force the top hit of every query to exactly
+    1.0. A weak top hit therefore reads as a weak *absolute* confidence rather
+    than 100%, which is the whole point of ig#1070.
+
+    ``k`` is the half-saturation constant (the raw score that maps to 0.5); it is
+    configurable via ``Settings.search.relevance_saturation_k`` and must be
+    calibrated against the real score distribution — see ``SearchSettings``.
+    Negative raw scores are clamped to 0.0 (degenerate / never expected for
+    full-text BM25, but cheap insurance).
+    """
+    if score <= 0.0:
+        return 0.0
+    return score / (score + k)
 
 
 @router.get("/search", response_model=SearchResultsResponse)
@@ -91,15 +113,20 @@ def search(
                 )
             )
 
-    # --- Normalize Lucene scores to [0, 1] ---
+    # --- Saturating relevance transform (absolute confidence) ---
     # Neo4j's ``db.index.fulltext.queryNodes`` returns unbounded BM25-style
-    # scores (commonly 1–5, but no upper bound). The frontend multiplies by 100
+    # scores (commonly 1–10, but no upper bound). The frontend multiplies by 100
     # to render a percentage, so a raw score of 2.5 would display as "250%".
-    # Max-normalisation maps the top result to 1.0 and preserves relative order.
+    #
+    # ig#1065 bounded this with within-result-set max-normalisation, but that
+    # forced the top hit of *every* query to exactly 100% regardless of how
+    # strong the match actually was — the badge colour thresholds then read as
+    # rank-within-result-set, not absolute confidence. ig#1070 replaces it with
+    # ``score / (score + k)`` (monotonic, bounded [0, 1), top hit no longer pinned
+    # to 1.0). ``k`` is configurable / calibration-pending — see ``SearchSettings``.
     if results:
-        max_score = max(r.score for r in results)
-        if max_score > 0:
-            results = [r.model_copy(update={"score": r.score / max_score}) for r in results]
+        k = get_settings().search.relevance_saturation_k
+        results = [r.model_copy(update={"score": saturate_relevance(r.score, k)}) for r in results]
 
     # --- Total count across both result types ---
     # The result list above is capped at ``limit``; ``total`` must reflect the

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 
 from src.api.deps import get_neo4j, get_pg
 from src.api.models import SearchResult, SearchResultsResponse
-from src.config import get_settings
+from src.config import Settings, get_settings
 from src.enrich.embeddings import get_embedder, to_pgvector_literal
 from src.utils.grades import normalize_grade
 from src.utils.neo4j_client import Neo4jClient
@@ -54,11 +54,28 @@ def saturate_relevance(score: float, k: float) -> float:
     return score / (score + k)
 
 
+def get_search_settings() -> Settings:
+    """Resolve application settings for the search route (overridable dependency).
+
+    A thin wrapper around ``get_settings`` rather than ``Depends(get_settings)``
+    directly: it keeps a clean ``() -> Settings`` signature so FastAPI never
+    introspects a *patched* ``get_settings``. The wider test suites
+    ``patch("src.config.get_settings")`` with a ``MagicMock`` (whose
+    ``(*args, **kwargs)`` signature FastAPI would otherwise treat as required
+    ``args``/``kwargs`` query params, 422-ing every ``/search`` request, since the
+    route modules are imported lazily inside ``create_app``). Resolving at call
+    time still honours a patched ``get_settings`` and lets tests override this
+    dependency directly. (ig#1070)
+    """
+    return get_settings()
+
+
 @router.get("/search", response_model=SearchResultsResponse)
 def search(
     q: str = Query("", max_length=500, description="Search query"),
     limit: int = Query(20, ge=1, le=100),
     neo4j: Neo4jClient = Depends(get_neo4j),
+    settings: Settings = Depends(get_search_settings),
 ) -> SearchResultsResponse:
     """Full-text search across hadiths and narrators.
 
@@ -124,8 +141,11 @@ def search(
     # rank-within-result-set, not absolute confidence. ig#1070 replaces it with
     # ``score / (score + k)`` (monotonic, bounded [0, 1), top hit no longer pinned
     # to 1.0). ``k`` is configurable / calibration-pending — see ``SearchSettings``.
+    # Resolved via the injected ``settings`` dependency (not a module-level cached
+    # read) so it is honoured per request and deterministically overridable in
+    # tests through ``app.dependency_overrides[get_settings]`` (ig#1070).
     if results:
-        k = get_settings().search.relevance_saturation_k
+        k = settings.search.relevance_saturation_k
         results = [r.model_copy(update={"score": saturate_relevance(r.score, k)}) for r in results]
 
     # --- Total count across both result types ---

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from urllib.parse import quote
 
-from pydantic import computed_field
+from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -74,6 +74,34 @@ class RateLimitSettings(BaseSettings):
     window_seconds: int = 60
 
     model_config = SettingsConfigDict(env_prefix="RATE_LIMIT_")
+
+
+class SearchSettings(BaseSettings):
+    """Relevance-scoring knobs for the search endpoints.
+
+    The full-text ``/search`` endpoint maps raw Neo4j (BM25-style) scores onto a
+    [0, 1) badge percentage via the saturating transform ``score / (score + k)``
+    (see ``src/api/routes/search.py``). The transform is monotonic and bounded
+    WITHOUT collapsing the top hit of every query to exactly 1.0 the way the
+    earlier within-result-set max-normalisation did (ig#1065 → replaced by
+    ig#1070), so the RelevanceBadge thresholds read as *absolute* confidence
+    rather than rank-within-this-result-set.
+    """
+
+    # ``k`` is the raw score at which the transform outputs exactly 0.5 — i.e. the
+    # half-saturation point. Larger ``k`` => the curve saturates more slowly, so a
+    # given raw score earns a *lower* badge percentage. BM25 scores from
+    # ``db.index.fulltext.queryNodes`` on this corpus commonly fall in the ~1–10
+    # range, so 5.0 is a deliberately provisional midpoint default.
+    #
+    # TODO(ig#1071 calibration): ``k`` AND the frontend RelevanceBadge thresholds
+    # (sahih ≥0.9, warning ≥0.7 in ``frontend/src/pages/SearchPage.tsx``) must be
+    # tuned *jointly* against the real BM25 score distribution once a real corpus
+    # and embedding model are loaded on the cluster. Until then this default is
+    # uncalibrated and intentionally swappable via env ``SEARCH_RELEVANCE_SATURATION_K``.
+    relevance_saturation_k: float = Field(default=5.0, gt=0.0)
+
+    model_config = SettingsConfigDict(env_prefix="SEARCH_")
 
 
 class RedisSettings(BaseSettings):
@@ -172,6 +200,7 @@ class Settings(BaseSettings):
     postgres: PostgresSettings = PostgresSettings()
     redis: RedisSettings = RedisSettings()
     rate_limit: RateLimitSettings = RateLimitSettings()
+    search: SearchSettings = SearchSettings()
     auth: AuthSettings = AuthSettings()
     security_headers: SecurityHeaderSettings = SecurityHeaderSettings()
     loki: LokiSettings = LokiSettings()

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
@@ -284,29 +285,41 @@ def test_saturation_k_reads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_search_route_honours_configured_k(
-    client: TestClient, mock_neo4j: MagicMock, monkeypatch: pytest.MonkeyPatch
+    app: FastAPI, client: TestClient, mock_neo4j: MagicMock
 ) -> None:
     """The /search transform uses the configured ``k``, not a magic number (ig#1070).
 
     A larger ``k`` saturates more slowly, so the same raw score earns a lower
     badge percentage — the calibration knob the issue calls for.
-    """
-    from src.config import get_settings
 
-    # The route reads ``get_settings().search.relevance_saturation_k`` per request;
-    # point that at a distinct k and confirm the emitted score tracks it. (monkeypatch
-    # restores the cached singleton after the test.)
-    monkeypatch.setattr(get_settings().search, "relevance_saturation_k", 20.0)
-    mock_neo4j.execute_read.side_effect = [
-        [{"id": "nar-1", "name_ar": "نص", "name_en": "narrator", "score": 2.5}],
-        [],
-        [{"total": 1}],
-        [{"total": 0}],
-    ]
-    resp = client.get("/api/v1/search?q=test")
-    assert resp.status_code == 200
-    # 2.5 / (2.5 + 20.0) — markedly lower than the default-k mapping above.
-    assert resp.json()["results"][0]["score"] == pytest.approx(2.5 / (2.5 + 20.0))
+    The route resolves ``k`` from its dedicated ``get_search_settings``
+    dependency, so we override that dependency directly. This is deterministic
+    regardless of test order (unlike mutating the cached singleton, which an
+    earlier test may have already fixed at the default) — the very failure mode
+    this guards against.
+    """
+    from src.api.routes import search as search_route
+    from src.config import SearchSettings, Settings
+
+    # Override the route's dedicated settings dependency by its own reference,
+    # which is order-independent (it does not depend on whether other suites have
+    # ``patch``ed ``src.config.get_settings``).
+    app.dependency_overrides[search_route.get_search_settings] = lambda: Settings(
+        search=SearchSettings(relevance_saturation_k=20.0)
+    )
+    try:
+        mock_neo4j.execute_read.side_effect = [
+            [{"id": "nar-1", "name_ar": "نص", "name_en": "narrator", "score": 2.5}],
+            [],
+            [{"total": 1}],
+            [{"total": 0}],
+        ]
+        resp = client.get("/api/v1/search?q=test")
+        assert resp.status_code == 200
+        # 2.5 / (2.5 + 20.0) — markedly lower than the default-k mapping above.
+        assert resp.json()["results"][0]["score"] == pytest.approx(2.5 / (2.5 + 20.0))
+    finally:
+        app.dependency_overrides.pop(search_route.get_search_settings, None)
 
 
 def test_semantic_search_clamps_negative_score(client: TestClient, app: object) -> None:

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -43,9 +43,11 @@ def test_search_fulltext_returns_results(client: TestClient, mock_neo4j: MagicMo
     assert body["total"] == 19
     assert len(body["results"]) == 2
     assert body["results"][0]["type"] == "narrator"
-    # Raw Lucene scores (2.5 narrator, 1.8 hadith) are max-normalised on the
-    # API side (ig#1065): top result maps to 1.0, relative order is preserved.
-    assert body["results"][0]["score"] == pytest.approx(1.0)
+    # Raw Lucene scores (2.5 narrator, 1.8 hadith) pass through the saturating
+    # transform ``score / (score + k)`` on the API side (ig#1070): bounded to
+    # [0, 1) and relative order preserved, but the top hit is NOT pinned to 1.0.
+    assert 0.0 < body["results"][0]["score"] < 1.0
+    assert body["results"][0]["score"] > body["results"][1]["score"]
     assert body["results"][1]["type"] == "hadith"
 
     # Verify the full-text query was used (CALL db.index.fulltext)
@@ -196,14 +198,15 @@ def test_search_empty_results(client: TestClient) -> None:
     assert body["results"] == []
 
 
-def test_search_normalizes_lucene_scores_to_unit_range(
+def test_search_saturates_lucene_scores_to_unit_range(
     client: TestClient, mock_neo4j: MagicMock
 ) -> None:
-    """Full-text raw Lucene scores >1 are max-normalised to [0,1] (ig#1065).
+    """Full-text raw Lucene scores pass through the saturating transform (ig#1070).
 
     Relative ordering must be preserved: the narrator (raw 2.5) outscores the
-    hadith (raw 1.8), so after normalisation both must be ≤1.0 and the narrator
-    score must remain higher.
+    hadith (raw 1.8), so after the transform both must be in [0, 1) and the
+    narrator score must remain higher — but unlike the old max-normalisation, the
+    top hit is NOT forced to exactly 1.0.
     """
     mock_neo4j.execute_read.side_effect = [
         [{"id": "nar-1", "name_ar": "نص", "name_en": "narrator", "score": 2.5}],
@@ -218,15 +221,92 @@ def test_search_normalizes_lucene_scores_to_unit_range(
     narrator = next(r for r in results if r["type"] == "narrator")
     hadith = next(r for r in results if r["type"] == "hadith")
 
-    # All scores must be within [0, 1] — no "250%" badges.
-    assert narrator["score"] <= 1.0
-    assert hadith["score"] <= 1.0
-    assert narrator["score"] >= 0.0
-    assert hadith["score"] >= 0.0
-    # Top result maps to 1.0.
-    assert narrator["score"] == pytest.approx(1.0)
+    # All scores must be within [0, 1) — no "250%" badges, none pinned to 100%.
+    assert 0.0 <= narrator["score"] < 1.0
+    assert 0.0 <= hadith["score"] < 1.0
+    # Top (raw 2.5) hit is a moderate match, NOT 100% — that's the ig#1070 point.
+    assert narrator["score"] < 0.99
+    assert narrator["score"] == pytest.approx(2.5 / (2.5 + 5.0))
     # Relative order preserved: narrator still outscores hadith.
     assert narrator["score"] > hadith["score"]
+
+
+def test_saturate_relevance_is_monotonic_and_bounded() -> None:
+    """The pure transform is strictly monotonic and bounded to [0, 1) (ig#1070)."""
+    from src.api.routes.search import saturate_relevance
+
+    k = 5.0
+    samples = [0.0, 0.1, 0.5, 1.0, 2.5, 10.0, 100.0, 1_000_000.0]
+    mapped = [saturate_relevance(s, k) for s in samples]
+
+    # Bounded: every output in [0, 1); even an enormous score never reaches 1.0.
+    assert all(0.0 <= m < 1.0 for m in mapped)
+    # Strictly monotonic increasing for strictly increasing positive inputs.
+    assert all(a < b for a, b in zip(mapped[1:], mapped[2:]))
+    # A zero / negative raw score floors to 0.0.
+    assert saturate_relevance(0.0, k) == 0.0
+    assert saturate_relevance(-3.0, k) == 0.0
+    # Half-saturation: score == k maps to exactly 0.5.
+    assert saturate_relevance(k, k) == pytest.approx(0.5)
+
+
+def test_saturate_relevance_weak_top_hit_not_pinned_to_one() -> None:
+    """A weak top hit reads as weak absolute confidence, not 100% (ig#1070).
+
+    This is the core regression ig#1070 fixes: the old max-normalisation forced
+    the single best result of every query to 1.0 regardless of match strength.
+    """
+    from src.api.routes.search import saturate_relevance
+
+    # A weak BM25 score of 0.4 with default k=5.0 maps well below the sahih
+    # (≥0.9) and warning (≥0.7) badge thresholds.
+    weak = saturate_relevance(0.4, 5.0)
+    assert weak < 0.7
+    assert weak != pytest.approx(1.0)
+
+
+def test_saturation_k_reads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``k`` is sourced from env ``SEARCH_RELEVANCE_SATURATION_K`` (ig#1070).
+
+    The default must be a positive, documented constant — not hard-wired — so it
+    can be calibrated against real BM25 distributions without a code change.
+    """
+    from src.config import SearchSettings
+
+    # Default is a sane positive constant (the provisional, calibration-pending k).
+    assert SearchSettings().relevance_saturation_k > 0.0
+    # ...and it is overridable from the environment.
+    monkeypatch.setenv("SEARCH_RELEVANCE_SATURATION_K", "20.0")
+    assert SearchSettings().relevance_saturation_k == pytest.approx(20.0)
+    # A non-positive k is rejected (would break the transform's denominator).
+    with pytest.raises(ValueError):
+        SearchSettings(relevance_saturation_k=0.0)
+
+
+def test_search_route_honours_configured_k(
+    client: TestClient, mock_neo4j: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The /search transform uses the configured ``k``, not a magic number (ig#1070).
+
+    A larger ``k`` saturates more slowly, so the same raw score earns a lower
+    badge percentage — the calibration knob the issue calls for.
+    """
+    from src.config import get_settings
+
+    # The route reads ``get_settings().search.relevance_saturation_k`` per request;
+    # point that at a distinct k and confirm the emitted score tracks it. (monkeypatch
+    # restores the cached singleton after the test.)
+    monkeypatch.setattr(get_settings().search, "relevance_saturation_k", 20.0)
+    mock_neo4j.execute_read.side_effect = [
+        [{"id": "nar-1", "name_ar": "نص", "name_en": "narrator", "score": 2.5}],
+        [],
+        [{"total": 1}],
+        [{"total": 0}],
+    ]
+    resp = client.get("/api/v1/search?q=test")
+    assert resp.status_code == 200
+    # 2.5 / (2.5 + 20.0) — markedly lower than the default-k mapping above.
+    assert resp.json()["results"][0]["score"] == pytest.approx(2.5 / (2.5 + 20.0))
 
 
 def test_semantic_search_clamps_negative_score(client: TestClient, app: object) -> None:


### PR DESCRIPTION
## Summary

Replaces the within-result-set **max-normalisation** of search relevance (ig#1065 / PR#1069) with an **absolute-confidence saturating transform** `score / (score + k)`.

Max-normalisation forced the top hit of *every* query to exactly **100%** regardless of how strong the match actually was, so the `RelevanceBadge` colour thresholds (sahih >=0.9, warning >=0.7) read as *rank-within-this-result-set* rather than absolute confidence. Closes #1070.

## What changed

- **`src/api/routes/search.py`** — new pure helper `saturate_relevance(score, k)` (monotonic, bounded `[0, 1)`, weak top hit no longer pinned to 1.0), applied to the full-text `/search` results where PR#1069 did the max-normalisation.
- **`src/config.py`** — new `SearchSettings.relevance_saturation_k` (env `SEARCH_RELEVANCE_SATURATION_K`, default `5.0`, validated `> 0`). `k` is the half-saturation constant (raw score -> 0.5). The default is **provisional** with an explicit calibration TODO (ig#1071): `k` *and* the badge thresholds must be tuned **jointly** against the real BM25 score distribution once a real corpus + embedding model are loaded. No magic number without provenance.
- **`frontend/src/pages/SearchPage.tsx`** — `RelevanceBadge` thresholds unchanged but re-commented: they now read as *absolute* confidence and carry the same calibration TODO.

## Test Plan

- **Backend** (`tests/test_api/test_search.py`, 23 passed locally):
  - `saturate_relevance` is strictly monotonic, bounded `[0, 1)`, floors <=0 to 0.0, half-saturates at `k`.
  - A weak top hit (raw 0.4) maps below the warning threshold - no longer 1.0.
  - `k` reads from `SEARCH_RELEVANCE_SATURATION_K` and rejects `<= 0`.
  - `/search` route honours a configured `k`.
  - Updated the PR#1069 tests that asserted top-hit `== 1.0` to the new saturating semantics (relative ordering still verified).
- **Frontend** (`SearchPage.test.tsx`, 8 passed): existing clamp tests retained; new tests assert weak/mid/strong scores map to muted/warning/sahih colours.
- **Gates run green locally:** `ruff check .` / `ruff format --check .` (whole tree), `mypy src/` (52 files), `tsc --noEmit`, `eslint src/`, `vitest`, `npm run build`.

> Note: the full backend unit suite can't be run end-to-end in this sandbox (no local Neo4j/Postgres; the rate-limit middleware's Redis connect hangs on IPv6 when Redis is down, and shares the 120/min window across tests when up - both pre-existing environment artifacts). The dedicated `test_search.py` file (the blast radius of this change) is green.

Reviewers: @ Ingrid Lindqvist, @ Marisol Vega-Cruz

🤖 Generated with [Claude Code](https://claude.com/claude-code)
