### PR TITLE
fix(api): add socket timeouts to rate-limit middleware Redis client (#1034)

### DIFF
--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -24,6 +24,15 @@ if TYPE_CHECKING:
 # Default maximum request body size: 1 MB.
 DEFAULT_MAX_BODY_SIZE = 1_048_576
 
+# Bounded socket timeouts (seconds) for the rate limiter's Redis client so a slow
+# or unreachable Redis fails open *fast* to the in-memory limiter instead of
+# blocking the request path (ig#1034). Redis is co-located in production, so a
+# healthy connect/command is sub-millisecond; half a second is generous headroom
+# while still bounding the worst-case stall. An explicit timeout in REDIS_URL
+# (e.g. ``?socket_connect_timeout=1``) still wins — redis-py lets URL query
+# options override constructor kwargs.
+REDIS_SOCKET_TIMEOUT_SECONDS = 0.5
+
 log = structlog.get_logger(logger_name=__name__)
 
 
@@ -128,7 +137,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         try:
             import redis as redis_lib
 
-            client = redis_lib.Redis.from_url(url, decode_responses=True)
+            client = redis_lib.Redis.from_url(
+                url,
+                decode_responses=True,
+                socket_connect_timeout=REDIS_SOCKET_TIMEOUT_SECONDS,
+                socket_timeout=REDIS_SOCKET_TIMEOUT_SECONDS,
+            )
             client.ping()
             self._redis = client
         except Exception:  # noqa: BLE001

--- a/tests/test_security/test_rate_limiting.py
+++ b/tests/test_security/test_rate_limiting.py
@@ -8,12 +8,12 @@ Maps to OWASP OTG-BUSLOGIC-005.
 from __future__ import annotations
 
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src.api.middleware import RateLimitMiddleware
+from src.api.middleware import REDIS_SOCKET_TIMEOUT_SECONDS, RateLimitMiddleware
 
 
 class TestRateLimitMiddleware:
@@ -118,3 +118,71 @@ class TestRateLimitMemoryFallback:
         assert mw._check_memory("10.0.0.1", now + 2) is False
         # IP B should still be allowed
         assert mw._check_memory("10.0.0.2", now + 2) is True
+
+
+class TestRateLimitRedisTimeout:
+    """Redis client is bounded by socket timeouts and fails open fast (ig#1034).
+
+    Without ``socket_connect_timeout``/``socket_timeout`` the lazy ``_get_redis``
+    ping blocks per-request when Redis is slow/unreachable (e.g. CI/local with no
+    Redis), hanging the whole request path. These tests pin the timeouts and the
+    fail-open-to-in-memory degradation.
+    """
+
+    def test_get_redis_sets_bounded_socket_timeouts(self) -> None:
+        """``_get_redis`` must construct the client with bounded socket timeouts."""
+        mw = RateLimitMiddleware(
+            app=MagicMock(), requests_per_minute=5, window_seconds=60, redis_url="redis://x:6379/0"
+        )
+        with patch("redis.Redis.from_url") as from_url:
+            from_url.return_value = MagicMock()  # ping() is a no-op MagicMock
+            mw._get_redis()
+
+        from_url.assert_called_once()
+        kwargs = from_url.call_args.kwargs
+        assert kwargs["socket_connect_timeout"] == REDIS_SOCKET_TIMEOUT_SECONDS
+        assert kwargs["socket_timeout"] == REDIS_SOCKET_TIMEOUT_SECONDS
+
+    def test_unreachable_redis_fails_open_to_memory(self) -> None:
+        """A ping that times out must degrade to None (in-memory), not raise/hang."""
+        import redis
+
+        mw = RateLimitMiddleware(
+            app=MagicMock(), requests_per_minute=5, window_seconds=60, redis_url="redis://x:6379/0"
+        )
+        client = MagicMock()
+        client.ping.side_effect = redis.exceptions.TimeoutError("timed out")
+        with patch("redis.Redis.from_url", return_value=client):
+            assert mw._get_redis() is None
+
+        # With Redis unavailable, the limiter falls back to the in-memory window.
+        assert mw._check_redis("127.0.0.1", time.time()) is None
+        assert mw._check_memory("127.0.0.1", time.time()) is True
+
+    def test_request_path_completes_when_redis_unreachable(self) -> None:
+        """A request still completes (does not hang) when Redis ping times out."""
+        import redis
+
+        from src.api.app import create_app
+
+        app = create_app()
+        mock_neo4j = MagicMock()
+        mock_neo4j.execute_read.return_value = []
+        mock_neo4j.execute_write.return_value = []
+        app.state.neo4j = mock_neo4j
+        app.add_middleware(
+            RateLimitMiddleware,
+            requests_per_minute=5,
+            window_seconds=60,
+            redis_url="redis://unreachable:6379/0",
+        )
+
+        client = MagicMock()
+        client.ping.side_effect = redis.exceptions.TimeoutError("timed out")
+        with patch("redis.Redis.from_url", return_value=client):
+            test_client = TestClient(app, raise_server_exceptions=False)
+            response = test_client.get("/health")
+
+        assert response.status_code in (200, 503), (
+            f"Request should complete via in-memory fallback, got {response.status_code}"
+        )


### PR DESCRIPTION
## Summary

The rate-limit middleware's lazy Redis client (`_get_redis()` → `redis.Redis.from_url(...)`) had **no socket timeouts**, so a slow/unreachable Redis blocked `client.ping()` (and commands) on the request path instead of failing open to the in-memory limiter — the production-risk form of the known offline-Redis ping hang.

## Fix
- `REDIS_SOCKET_TIMEOUT_SECONDS = 0.5`, passed as both `socket_connect_timeout` and `socket_timeout`. Redis is co-located in prod (sub-ms healthy round-trip); 0.5s is generous headroom while bounding the worst-case stall. An explicit timeout in `REDIS_URL` still wins (redis-py URL query options override constructor kwargs).
- Existing fail-open behaviour (`except` → in-memory window) preserved; now triggers **fast** on timeout instead of hanging.

## Tests (`TestRateLimitRedisTimeout`)
- bounded socket timeouts set on the client,
- ping `TimeoutError` degrades to the in-memory limiter (no raise/hang),
- a request still completes when Redis is unreachable.

## Verification
- `ruff check` / `ruff format --check` / `mypy src/` — all clean.
- The two non-app unit tests pass locally (0.18s). The request-path test (`create_app` + TestClient) is left to CI: the app lifespan connects to services that aren't present in the local sandbox, so it's CI-verified alongside the rest of the suite.

Closes #1034
