### PR TITLE
tech-debt(grades): single source of truth for GRADE_LABELS (backend → frontend) (#1054)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
       - run: uv run mypy src/
+      # Grade-vocab single-source-of-truth gate (ig#1054). The frontend's
+      # GRADE_LABELS is generated from src/utils/grades.py into
+      # frontend/src/lib/grade-vocab.generated.json; fail if the committed JSON
+      # has drifted from the backend. Mirrored by the `grade-vocab-drift`
+      # pre-commit hook. Runs here (not in the node-only frontend job) because it
+      # needs to import the Python source of truth.
+      - name: Check grade-vocab drift (backend <-> frontend)
+        run: uv run python scripts/emit_grade_vocab.py check
 
   security-audit:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,19 @@ repos:
       # Integration tests require Docker (Neo4j, PostgreSQL) — run in CI only.
       # To run locally: make infra && ENVIRONMENT=test uv run pytest tests/integration/ -m integration
 
+      # Grade-vocab single-source-of-truth gate (ig#1054). Mirrors the
+      # "Check grade-vocab drift" step in ci.yml's lint-and-typecheck job: fails
+      # if frontend/src/lib/grade-vocab.generated.json has drifted from the
+      # backend GRADE_LABELS. Regenerate with `uv run python
+      # scripts/emit_grade_vocab.py emit` and commit the result.
+      - id: grade-vocab-drift
+        name: grade-vocab-drift
+        entry: uv run python scripts/emit_grade_vocab.py check
+        language: system
+        pass_filenames: false
+        files: ^(src/utils/grades\.py|scripts/emit_grade_vocab\.py|frontend/src/lib/grade-vocab\.generated\.json)$
+        stages: [pre-commit]
+
   # --- Lockfile validation ---
   - repo: local
     hooks:

--- a/frontend/src/lib/grade-vocab.generated.json
+++ b/frontend/src/lib/grade-vocab.generated.json
@@ -1,0 +1,9 @@
+{
+  "sahih": "Sahih",
+  "hasan": "Hasan",
+  "hasan_sahih": "Hasan Sahih",
+  "daif": "Da'if",
+  "mawdu": "Mawdu'",
+  "munkar": "Munkar",
+  "shadh": "Shadh"
+}

--- a/frontend/src/lib/grades.ts
+++ b/frontend/src/lib/grades.ts
@@ -2,15 +2,14 @@
 // mapped to display labels and Tailwind colour classes. The raw scholar text is
 // shown verbatim; these helpers drive the badge/bar colour and the filter labels.
 
-export const GRADE_LABELS: Record<string, string> = {
-  sahih: 'Sahih',
-  hasan: 'Hasan',
-  hasan_sahih: 'Hasan Sahih',
-  daif: "Da'if",
-  mawdu: "Mawdu'",
-  munkar: 'Munkar',
-  shadh: 'Shadh',
-}
+// GRADE_LABELS has a single source of truth in the backend
+// (src/utils/grades.py). The JSON below is generated from it by
+// `scripts/emit_grade_vocab.py emit` and kept in sync by the grade-vocab-drift
+// CI step + pre-commit hook (ig#1054) — do NOT hand-edit the generated file.
+// The colour/bar helpers below stay here: they are presentation, not vocabulary.
+import gradeLabels from './grade-vocab.generated.json'
+
+export const GRADE_LABELS: Record<string, string> = gradeLabels
 
 // The full canonical grade vocabulary, in display order. Drives the search
 // page's grade facet so it can never silently drop a valid grade or drift out of

--- a/scripts/emit_grade_vocab.py
+++ b/scripts/emit_grade_vocab.py
@@ -1,0 +1,105 @@
+"""Emit and diff the canonical hadith-grade vocabulary for the frontend.
+
+The grade vocabulary — the canonical token set and each token's human-readable
+display label (``GRADE_LABELS``) — has a single source of truth in the backend
+module ``src/utils/grades.py``. The frontend used to hand-maintain a second copy
+of ``GRADE_LABELS`` in ``frontend/src/lib/grades.ts``; the two could silently
+drift (ig#1054). This script makes the frontend *derive* the labels instead:
+
+- ``emit``  — read ``GRADE_LABELS`` from ``src.utils.grades`` and write it as an
+  ordered JSON map to ``frontend/src/lib/grade-vocab.generated.json`` (the
+  ``--out`` default). ``frontend/src/lib/grades.ts`` imports that file, so the
+  backend is the only place a grade label is defined.
+- ``check`` — regenerate the JSON in memory and compare against the committed
+  file, exiting non-zero on any drift. This is what the ``grade-vocab-drift`` CI
+  step and the ``grade-vocab-drift`` pre-commit hook run to gate PRs.
+
+Mirrors the emit/check shape of ``scripts/emit_ingest_schema.py`` and the
+``gen:types`` + ``git diff --exit-code`` drift gate already used for the
+user-service OpenAPI types in ``.github/workflows/ci.yml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# scripts/ is a sibling of src/; make ``src`` importable when run directly.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.grades import GRADE_LABELS, GRADE_TOKENS  # noqa: E402
+
+_DEFAULT_OUT = _REPO_ROOT / "frontend" / "src" / "lib" / "grade-vocab.generated.json"
+
+
+def _render() -> str:
+    """Return the canonical grade-label JSON (insertion order preserved).
+
+    Guards the backend invariant that every canonical token has a display label:
+    ``GRADE_LABELS`` keys must equal the canonical token set so the frontend can
+    never receive a vocabulary that is missing a label (or carries a stray one).
+    """
+    if set(GRADE_LABELS) != set(GRADE_TOKENS):
+        missing = set(GRADE_TOKENS) - set(GRADE_LABELS)
+        extra = set(GRADE_LABELS) - set(GRADE_TOKENS)
+        raise SystemExit(
+            "GRADE_LABELS is out of sync with the canonical token set "
+            f"(missing labels: {sorted(missing)}; stray labels: {sorted(extra)}). "
+            "Fix src/utils/grades.py before regenerating."
+        )
+    # Sort by display order (GRADE_LABELS insertion order) so the frontend facet
+    # order is stable and reviewable; trailing newline keeps it diff-friendly.
+    return json.dumps(dict(GRADE_LABELS), indent=2, ensure_ascii=False) + "\n"
+
+
+def _emit(out: Path) -> None:
+    out.write_text(_render(), encoding="utf-8")
+    print(f"wrote {out.relative_to(_REPO_ROOT)} ({len(GRADE_LABELS)} grade labels)")
+
+
+def _check(out: Path) -> int:
+    expected = _render()
+    if not out.exists():
+        print(
+            f"::error::{out.relative_to(_REPO_ROOT)} is missing — run "
+            "`python scripts/emit_grade_vocab.py emit`",
+            file=sys.stderr,
+        )
+        return 1
+    actual = out.read_text(encoding="utf-8")
+    if actual != expected:
+        print(
+            f"::error::{out.relative_to(_REPO_ROOT)} is out of sync with "
+            "src/utils/grades.py GRADE_LABELS. Run "
+            "`python scripts/emit_grade_vocab.py emit` and commit the result.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"{out.relative_to(_REPO_ROOT)} is in sync with src/utils/grades.py")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    for name in ("emit", "check"):
+        p = sub.add_parser(name)
+        p.add_argument(
+            "--out",
+            type=Path,
+            default=_DEFAULT_OUT,
+            help="path to the generated JSON (default: the frontend grade-vocab.generated.json)",
+        )
+    args = parser.parse_args(argv)
+    if args.cmd == "emit":
+        _emit(args.out)
+        return 0
+    return _check(args.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_utils/test_grades.py
+++ b/tests/test_utils/test_grades.py
@@ -7,13 +7,22 @@ Uses the production-shaped free-text grade strings actually present in the graph
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from src.utils.grades import (
+    GRADE_LABELS,
     GRADE_TOKENS,
     grade_filter_clause,
     normalize_grade,
 )
+
+# Generated frontend artifact derived from GRADE_LABELS (ig#1054). Kept in sync
+# by scripts/emit_grade_vocab.py (CI: grade-vocab-drift step; pre-commit hook).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GRADE_VOCAB_JSON = _REPO_ROOT / "frontend" / "src" / "lib" / "grade-vocab.generated.json"
 
 # (raw free-text grade, expected canonical token) — drawn from the stg distribution
 # cited in the issue plus the apostrophe/Arabic variants.
@@ -35,6 +44,29 @@ PRODUCTION_GRADES: list[tuple[str, str]] = [
     ("Munkar", "munkar"),
     ("Shadh", "shadh"),
 ]
+
+
+def test_grade_labels_cover_canonical_token_set() -> None:
+    """Every canonical token has exactly one display label — no missing/stray keys.
+
+    This is the backend invariant scripts/emit_grade_vocab.py guards before
+    emitting the frontend artifact; assert it here so the suite fails loudly if a
+    token is added to _PREDICATES without a matching GRADE_LABELS entry.
+    """
+    assert set(GRADE_LABELS) == set(GRADE_TOKENS)
+
+
+def test_frontend_grade_vocab_in_sync_with_backend() -> None:
+    """The committed frontend JSON must equal GRADE_LABELS (single source of truth).
+
+    Mirrors the grade-vocab-drift CI/pre-commit gate so direct edits to either
+    side are caught by the test suite too (ig#1054).
+    """
+    on_disk = json.loads(_GRADE_VOCAB_JSON.read_text(encoding="utf-8"))
+    assert on_disk == dict(GRADE_LABELS)
+    # Key order is load-bearing: the frontend facet derives its display order from
+    # Object.keys(GRADE_LABELS), so the generated order must match the backend's.
+    assert list(on_disk.keys()) == list(GRADE_LABELS.keys())
 
 
 @pytest.mark.parametrize(("raw", "expected"), PRODUCTION_GRADES)


### PR DESCRIPTION
## What

Establishes a **single source of truth** for the hadith-grade vocabulary so the backend and frontend copies of `GRADE_LABELS` can no longer drift (ig#1054, follow-up TechDebt from PR #1052 review).

Before: `GRADE_LABELS` (canonical token → display label) was hand-maintained in **both** `src/utils/grades.py` and `frontend/src/lib/grades.ts`.

## Approach

Backend is the source of truth; the frontend **derives** from it via a committed generated artifact, gated against drift — mirroring the repo's existing `gen:types` drift-gate idiom and the `emit_ingest_schema.py` emit/check pattern.

- **`scripts/emit_grade_vocab.py`** (`emit` / `check`) reads `GRADE_LABELS` from `src.utils.grades` and writes the ordered map to **`frontend/src/lib/grade-vocab.generated.json`**.
- **`frontend/src/lib/grades.ts`** imports that JSON instead of a literal map. `GRADE_TOKENS` (derived) and the colour/bar helpers — which are presentation, not vocabulary — stay frontend-side. Display/facet key order is preserved.
- **Drift gate (can't-drift enforcement):**
  - CI: new `Check grade-vocab drift` step in `ci.yml`'s `lint-and-typecheck` job (runs where the Python source is importable, not the node-only frontend job).
  - Mirrored by a `grade-vocab-drift` **pre-commit** hook (full local⇄CI parity).
  - `emit()` guards the backend invariant `set(GRADE_LABELS) == set(GRADE_TOKENS)`.
  - Backend tests assert the invariant + that the committed JSON matches `GRADE_LABELS`.

## Verification (local, all green)

- Backend: `emit_grade_vocab.py check` in sync; ruff check/format; mypy; `pytest tests/test_utils/test_grades.py` 43 passed.
- Frontend: `tsc --noEmit` clean; `eslint src/` 0 errors; **full vitest 323 passed**.
- pre-commit ⇄ CI sync-drift gate: OK.

## Acceptance

- [x] A single source of truth for grade tokens/labels; frontend derives rather than duplicates.

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)
