### PR TITLE
fix(embed-image): set PYTHONPATH=/app so isnad CLI can import src (#1093)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,14 @@ FROM base AS embed
 WORKDIR /app
 COPY --from=embed-builder /app/.venv /app/.venv
 COPY . .
-ENV PATH="/app/.venv/bin:$PATH"
+# PYTHONPATH=/app puts the src-layout package on the import path for the `isnad`
+# console script. `uv sync` in embed-builder installs only deps (src/ isn't
+# copied there), and the generated /app/.venv/bin/isnad runs under the venv
+# interpreter, which does NOT add cwd to sys.path — so `import src` (from
+# `[project.scripts] isnad = "src.cli:main"`) fails without this. The api image
+# only survives the same gap because uvicorn inserts cwd onto sys.path. (#1093)
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH=/app
 
 # Default to the 384-dim multilingual model (matches EMBEDDING_DIM / the
 # vector(384) column). Overridable by the deploy compose env. The build bakes the
@@ -49,7 +56,13 @@ WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 COPY . .
 
-ENV PATH="/app/.venv/bin:$PATH"
+# PYTHONPATH=/app defensively mirrors the embed stage: the api is launched via
+# `uvicorn src.api.app` and only imports `src` because uvicorn adds cwd to
+# sys.path. Anything invoking the `isnad` console script in this image (e.g. a
+# one-off `isnad …` exec) would hit the same `import src` gap as #1093. Harmless
+# for the uvicorn path, robust for the rest.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH=/app
 
 # No CMD here — docker-compose.prod.yml `command:` is the single source of truth
 # for the uvicorn invocation (includes --workers and other prod-specific flags).


### PR DESCRIPTION
## Summary

Fixes the `noorinalabs-isnad-graph-embed` image, whose `isnad` CLI dies with `ModuleNotFoundError: No module named 'src'` — blocking the corpus re-embedding capstone (#1071).

### Root cause
- The `embed-builder` stage runs `uv sync --frozen --no-dev --extra ml` with only `pyproject.toml` + `uv.lock` copied; `src/` is copied later (`COPY . .` in the `embed` stage). So the local src-layout package is never installed onto the venv's import path.
- The generated console script `/app/.venv/bin/isnad` (`[project.scripts] isnad = "src.cli:main"`) runs under the venv interpreter, which does **not** add cwd to `sys.path` — so `import src` fails even though `/app/src` exists.
- The api/`runtime` image shares the same pattern but masks the bug: it's launched via `uvicorn src.api.app`, and uvicorn inserts cwd onto `sys.path`. The CLI path was never exercised until the re-embed mechanism.

### Fix
Add `PYTHONPATH=/app` to the `embed` stage `ENV`:
```dockerfile
ENV PATH="/app/.venv/bin:$PATH" \
    PYTHONPATH=/app
```
This is the canonical way to import a `src/`-layout package, mirrors the cwd-on-path behaviour the api image already relies on, and works with the `read_only` rootfs (no write, no extra build step or network). PYTHONPATH was preferred over `uv pip install -e .` to keep the image build step-free and offline.

**Runtime stage also touched (defensive):** the `runtime` (api) stage gets the same `PYTHONPATH=/app`. It is a latent twin of this bug — it only imports `src` today because uvicorn inserts cwd; any direct `isnad` console-script exec in that image would hit the identical gap. The addition is harmless for the uvicorn path and makes the image robust regardless of launch mechanism.

## Test Plan
- Dockerfile static validation: `docker buildx build --target embed --check .` → **Check complete, no warnings found** (exit 0).
- No PR-time gate builds the embed image (it builds only in `ghcr-publish.yml` on push to `main`). The **runtime proof** is post-merge:
  1. embed image republished by `ghcr-publish.yml` on merge to `main`,
  2. a real `reembed-corpus` staging run exercising `isnad embed-hadiths | reindex-embeddings | verify-recall` — driven by the orchestrator as part of the #1071 capstone.

Closes #1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
