### PR TITLE
tech-debt(frontend): apply readJsonResponse JSON-guard to useAuth.ts fetch paths

### DIFF
--- a/frontend/src/hooks/__tests__/useAuth.jsonGuard.test.tsx
+++ b/frontend/src/hooks/__tests__/useAuth.jsonGuard.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { AuthProvider, useAuth } from "../useAuth"
+
+// The token-refresh path is only exercised on a 401; mock it so it never
+// reaches a real network call and so a 401 deterministically yields "no token".
+vi.mock("../../api/token-refresh", () => ({
+  refreshAccessToken: vi.fn(async () => null),
+}))
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+// A reverse-proxy fallback / misrouted origin answering 200 with the SPA
+// index.html instead of JSON — the deploy#420 class that ig#993 guards against.
+function htmlResponse(): Response {
+  return new Response("<!DOCTYPE html><html><body>SPA</body></html>", {
+    status: 200,
+    headers: { "Content-Type": "text/html" },
+  })
+}
+
+function Probe() {
+  const { loading, user } = useAuth()
+  if (loading) return <div>loading</div>
+  return <div>{user ? `user:${user.email}` : "anon"}</div>
+}
+
+function renderProvider() {
+  return render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>,
+  )
+}
+
+describe("AuthProvider boot load — readJsonResponse guard (ig#993)", () => {
+  beforeEach(() => {
+    localStorage.setItem("access_token", "tok")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it("loads the user when /users/me answers with JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ id: "1", email: "jane@example.com", roles: [] })),
+    )
+
+    renderProvider()
+
+    await waitFor(() => expect(screen.getByText("user:jane@example.com")).toBeInTheDocument())
+  })
+
+  it("degrades to unauthenticated (not a stuck spinner) on a non-JSON 200", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => htmlResponse()))
+
+    renderProvider()
+
+    // The bare `res.json()` would have thrown an unhandled SyntaxError, leaving
+    // `loading` true forever. The guard turns it into a clean "anon" state.
+    await waitFor(() => expect(screen.getByText("anon")).toBeInTheDocument())
+  })
+})

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, type React
 import { createElement } from 'react'
 import type { components } from '../types/user-service'
 import { refreshAccessToken } from '../api/token-refresh'
+import { readJsonResponse } from '../lib/authJson'
 
 export type UserRole = 'trial' | 'reader' | 'researcher' | 'admin'
 
@@ -129,8 +130,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Revoke only the current session (best-effort)
       const headers = { Authorization: `Bearer ${token}` }
       fetch(`${SESSIONS_BASE}`, { headers, credentials: 'include' })
-        .then((res) => (res.ok ? res.json() : Promise.reject(res)))
-        .then((data: { sessions: Array<{ id: string; is_current: boolean }> }) => {
+        .then((res) =>
+          res.ok
+            ? readJsonResponse<{ sessions: Array<{ id: string; is_current: boolean }> }>(res)
+            : Promise.reject(res),
+        )
+        .then((data) => {
           const current = data.sessions.find((s) => s.is_current)
           if (current) {
             return fetch(`${SESSIONS_BASE}/${current.id}`, {
@@ -185,8 +190,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       if (res.ok) {
-        const data: AuthUser = await res.json()
-        setUser(data)
+        try {
+          const data = await readJsonResponse<AuthUser>(res)
+          setUser(data)
+        } catch {
+          // Non-JSON 200 (e.g. a misrouted origin serving index.html — the
+          // deploy#420 class). Treat as unauthenticated rather than letting an
+          // unhandled parse error leave the app stuck on the loading spinner.
+          setUser(null)
+        }
       } else {
         setUser(null)
       }
@@ -205,7 +217,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const headers = { Authorization: `Bearer ${token}` }
         const res = await fetch(`${SESSIONS_BASE}`, { headers, credentials: 'include' })
         if (res.ok) {
-          const data: { sessions: Array<{ id: string; is_current: boolean }> } = await res.json()
+          const data =
+            await readJsonResponse<{ sessions: Array<{ id: string; is_current: boolean }> }>(res)
           const current = data.sessions.find((s) => s.is_current)
           if (current) {
             await fetch(`${SESSIONS_BASE}/${current.id}`, {
@@ -266,7 +279,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (res.ok) {
-        const data: AuthUser = await res.json()
+        const data = await readJsonResponse<AuthUser>(res)
         setUser(data)
       }
     } catch {


### PR DESCRIPTION
## Summary

Routes the four unguarded `res.json()` calls in `frontend/src/hooks/useAuth.ts` through the shared `readJsonResponse` content-type guard (`frontend/src/lib/authJson.ts`), extending the protection #977 added to `LoginPage` across the whole auth surface.

`useAuth.ts` was left out of #977's LoginPage-only scope but has the same latent exposure on these fetch paths:

| Path | Site | Prior failure mode |
|------|------|--------------------|
| boot `/users/me` load (`loadUser`) | `await res.json()` | non-JSON 200 → unhandled `SyntaxError` → app stuck on loading spinner |
| `logout` session lookup | `.then(res => res.json())` | error swallowed by trailing `.catch` |
| `signOut` session lookup | `await res.json()` (in `try`) | already caught |
| `refreshUser` `/users/me` | `await res.json()` (in `try`) | already caught |

A non-JSON 200 — e.g. a misrouted origin serving the SPA `index.html` (the deploy#420 class) — previously threw the raw `Unexpected token '<'` `SyntaxError`. With the guard, every path degrades to a clean `NonJsonResponseError`.

The **boot load** is the only path that wasn't already inside a `try`/`catch`: it now wraps the parse and falls back to unauthenticated (`setUser(null)`, `loading=false`) rather than leaking an unhandled rejection that bricks the app on the spinner. The `signOut`/`refreshUser` (`try`/`catch`) and `logout` (`.catch`) paths inherit graceful handling for free.

## Tests

- Adds `useAuth.jsonGuard.test.tsx` — renders the real `AuthProvider` and asserts (a) JSON 200 loads the user, (b) a non-JSON 200 degrades to `anon` (loading resolves) instead of a stuck spinner.
- Full frontend suite green locally: **325 tests / 48 files passing**, `tsc --noEmit` clean, `npm run lint` 0 errors (pre-existing warnings only).

Closes #993. Ref #977, deploy#420.
