### PR TITLE
test(unit): stub neo4j driver in offline fixture so unmocked lifespan can't stall (ig#1118)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,41 @@ from src.models.hadith import Hadith
 from src.models.narrator import Narrator
 
 
+class _OfflineNeo4jDriver:
+    """Stand-in neo4j driver that refuses to open a bolt socket (ig#1118).
+
+    Unlike the redis/psycopg constructors below, ``GraphDatabase.driver()`` is
+    *lazy* — it never connects, so patching it to *raise* would break
+    ``Neo4jClient.__init__`` (the app lifespan guards only the index query, not
+    the constructor). Instead we hand back a driver whose session/connectivity
+    probes raise ``ServiceUnavailable`` immediately — exactly the error a
+    refused/blackholed connect ultimately produces — so the lifespan's
+    best-effort ``ensure_fulltext_indexes`` degrades instantly.
+    """
+
+    def session(self, *_args: object, **_kwargs: object) -> NoReturn:
+        import neo4j
+
+        raise neo4j.exceptions.ServiceUnavailable("Neo4j disabled in offline unit tier (ig#1118)")
+
+    def verify_connectivity(self, *_args: object, **_kwargs: object) -> NoReturn:
+        import neo4j
+
+        raise neo4j.exceptions.ServiceUnavailable("Neo4j disabled in offline unit tier (ig#1118)")
+
+    def close(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def __enter__(self) -> _OfflineNeo4jDriver:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
 @pytest.fixture(autouse=True)
 def _offline_external_clients(request: pytest.FixtureRequest) -> Iterator[None]:
-    """Make Redis/Postgres probes fail fast so the unit tier runs offline (ig#1113).
+    """Make Redis/Postgres/Neo4j probes fail fast so the unit tier runs offline.
 
     Tests that spin up the FastAPI app (``test_api`` / ``test_auth`` /
     ``test_security``) route requests through code that opens real sockets to
@@ -35,16 +67,21 @@ def _offline_external_clients(request: pytest.FixtureRequest) -> Iterator[None]:
       on ``redis://localhost:6379`` (per app instance);
     * the ``/health`` (and ``/status``) routes → ``PgClient()`` →
       ``psycopg.connect`` on ``localhost:5432`` and ``get_redis_client`` →
-      ``redis.Redis.from_url(...).ping()``.
+      ``redis.Redis.from_url(...).ping()``;
+    * the app lifespan → ``Neo4jClient`` → ``GraphDatabase.driver(...)`` →
+      ``ensure_fulltext_indexes`` on ``bolt://localhost:7687`` (per app
+      instance, on any context-managed / unmocked ``TestClient`` startup).
 
     With no service running this fast-fails in CI (loopback ``ECONNREFUSED`` →
-    the routes/middleware degrade gracefully), but in a blackhole-connect
-    sandbox each ``connect()`` stalls for the full socket timeout, hanging the
-    offline unit run. Forcing the two client constructors to raise immediately
-    reproduces CI's fast-fail deterministically: the rate limiter falls back to
-    its in-memory window, the health checks report the service ``down`` (503),
-    and no socket is ever opened. This is exactly the degradation those code
-    paths already document and the unit tier already relies on.
+    the routes/middleware/lifespan degrade gracefully), but in a
+    blackhole-connect sandbox each ``connect()`` stalls for the full socket /
+    connection-acquisition timeout (redis/postgres seconds; neo4j ~60s),
+    hanging the offline unit run. Forcing the three client entrypoints to refuse
+    immediately reproduces CI's fast-fail deterministically: the rate limiter
+    falls back to its in-memory window, the health checks report the service
+    ``down`` (503), the index bootstrap is skipped, and no socket is ever
+    opened. This is exactly the degradation those code paths already document
+    and the unit tier already relies on.
 
     Tests that exercise these clients directly (e.g.
     ``test_security/test_rate_limiting.py`` or ``test_api/test_health.py``)
@@ -67,9 +104,13 @@ def _offline_external_clients(request: pytest.FixtureRequest) -> Iterator[None]:
 
         raise psycopg.OperationalError("Postgres disabled in offline unit tier (ig#1113)")
 
+    def _offline_neo4j_driver(*_args: object, **_kwargs: object) -> _OfflineNeo4jDriver:
+        return _OfflineNeo4jDriver()
+
     with (
         patch("redis.Redis.from_url", side_effect=_refuse_redis),
         patch("psycopg.connect", side_effect=_refuse_postgres),
+        patch("neo4j.GraphDatabase.driver", side_effect=_offline_neo4j_driver),
     ):
         yield
 

