### PR TITLE
tech-debt(embed-image): install isnad package into venv; drop PYTHONPATH/sys.path reliance (#1095)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,24 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# Two-step uv sync (see #1095): the first sync resolves/installs ONLY the locked
+# dependencies (with just pyproject.toml + uv.lock present) so that layer stays
+# cached across source-only changes. After `COPY . .` brings the source in, the
+# second `uv sync --no-editable` installs the `isnad-graph` project itself as a
+# real (non-editable) wheel — so `src` lands in the venv's site-packages. That
+# makes the `isnad` console script (`[project.scripts] isnad = "src.cli:main"`)
+# and `import src` resolve from the installed package with NO `PYTHONPATH=/app`
+# / cwd-on-sys.path reliance (the #1093/#1094 trick this issue retires). Non-
+# editable is deliberate: an editable install just re-adds the repo root to
+# sys.path (same as the old PYTHONPATH trick, exposing data/docs/queries/… as
+# importable), whereas a real wheel puts only `src` on the path.
 FROM base AS builder
 WORKDIR /app
+RUN pip install --no-cache-dir uv
 COPY pyproject.toml uv.lock ./
-RUN pip install --no-cache-dir uv && uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-install-project
+COPY . .
+RUN uv sync --frozen --no-dev --no-editable
 
 # --- Embed image (semantic re-embedding mechanism, #1057/#1088/#1071) ---------
 # A SEPARATE, heavier image than the API: it installs the optional `ml` extra
@@ -21,21 +35,21 @@ RUN pip install --no-cache-dir uv && uv sync --frozen --no-dev
 # `…-isnad-graph-embed` image (see .github/workflows/ghcr-publish.yml).
 FROM base AS embed-builder
 WORKDIR /app
+RUN pip install --no-cache-dir uv
 COPY pyproject.toml uv.lock ./
-RUN pip install --no-cache-dir uv && uv sync --frozen --no-dev --extra ml
+RUN uv sync --frozen --no-dev --extra ml --no-install-project
+COPY . .
+RUN uv sync --frozen --no-dev --extra ml --no-editable
 
 FROM base AS embed
 WORKDIR /app
 COPY --from=embed-builder /app/.venv /app/.venv
 COPY . .
-# PYTHONPATH=/app puts the src-layout package on the import path for the `isnad`
-# console script. `uv sync` in embed-builder installs only deps (src/ isn't
-# copied there), and the generated /app/.venv/bin/isnad runs under the venv
-# interpreter, which does NOT add cwd to sys.path — so `import src` (from
-# `[project.scripts] isnad = "src.cli:main"`) fails without this. The api image
-# only survives the same gap because uvicorn inserts cwd onto sys.path. (#1093)
-ENV PATH="/app/.venv/bin:$PATH" \
-    PYTHONPATH=/app
+# No PYTHONPATH: `src` is installed into the venv's site-packages as a real wheel
+# (see the two-step uv sync above / #1095), so the generated /app/.venv/bin/isnad
+# console script imports `src` directly even though the venv interpreter does not
+# add cwd to sys.path.
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Default to the 384-dim multilingual model (matches EMBEDDING_DIM / the
 # vector(384) column). Overridable by the deploy compose env. The build bakes the
@@ -56,13 +70,11 @@ WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 COPY . .
 
-# PYTHONPATH=/app defensively mirrors the embed stage: the api is launched via
-# `uvicorn src.api.app` and only imports `src` because uvicorn adds cwd to
-# sys.path. Anything invoking the `isnad` console script in this image (e.g. a
-# one-off `isnad …` exec) would hit the same `import src` gap as #1093. Harmless
-# for the uvicorn path, robust for the rest.
-ENV PATH="/app/.venv/bin:$PATH" \
-    PYTHONPATH=/app
+# No PYTHONPATH: `src` is an installed wheel in the venv's site-packages (see the
+# two-step uv sync above / #1095), so both `uvicorn src.api.app` and any direct
+# `isnad` console-script exec resolve `import src` without relying on uvicorn's
+# cwd insertion.
+ENV PATH="/app/.venv/bin:$PATH"
 
 # No CMD here — docker-compose.prod.yml `command:` is the single source of truth
 # for the uvicorn invocation (includes --workers and other prod-specific flags).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,10 @@ warn_uninitialized = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["."]
+# No `pythonpath = ["."]`: `isnad-graph` is installed into the venv by `uv sync`
+# (editable in dev/CI, a real wheel in the Docker images — see Dockerfile/#1095),
+# so `import src` resolves from the installed package rather than from the repo
+# root being on sys.path.
 markers = [
     "integration: marks tests requiring Docker containers (Neo4j, PostgreSQL, Redis)",
     "e2e: marks browser automation tests requiring running frontend and backend",

--- a/scripts/emit_ingest_schema.py
+++ b/scripts/emit_ingest_schema.py
@@ -46,9 +46,9 @@ if TYPE_CHECKING:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 
-# Allow ``from src.models...`` imports when run as a standalone script.
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+# `from src.models...` imports resolve because `isnad-graph` is installed into the
+# venv by `uv sync` (this script's CI invocation is `uv run python …`); no
+# sys.path manipulation needed (#1095).
 
 
 # Cypher node label → Pydantic model class. Order is preserved in emitted output.


### PR DESCRIPTION
## Summary

Follow-up to #1093/#1094. Those fixed the `isnad` CLI's `ModuleNotFoundError: No module named 'src'` in the embed image by setting `PYTHONPATH=/app`, but left the image relying on cwd-on-`sys.path` rather than the project being **installed** into the venv — and `PYTHONPATH=/app` made every repo-root dir (`data`, `docs`, `queries`, …) shadowing-eligible on `sys.path`.

This retires the trick by actually installing the project.

## Changes

- **Dockerfile** — each builder (`builder`, `embed-builder`) now does a two-step `uv sync`: first `--no-install-project` (deps only — kept as the cached layer), then after `COPY . .` a `uv sync --no-editable` that builds + installs `isnad-graph` as a **real (non-editable) wheel**, so `src` lands in the venv's `site-packages`. `PYTHONPATH=/app` dropped from both the `embed` and `runtime` stages.
  - Non-editable is deliberate: an *editable* install just re-adds the repo root to `sys.path` (the same footgun as the old `PYTHONPATH` trick — hatchling's editable `.pth` for this `src`-layout is literally the repo-root path). A real wheel exposes only `src`.
- **pyproject.toml** — drop `pytest pythonpath = ["."]`; the editable install from `uv sync` (dev/CI) puts `src` on the path with no cwd reliance.
- **scripts/emit_ingest_schema.py** — drop the standalone `sys.path.insert(REPO_ROOT)` hack; its CI invocation is `uv run python …`, so the installed package resolves `from src.models...`.

## Verification

- `runtime` image built locally. With `PYTHONPATH` unset and cwd `/` (not `/app`): `import src` resolves to `/app/.venv/lib/python3.14/site-packages/src/__init__.py` (the installed wheel, **not** `/app/src`, **not** cwd), and `isnad --help` works. The `embed` stage uses the identical install path (only `--extra ml` differs).
- `docker buildx build --target embed --check` / `--target runtime --check`: clean.
- `uv run pytest --collect-only -m "not integration and not e2e"`: 724 tests collected, **no import errors**. 263 unit tests (models/utils/config/enrich) pass.
- `ruff check` (src/tests + scripts) + `ruff format --check` clean; `mypy src/` clean.
- `uv run python scripts/emit_ingest_schema.py emit` exercises the dynamic `from src.models...` imports successfully.

## Out of scope (pre-existing, flagged separately)

`scripts/sync_to_vps.py` imports `src.pipeline.audit` / `src.pipeline.manifest`, which **do not exist** anywhere in `src/`. It fails `ModuleNotFoundError: No module named 'src.pipeline'` on the base branch too (even with its old `sys.path` hack), so it's pre-existing dead code unrelated to this issue and not touched here. Not exercised by any CI job.

Reviewers: **Linh Pham**, **Marisol Vega-Cruz**

Closes #1095
