### PR TITLE
search: facets refine semantic results (project facet metadata into pgvector) (#1060)

### DIFF
--- a/frontend/src/lib/__tests__/searchFacets.test.ts
+++ b/frontend/src/lib/__tests__/searchFacets.test.ts
@@ -173,6 +173,30 @@ describe('matchesFacets', () => {
     expect(refined.map((r) => r.id)).toEqual(['s1', 's3'])
   })
 
+  // Regression for #1060 + #1061: the semantic endpoint must canonicalize
+  // topic_tags (via canonical_topics_for_tags) so a semantic hit carries the same
+  // canonical tokens the topic facet compares against. With RAW tags the topic
+  // facet would never match and would wrongly exclude the hit — the no-op #1060
+  // fixes, here proven for the topic facet specifically.
+  it('refines semantic-style hits by a canonical topic facet, preserving rank order', () => {
+    const semanticHits: SearchResult[] = [
+      result({ id: 't1', type: 'hadith', topics: ['akhlaq'], score: 0.95 }),
+      result({ id: 't2', type: 'hadith', topics: ['fiqh'], score: 0.9 }),
+      result({ id: 't3', type: 'hadith', topics: ['akhlaq', 'aqidah'], score: 0.7 }),
+    ]
+    // The facet selection holds canonical tokens (#1061), the same vocabulary the
+    // semantic endpoint now projects onto each hit.
+    const facets: FacetSelection = { ...NO_FACETS, topics: ['akhlaq'] }
+
+    const refined = semanticHits
+      .filter((r) => matchesFacets(r, facets))
+      .sort((a, b) => b.score - a.score)
+
+    // Only the canonical-akhlaq hits survive, still in descending cosine order;
+    // the fiqh-only hit is excluded (canonical token mismatch, not permissive).
+    expect(refined.map((r) => r.id)).toEqual(['t1', 't3'])
+  })
+
   it('requires all active facet groups to match (AND across groups)', () => {
     const r = result({ type: 'hadith', collection: 'Sahih al-Bukhari', grade: 'sahih', topics: ['fiqh'] })
     expect(

--- a/frontend/src/lib/__tests__/searchFacets.test.ts
+++ b/frontend/src/lib/__tests__/searchFacets.test.ts
@@ -153,6 +153,26 @@ describe('matchesFacets', () => {
     })
   })
 
+  // Regression for #1060: semantic search hits used to carry no facet metadata,
+  // so an active facet never excluded them (every hit looked "unknown"). Now that
+  // the semantic endpoint projects collection/grade/topics, the same matcher
+  // refines semantic results — and the page's score sort preserves cosine order.
+  it('refines semantic-style results once they carry facet metadata, preserving rank order', () => {
+    const semanticHits: SearchResult[] = [
+      result({ id: 's1', type: 'hadith', collection: 'Sahih al-Bukhari', grade: 'sahih', score: 0.93 }),
+      result({ id: 's2', type: 'hadith', collection: 'Sahih Muslim', grade: 'sahih', score: 0.88 }),
+      result({ id: 's3', type: 'hadith', collection: 'Sahih al-Bukhari', grade: 'daif', score: 0.81 }),
+    ]
+    const facets: FacetSelection = { ...NO_FACETS, collections: ['Sahih al-Bukhari'] }
+
+    const refined = semanticHits
+      .filter((r) => matchesFacets(r, facets))
+      .sort((a, b) => b.score - a.score)
+
+    // Only the Bukhari hits survive, still in descending cosine order.
+    expect(refined.map((r) => r.id)).toEqual(['s1', 's3'])
+  })
+
   it('requires all active facet groups to match (AND across groups)', () => {
     const r = result({ type: 'hadith', collection: 'Sahih al-Bukhari', grade: 'sahih', topics: ['fiqh'] })
     expect(

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -294,7 +294,12 @@ def search_semantic(
                 score=max(0.0, min(1.0, raw_score)),
                 collection=r.get("collection_name"),
                 grade=normalize_grade(r.get("grade")),
-                topics=r.get("topic_tags") or [],
+                # Map raw free-text topic_tags onto the canonical topic vocabulary,
+                # exactly as the full-text path does — the frontend facet matcher
+                # compares against canonical tokens (#1061), so raw tags here would
+                # never match an active topic facet and would wrongly exclude the
+                # hit (the very no-op #1060 fixes, but for topics).
+                topics=canonical_topics_for_tags(r.get("topic_tags")),
             )
         )
 

--- a/src/api/routes/search.py
+++ b/src/api/routes/search.py
@@ -245,6 +245,7 @@ def search_semantic(
         rows = pg.execute(
             """
             SELECT h.id, h.matn_ar, h.matn_en,
+                   h.collection_name, h.grade, h.topic_tags,
                    1 - (e.embedding <=> %s::vector) AS score
             FROM isnad_graph.hadith_embeddings e
             JOIN isnad_graph.hadiths h ON h.id = e.hadith_id
@@ -272,11 +273,12 @@ def search_semantic(
             },
         )
 
-    # Facet metadata (collection/grade/topics) is intentionally left empty for
-    # semantic hits: those attributes live on the Neo4j graph, not on the
-    # ``isnad_graph.hadiths`` projection this query reads, and the search-page
-    # matcher treats a missing value as "unknown, not excluded" — so facets do
-    # not (yet) refine semantic results. (#1036)
+    # Facet metadata (collection/grade/topics) is now projected alongside the
+    # embedding in ``isnad_graph.hadiths`` (see ``src/enrich/embeddings.py``), so
+    # semantic hits carry the same filterable attributes as full-text hits and the
+    # search page's facet matcher refines them identically. ``grade`` is the raw
+    # scholar string here; it is normalized to a canonical token API-side, exactly
+    # as the full-text path does. (#1060)
     results: list[SearchResult] = []
     for r in rows:
         snippet = r.get("matn_en") or r["matn_ar"]
@@ -290,6 +292,9 @@ def search_semantic(
                 title=snippet[:120] + "..." if len(snippet) > 120 else snippet,
                 title_ar=r["matn_ar"][:120],
                 score=max(0.0, min(1.0, raw_score)),
+                collection=r.get("collection_name"),
+                grade=normalize_grade(r.get("grade")),
+                topics=r.get("topic_tags") or [],
             )
         )
 

--- a/src/enrich/embeddings.py
+++ b/src/enrich/embeddings.py
@@ -43,7 +43,7 @@ import hashlib
 import math
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from src.config import get_settings
 from src.models.enrich import EmbeddingLoadResult
@@ -231,16 +231,33 @@ def embedding_text(matn_ar: str | None, matn_en: str | None) -> str:
     return (matn_en or matn_ar or "").strip()
 
 
+# Projects the matn text plus the facet metadata the search page filters on
+# (collection / grade / topic). ``grade`` resolves the connected Grading node and
+# falls back to the legacy flat properties, mirroring the search route's
+# ``_fulltext_hadith_search`` ``coalesce`` so the semantic path carries the same
+# raw grade the fulltext path normalises (#1060). Mirroring this metadata into the
+# pgvector-side ``isnad_graph.hadiths`` projection is what lets facets refine
+# semantic results.
 _FETCH_HADITHS_QUERY = """
 MATCH (h:Hadith)
-RETURN h.id AS id, h.matn_ar AS matn_ar, h.matn_en AS matn_en
+OPTIONAL MATCH (h)-[:GRADED_BY]->(g:Grading)
+RETURN h.id AS id, h.matn_ar AS matn_ar, h.matn_en AS matn_en,
+       h.collection_name AS collection_name,
+       h.topic_tags AS topic_tags,
+       coalesce(g.grade, h.grade_composite, h.grade) AS grade
 """
 
 
 def fetch_hadiths_from_neo4j(
     neo4j: Neo4jClient, *, limit: int | None = None
-) -> list[dict[str, str | None]]:
-    """Read ``(id, matn_ar, matn_en)`` for every Hadith node (source of truth)."""
+) -> list[dict[str, Any]]:
+    """Read matn text + facet metadata for every Hadith node (source of truth).
+
+    Returns ``id``, ``matn_ar``, ``matn_en`` (the embedded/displayed text) plus
+    ``collection_name``, ``grade``, and ``topic_tags`` — the facet metadata the
+    search page filters on, projected here so it lands in pgvector alongside the
+    embedding (#1060).
+    """
     query = _FETCH_HADITHS_QUERY
     params: dict[str, int] = {}
     if limit is not None:
@@ -263,10 +280,25 @@ def ensure_embedding_schema(pg: PgClient, dim: int = EMBEDDING_DIM) -> None:
     pg.execute(
         """
         CREATE TABLE IF NOT EXISTS isnad_graph.hadiths (
-            id      text PRIMARY KEY,
-            matn_ar text,
-            matn_en text
+            id              text PRIMARY KEY,
+            matn_ar         text,
+            matn_en         text,
+            collection_name text,
+            grade           text,
+            topic_tags      text[]
         )
+        """
+    )
+    # Backfill the facet columns on a pre-existing ``hadiths`` table (the
+    # CREATE above is a no-op once the table exists). Idempotent, so re-running
+    # the loader against an older deployment adds the metadata projection
+    # without a separate migration (#1060).
+    pg.execute(
+        """
+        ALTER TABLE isnad_graph.hadiths
+            ADD COLUMN IF NOT EXISTS collection_name text,
+            ADD COLUMN IF NOT EXISTS grade           text,
+            ADD COLUMN IF NOT EXISTS topic_tags      text[]
         """
     )
     pg.execute(
@@ -291,10 +323,14 @@ def ensure_embedding_schema(pg: PgClient, dim: int = EMBEDDING_DIM) -> None:
 
 
 _UPSERT_HADITH_SQL = """
-INSERT INTO isnad_graph.hadiths (id, matn_ar, matn_en)
-VALUES (%s, %s, %s)
+INSERT INTO isnad_graph.hadiths (id, matn_ar, matn_en, collection_name, grade, topic_tags)
+VALUES (%s, %s, %s, %s, %s, %s)
 ON CONFLICT (id) DO UPDATE
-SET matn_ar = EXCLUDED.matn_ar, matn_en = EXCLUDED.matn_en
+SET matn_ar = EXCLUDED.matn_ar,
+    matn_en = EXCLUDED.matn_en,
+    collection_name = EXCLUDED.collection_name,
+    grade = EXCLUDED.grade,
+    topic_tags = EXCLUDED.topic_tags
 """
 
 _UPSERT_EMBEDDING_SQL = """
@@ -342,7 +378,16 @@ def run_embedding_load(
                 skipped_empty += 1
                 continue
             text = embedding_text(row.get("matn_ar"), row.get("matn_en"))
-            hadith_params.append((hadith_id, row.get("matn_ar"), row.get("matn_en")))
+            hadith_params.append(
+                (
+                    hadith_id,
+                    row.get("matn_ar"),
+                    row.get("matn_en"),
+                    row.get("collection_name"),
+                    row.get("grade"),
+                    row.get("topic_tags"),
+                )
+            )
             if not text:
                 skipped_empty += 1
                 continue

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -383,7 +383,9 @@ def test_semantic_search_populates_facet_metadata(client: TestClient, app: objec
     hit = resp.json()["results"][0]
     assert hit["collection"] == "Sahih al-Bukhari"
     assert hit["grade"] == "sahih"  # normalized from "Sahih - Authentic"
-    assert hit["topics"] == ["intentions"]
+    # Raw tag "intentions" maps onto the canonical "akhlaq" topic (#1061), so the
+    # facet (which compares canonical tokens) refines semantic hits too (#1060).
+    assert hit["topics"] == ["akhlaq"]
 
     # The data query must project the facet columns, not just the embedding/score.
     data_sql = mock_pg.execute.call_args_list[0].args[0]

--- a/tests/test_api/test_search.py
+++ b/tests/test_api/test_search.py
@@ -345,6 +345,83 @@ def test_semantic_search_returns_results_when_pg_available(client: TestClient, a
     del app.dependency_overrides[get_pg]
 
 
+def test_semantic_search_populates_facet_metadata(client: TestClient, app: object) -> None:
+    """Semantic hits carry the facet metadata the search page filters on (#1060).
+
+    Facets only refine semantic results if those results expose
+    ``collection``/``grade``/``topics`` — otherwise the client-side matcher treats
+    every semantic hit as "unknown" and never excludes it. The metadata is
+    projected into ``isnad_graph.hadiths`` and selected by the semantic query; the
+    raw grade is normalized to its canonical token API-side, mirroring full-text.
+    """
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = [
+        [
+            {
+                "id": "had-1",
+                "matn_ar": "نص",
+                "matn_en": "matn text",
+                "collection_name": "Sahih al-Bukhari",
+                "grade": "Sahih - Authentic",
+                "topic_tags": ["intentions"],
+                "score": 0.9,
+            }
+        ],
+        [{"total": 1}],
+    ]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test")
+    assert resp.status_code == 200
+    hit = resp.json()["results"][0]
+    assert hit["collection"] == "Sahih al-Bukhari"
+    assert hit["grade"] == "sahih"  # normalized from "Sahih - Authentic"
+    assert hit["topics"] == ["intentions"]
+
+    # The data query must project the facet columns, not just the embedding/score.
+    data_sql = mock_pg.execute.call_args_list[0].args[0]
+    assert "collection_name" in data_sql
+    assert "h.grade" in data_sql
+    assert "topic_tags" in data_sql
+
+    del app.dependency_overrides[get_pg]
+
+
+def test_semantic_search_facet_metadata_defaults_when_absent(
+    client: TestClient, app: object
+) -> None:
+    """A semantic row with no facet columns yields null/empty fields, not errors (#1060)."""
+    mock_pg = MagicMock()
+    mock_pg.execute.side_effect = [
+        [{"id": "had-1", "matn_ar": "م", "matn_en": "h", "score": 0.5}],
+        [{"total": 1}],
+    ]
+    mock_pg.close.return_value = None
+
+    from fastapi import FastAPI
+
+    from src.api.deps import get_pg
+
+    assert isinstance(app, FastAPI)
+    app.dependency_overrides[get_pg] = lambda: mock_pg
+
+    resp = client.get("/api/v1/search/semantic?q=test")
+    assert resp.status_code == 200
+    hit = resp.json()["results"][0]
+    assert hit["collection"] is None
+    assert hit["grade"] is None
+    assert hit["topics"] == []
+
+    del app.dependency_overrides[get_pg]
+
+
 def test_semantic_search_embeds_query_at_runtime(client: TestClient, app: object) -> None:
     """The query is embedded into a pgvector literal, not matched by exact text.
 

--- a/tests/test_enrich/test_embeddings.py
+++ b/tests/test_enrich/test_embeddings.py
@@ -126,6 +126,21 @@ def test_ensure_embedding_schema_creates_tables_with_dim() -> None:
     assert "ivfflat" in executed
 
 
+def test_ensure_embedding_schema_projects_facet_columns() -> None:
+    """The hadiths projection carries the facet metadata, with an idempotent
+    backfill for pre-existing tables (#1060)."""
+    pg = MagicMock()
+    ensure_embedding_schema(pg, EMBEDDING_DIM)
+    executed = " ".join(call.args[0] for call in pg.execute.call_args_list)
+    # Columns present in the CREATE TABLE for fresh installs.
+    assert "collection_name text" in executed
+    assert "topic_tags      text[]" in executed
+    # Idempotent ADD COLUMN IF NOT EXISTS backfill for older deployments.
+    assert "ALTER TABLE isnad_graph.hadiths" in executed
+    assert "ADD COLUMN IF NOT EXISTS collection_name" in executed
+    assert "ADD COLUMN IF NOT EXISTS topic_tags" in executed
+
+
 def test_ensure_embedding_schema_rejects_non_int_dim() -> None:
     pg = MagicMock()
     with pytest.raises(ValueError):
@@ -151,6 +166,22 @@ def test_fetch_hadiths_no_limit_passes_none() -> None:
     query, params = neo4j.execute_read.call_args.args
     assert "LIMIT" not in query
     assert params is None
+
+
+def test_fetch_hadiths_projects_facet_metadata() -> None:
+    """The fetch query projects collection/grade/topics so they reach pgvector (#1060).
+
+    ``grade`` resolves the connected Grading node with the same ``coalesce``
+    fallback the full-text search route uses, keeping the two paths consistent.
+    """
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = []
+    fetch_hadiths_from_neo4j(neo4j)
+    query = neo4j.execute_read.call_args.args[0]
+    assert "collection_name AS collection_name" in query
+    assert "topic_tags AS topic_tags" in query
+    assert "GRADED_BY" in query
+    assert "coalesce(g.grade, h.grade_composite, h.grade) AS grade" in query
 
 
 # --- run_embedding_load (the mechanism, against mock clients) -----------------
@@ -190,6 +221,38 @@ def test_run_embedding_load_embeds_and_upserts() -> None:
     assert hadith_id == "h1"
     assert source_text == "first hadith"
     assert vector_literal.startswith("[") and vector_literal.endswith("]")
+
+
+def test_run_embedding_load_upserts_facet_metadata() -> None:
+    """The hadiths upsert carries collection/grade/topics into the projection (#1060)."""
+    neo4j = MagicMock()
+    neo4j.execute_read.return_value = [
+        {
+            "id": "h1",
+            "matn_ar": "نص",
+            "matn_en": "a hadith",
+            "collection_name": "Sahih al-Bukhari",
+            "grade": "Sahih - Authentic",
+            "topic_tags": ["intentions"],
+        }
+    ]
+    pg = MagicMock()
+
+    run_embedding_load(neo4j, pg, embedder=HashingEmbedder())
+
+    hadith_call = next(
+        call
+        for call in pg.execute_many.call_args_list
+        if "INSERT INTO isnad_graph.hadiths" in call.args[0]
+    )
+    sql, rows = hadith_call.args
+    # The upsert lists and writes the facet columns.
+    assert "collection_name" in sql
+    assert "grade" in sql
+    assert "topic_tags" in sql
+    # The bound row carries the metadata through to the projection.
+    (row,) = rows
+    assert row == ("h1", "نص", "a hadith", "Sahih al-Bukhari", "Sahih - Authentic", ["intentions"])
 
 
 def test_run_embedding_load_skips_textless_hadiths() -> None:


### PR DESCRIPTION
## Summary

Facets (grade / topic / collection) did not refine **semantic** search results, only full-text ones (#1060).

The search page applies the *same* client-side facet matcher (`matchesFacets`, `frontend/src/lib/searchFacets.ts`) to both full-text and semantic results. But semantic hits carried no `collection`/`grade`/`topics`: the pgvector-side `isnad_graph.hadiths` projection only stored `(id, matn_ar, matn_en)`, and the semantic SQL selected only the embedding/score. The matcher treats a missing attribute as "unknown, not excluded", so every semantic hit passed every facet — the facets were no-ops on semantic results.

**Fix:** project the facet metadata into pgvector alongside the embedding, mirroring the full-text path, so semantic results carry the same filterable attributes and the existing matcher refines them identically. No frontend change is required.

- **`src/enrich/embeddings.py`** — `fetch_hadiths_from_neo4j` now also reads `collection_name`, `topic_tags`, and `grade` (via the `GRADED_BY` → `coalesce(g.grade, h.grade_composite, h.grade)` fallback, the same expression `_fulltext_hadith_search` uses). The `isnad_graph.hadiths` table gains `collection_name` / `grade` / `topic_tags` columns, with an idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` backfill so re-running the loader against an existing deployment needs no separate migration. The upsert carries the new fields through.
- **`src/api/routes/search.py`** — the `/search/semantic` query selects the three columns and populates `SearchResult.collection` / `normalize_grade(grade)` / `topics`. Grade is stored raw and normalized API-side, exactly as the full-text path does. Embedder and ranking formula are untouched (the `EMBEDDING_MODEL=hashing` default and the real-model swap remain ig#1071, out of scope here).

## Test Plan

- `tests/test_api/test_search.py`
  - `test_semantic_search_populates_facet_metadata` — a semantic hit exposes `collection`, the normalized `grade` token, and `topics`; the data query projects the facet columns.
  - `test_semantic_search_facet_metadata_defaults_when_absent` — a row without the facet columns yields null/empty fields, not an error.
  - Existing semantic tests (score clamp, runtime embedding, distinct-query ranking, limit cap, 503) still pass — projection/ordering unchanged.
- `tests/test_enrich/test_embeddings.py`
  - `test_ensure_embedding_schema_projects_facet_columns` — schema carries the columns + idempotent backfill.
  - `test_fetch_hadiths_projects_facet_metadata` — the Neo4j fetch projects `collection_name`/`topic_tags`/`grade` with the `GRADED_BY` coalesce.
  - `test_run_embedding_load_upserts_facet_metadata` — the hadiths upsert writes the metadata through to the projection.
- `frontend/src/lib/__tests__/searchFacets.test.ts`
  - new case: once semantic-style results carry `collection`/`grade`, the matcher refines them and the score sort preserves cosine rank order.

Local (worktree off `deployments/phase-5/wave-4`): `pytest tests/test_api/test_search.py tests/test_enrich/test_embeddings.py` → 45 passed; `vitest run searchFacets.test.ts` → 19 passed; `ruff check .` + `ruff format --check .` clean; `mypy src/` → success (52 files). Pre-commit + pre-push hooks (ruff/mypy/pytest) green.

Closes #1060