--- a/tests/test_api/test_app_lifespan.py
+++ b/tests/test_api/test_app_lifespan.py
@@ -31,6 +31,25 @@ def _patch_neo4j(monkeypatch: pytest.MonkeyPatch, client: MagicMock) -> None:
     monkeypatch.setattr(neo4j_module, "Neo4jClient", lambda **_: client)
 
 
+def test_offline_fixture_neutralizes_neo4j_driver() -> None:
+    """The autouse offline fixture (``tests/conftest.py``) must stub the neo4j
+    driver so a context-managed, unmocked ``TestClient`` — which runs the app
+    lifespan and constructs a *real* ``Neo4jClient`` — cannot stall ~60s opening
+    a bolt socket under network isolation (ig#1118).
+
+    We assert at the driver entrypoint rather than via a live ~60s connect so
+    the guard itself never blocks: with the stub a session probe raises
+    ``ServiceUnavailable`` instantly; without it the real (lazy) driver returns
+    a session without connecting, so this test fails fast (DID NOT RAISE)
+    instead of hanging.
+    """
+    import neo4j
+
+    driver = neo4j.GraphDatabase.driver("bolt://192.0.2.1:7687", auth=("neo4j", "x"))
+    with pytest.raises(neo4j.exceptions.ServiceUnavailable, match="ig#1118"):
+        driver.session()
+
+
 @pytest.mark.asyncio
 async def test_lifespan_ensures_fulltext_indexes(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Extends the autouse `_offline_external_clients` fixture (`tests/conftest.py`, ig#1113) to also stub the **neo4j** driver entrypoint, so the unit tier is robustly offline-green under true network isolation — not just because a dead loopback port ECONNREFUSEs fast.

## Background

ig#1113 (PR #1114) made redis/postgres probes fail fast offline, but left neo4j unstubbed. A context-managed / unmocked `TestClient` runs the app lifespan, which constructs a **real** `Neo4jClient` and calls `ensure_fulltext_indexes()` — opening a bolt socket on `bolt://localhost:7687`.

- Under loopback (CI/WSL) this **ECONNREFUSEs fast**, which is why CI is green.
- Under a true blackhole-connect sandbox it **stalls ~60s** on the driver's connection-acquisition timeout before degrading.

**Measured at HEAD** (NEO4J_URI → blackhole `192.0.2.1`, lifespan-running unmocked TestClient): **61.57s** startup stall.

## What changed

- `tests/conftest.py`: add a third patch to the autouse fixture — `neo4j.GraphDatabase.driver` → an `_OfflineNeo4jDriver` stand-in whose `session()` / `verify_connectivity()` raise `ServiceUnavailable` immediately.
  - Unlike redis/psycopg (which `side_effect`-raise on the constructor), `GraphDatabase.driver()` is **lazy** — patching it to *raise* would break `Neo4jClient.__init__` (the lifespan guards only the index query, not the constructor). So we return a degraded driver instead.
- `tests/test_api/test_app_lifespan.py`: a deterministic regression test (`test_offline_fixture_neutralizes_neo4j_driver`) asserting the driver entrypoint is stubbed. It asserts at the entrypoint (not via a live ~60s connect) so the guard itself can never hang.

## Scope note (honest framing)

No *current* unit test reaches this path — every app fixture mocks `Neo4jClient` and returns a non-context-managed `TestClient` (lifespan never fires), so the unit tier was already offline-green. This is a **defense-in-depth safety net** against a future unmocked lifespan test, mirroring why redis/postgres are stubbed even though tests also re-patch them locally.

## Verification (offline, services NOT running)

- Unit selection with `NEO4J_URI=bolt://192.0.2.1:7687` (blackhole): **730 passed, 57 deselected, ~38s**.
- Unmocked lifespan startup against the blackhole: **61.57s → 0.22s**.
- Regression test green; `ruff format`/`ruff` (v0.15.11), `mypy src/`, `pip-audit`, `gitleaks`, `pytest-unit`, and `frontend-build` pre-push hook all Passed.
- Integration/e2e tests are **unaffected** — they opt out via the existing marker early-return that precedes all three patches, keeping real driver wiring against their testcontainers.

Closes #1118
Part of noorinalabs/noorinalabs-main#746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
