### PR TITLE
docs(claude): add zsh Shell environment note (#759)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ npm run test        # Run Vitest
 npm run lint        # Run ESLint
 ```
 
+## Shell environment
+
+The development shell is **zsh** (not bash). Write zsh-safe terminal commands and avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs such as `…?ref=main` URLs). Prefer POSIX-portable constructs; use `bash -c '...'` explicitly when bash is genuinely required. Canonical do/don't list: org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in noorinalabs-main.
+
 ## Architecture
 
 ### Backend layout (`src/`)


### PR DESCRIPTION
## Summary

Adds a concise **"Shell environment"** subsection to this repo's `CLAUDE.md`, placed right after the Build & Development Commands block. It documents that the dev shell is **zsh** (not bash): write zsh-safe terminal commands, avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs), prefer POSIX-portable constructs, and use `bash -c '...'` explicitly when bash is genuinely required. Points readers to the canonical org do/don't list in `docs/TOOLCHAIN.md` + `ontology/conventions.md` (noorinalabs-main).

Docs-only, 4 lines added. No source/config/workflow touched.

## Checks
- cspell (CLAUDE.md): 0 issues
- markdownlint-cli2: 0 errors
- lychee: change adds no markdown links (paths are code-spans) — internal link-check unaffected
- pre-commit + pre-push hooks: green (frontend deps installed so frontend-build runs, not skipped)

Part of #759 (one of 7 per-repo zsh shell notes).
