### PR TITLE
fix(test-infra): pass NEO4J password to Neo4jContainer constructor (ig#975)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,9 +13,14 @@ NEO4J_TEST_PASSWORD = "testpassword123"
 
 @pytest.fixture(scope="session")
 def neo4j_container():
-    """Start a real Neo4j container for integration tests."""
-    container = Neo4jContainer("neo4j:5-community")
-    container.with_env("NEO4J_AUTH", f"neo4j/{NEO4J_TEST_PASSWORD}")
+    """Start a real Neo4j container for integration tests.
+
+    The password MUST be passed to the constructor: testcontainers 4.x's
+    ``Neo4jContainer._configure()`` calls ``with_env("NEO4J_AUTH", f"neo4j/{self.password}")``
+    at container-start time, which clobbers any ``with_env("NEO4J_AUTH", ...)`` set on the
+    fixture side (it would otherwise default to ``neo4j/password`` → AuthError). See ig#975.
+    """
+    container = Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD)
     with container as neo4j:
         yield neo4j
 


### PR DESCRIPTION
## Summary

Fixes the `neo4j_client` integration-test fixture auth (ig#975). In testcontainers 4.x,
`Neo4jContainer._configure()` runs `with_env("NEO4J_AUTH", f"neo4j/{self.password}")` at
container-start time, which **clobbered** the fixture's own `container.with_env("NEO4J_AUTH", ...)`.
Because `self.password` defaulted to `"password"`, the container came up with `neo4j/password`
while `Neo4jClient` connected with `testpassword123` → **AuthError at fixture setup**.

The fix passes the password through the supported constructor parameter:

```python
container = Neo4jContainer("neo4j:5-community", password=NEO4J_TEST_PASSWORD)
```

so `_configure()` sets `NEO4J_AUTH` consistently with the client credentials, and removes the
now-redundant (and overridden) `with_env` line.

## Verification (local, real Docker)

`make test-integration` now brings up `neo4j:5-community` and the fixture **authenticates**:
- `neo4j_connected uri=bolt://localhost:<port>`
- `constraint_ensured` for all node types (Narrator/Hadith/Collection/Chain/Grading/HistoricalEvent/Location)
- seed data loads

The AuthError-at-setup that blocked the standard target is resolved.

## Out of scope — pre-existing defects newly *unmasked* by this fix

With the AuthError gone, the integration tests now progress to the API layer and surface two
**separate, pre-existing** problems (previously hidden because tests errored at fixture setup
before any request was made). Neither is caused by this change:

1. **API-auth 401** — the `api_client` fixture (`tests/integration/test_api_endpoints.py`) builds
   the app and sets `app.state.neo4j` but injects **no bearer token / `dependency_overrides`**, so
   every `require_auth`-guarded route (registered in `src/api/app.py`) returns `401`. This is an
   integration-test harness gap, not the neo4j fixture auth.
2. **RateLimitMiddleware Redis `ping()` blocking ~133s/request** — the known issue tracked by
   **ig#1034** (no `socket_connect_timeout` on the rate-limit Redis client). Makes the suite
   impractically slow in environments without a reachable Redis.

Recommend dispositioning these via a follow-up issue (auth-override harness) + ig#1034 (Redis
timeout). Integration tests are **not** a CI gate (CI runs `pytest -m "not integration and not e2e"`),
so this PR's required checks are unaffected.

Closes #975

## Reviewers
@Marisol-Vega-Cruz @Aisling-Brennan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
