### PR TITLE
tech-debt(ci-parity): mirror cspell into pre-commit + classify cspell kind (rollout of main#684)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -23,11 +23,15 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
-understand.
+understand. Closing a blind spot here means ADDING the kind to
+`_KIND_PATTERNS` (cf. `cspell`, noorinalabs-main#684) so a CI job that runs it
+starts demanding a pre-commit mirror — an un-classified CI check is silently
+un-mirrored, which is the exact divergence this gate exists to prevent.
 
 Input Language
 ==============
@@ -79,6 +83,13 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build"),
+    # `cspell` closes the spell-check blind spot (noorinalabs-main#684): docs.yml's
+    # Spellcheck job runs the `streetsidesoftware/cspell-action` (or a `cspell`
+    # CLI), but until this kind existed an un-classified spell gate produced ZERO
+    # drift signal, so the repo could enforce cspell in CI with no pre-commit
+    # mirror — new domain vocabulary then failed only after push. Patterns cover
+    # the action ref, the bundled-CLI step name, and the generic job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -1,0 +1,149 @@
+"""Tests for pre_commit_ci_sync — the pre-commit <-> CI drift gate (#327).
+
+Scoped to the cspell-kind classification that closes the spell-check blind spot
+(noorinalabs-main#684): docs.yml's `Spellcheck (cspell)` job must register as the
+`cspell` kind so the drift gate DEMANDS a `.pre-commit-config.yaml` mirror — an
+un-classified spell gate produces ZERO drift signal, which is the exact silent
+divergence the gate exists to prevent.
+
+This repo's helper is the line-scanner classifier (not the parent's structural
+parser), so these tests exercise it through the same public entry points the gate
+uses: ``kinds_from_ci`` / ``kinds_from_precommit`` / ``compute_drift``.
+
+Run:  python3 -m pytest .claude/lib/tests/test_pre_commit_ci_sync.py -q
+  or  python3 -m unittest discover -s .claude/lib/tests
+(this repo's main suite has ``testpaths = ["tests"]``, so it is invoked
+explicitly, the same way the docs.yml sync gate runs the helper directly).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Helper lives at .claude/lib/pre_commit_ci_sync.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pre_commit_ci_sync import (  # noqa: E402
+    check_repo,
+    compute_drift,
+    kinds_from_ci,
+    kinds_from_precommit,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class CspellKindClassification(unittest.TestCase):
+    """#684: a CI Spellcheck job must classify as the `cspell` kind on EITHER
+    expression — the `streetsidesoftware/cspell-action` `uses:` ref, a bundled
+    `cspell` CLI run, or the generic `spellcheck` word — and a pre-commit cspell
+    hook must classify too, so a CI spell gate with no local mirror produces
+    harmful drift instead of silence."""
+
+    def test_cspell_action_uses_ref_classified(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    name: Spellcheck (cspell)
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e # v8.4.0
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_cspell_cli_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  spell:
+    steps:
+      - run: npx cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_generic_spellcheck_word_classified(self) -> None:
+        # A repo that names the step/run with the generic word still registers.
+        self.assertIn("cspell", kinds_from_ci("      - run: make spellcheck\n"))
+
+    def test_precommit_cspell_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_ci_cspell_without_precommit_is_harmful_drift(self) -> None:
+        # The exact divergence #684 exists to catch: CI enforces cspell, the
+        # pre-commit config does not mirror it.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("cspell", harmful)
+
+    def test_ci_cspell_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("cspell", harmful)
+
+
+class RealRepoHasNoCspellDrift(unittest.TestCase):
+    """End-to-end against this repo's own files: docs.yml enforces cspell and
+    .pre-commit-config.yaml now mirrors it, so the gate must see no cspell drift.
+    This is the gate exactly as the `Pre-commit ⇄ CI sync-drift gate` job runs
+    it — globbing ALL workflow files."""
+
+    def test_repo_ci_enforces_cspell(self) -> None:
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        ci_kinds: set[str] = set()
+        for p in sorted(wf_dir.glob("*.y*ml")):
+            if p.is_file():
+                ci_kinds |= kinds_from_ci(p.read_text(encoding="utf-8"))
+        self.assertIn("cspell", ci_kinds)
+
+    def test_repo_precommit_mirrors_cspell(self) -> None:
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        self.assertIn("cspell", kinds_from_precommit(precommit.read_text(encoding="utf-8")))
+
+    def test_repo_has_no_cspell_drift(self) -> None:
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        ci_paths = sorted(wf_dir.glob("*.y*ml"))
+        self.assertTrue(ci_paths, "repo must have workflow files")
+        harmful, _ = check_repo(precommit, ci_paths)
+        self.assertNotIn(
+            "cspell",
+            harmful,
+            f"cspell must be mirrored in pre-commit; harmful drift: {sorted(harmful)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@
 # fast instead of surfacing a lint/type/test/actionlint/build error only after a
 # PR is opened (Phase-3 end-state criterion #6 / #327). The kind-level mirror
 # (ruff, mypy, pytest, eslint, typescript, gitleaks, pip-audit, actionlint,
-# build present on both sides) is enforced in CI by `.claude/lib/
+# build, cspell present on both sides) is enforced in CI by `.claude/lib/
 # pre_commit_ci_sync.py` — if a future edit drops a check from one side, the
 # "Pre-commit <-> CI sync-drift gate" job in docs.yml fails the build.
 #
 # Stage split (fail-fast, cheapest first):
 #   pre-commit (every commit) — ruff-format, ruff-lint, gitleaks, actionlint,
-#     pip-audit, mypy, unit tests, ESLint, frontend type-check. Fast checks that
-#     catch the most common defects before a commit is recorded.
+#     cspell, pip-audit, mypy, unit tests, ESLint, frontend type-check. Fast
+#     checks that catch the most common defects before a commit is recorded.
 #   commit-msg               — co-author trailer enforcement.
 #   pre-push  (every push)   — frontend build. The heavier compile that mirrors
 #     ci.yml's `npm run build`; run before code leaves the machine, not on every
@@ -57,6 +57,29 @@ repos:
     hooks:
       - id: actionlint
         name: actionlint
+        stages: [pre-commit]
+
+  # --- Spellcheck (commit stage) — mirrors docs.yml Spellcheck (cspell) job ---
+  # Closes the spell-check blind spot (noorinalabs-main#684): CI's
+  # `streetsidesoftware/cspell-action@…v8.4.0` enforced cspell with no local
+  # mirror, so new authored-prose typos failed only after push. The
+  # `Pre-commit ⇄ CI sync-drift gate` now classifies the `cspell` kind and
+  # DEMANDS this mirror.
+  #
+  # Pinned to v8.4.0 of cspell-cli to match the exact cspell the
+  # `cspell-action@…v8.4.0` CI step bundles — same engine + dictionaries on both
+  # sides, so a word that passes locally passes in CI and vice-versa.
+  # `language: node`, so pre-commit provisions its own node/cspell env (no system
+  # cspell required). `--config .cspell.json` reuses the same dictionaries +
+  # ignore rules CI loads; `files` is the regex equivalent of the CI action's
+  # authored-prose glob set (CLAUDE.md, README.md, docs, skills, charter).
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(CLAUDE\.md|README\.md|docs/.*\.md|\.claude/skills/.*\.md|\.claude/team/charter\.md)$
         stages: [pre-commit]
 
   # --- Branch & commit identity checks ---


### PR DESCRIPTION
## Summary

Rollout of the parent cspell CI<->pre-commit parity fix (meta: noorinalabs-main#684) to isnad-graph. Closes the spell-check blind spot in the `Pre-commit ⇄ CI sync-drift gate`: docs.yml runs a `Spellcheck (cspell)` job, but the gate's classifier did not recognize the `cspell` kind, so the job was silently un-mirrored — new authored-prose typos failed only after push.

## Changes

**Part 1 — classify the `cspell` kind** in `.claude/lib/pre_commit_ci_sync.py` (`_KIND_PATTERNS`), so the sync-drift gate now DEMANDS a pre-commit mirror of docs.yml's cspell job instead of ignoring it. Adds `CspellKindClassification` + `RealRepoHasNoCspellDrift` test classes in a new `.claude/lib/tests/test_pre_commit_ci_sync.py`.

**Part 2 — mirror the cspell hook** into `.pre-commit-config.yaml`, pinned to `streetsidesoftware/cspell-cli` **v8.4.0** to match this repo's CI `streetsidesoftware/cspell-action@…v8.4.0`, with `--config .cspell.json` and `files:` scoped to the regex equivalent of the CI action's authored-prose globs (`CLAUDE.md`, `README.md`, `docs/**/*.md`, `.claude/skills/**/*.md`, `.claude/team/charter.md`).

## cspell version pinned

`streetsidesoftware/cspell-cli` **v8.4.0** (matches CI's `cspell-action@de2a73e…` v8.4.0 — same engine + dictionaries on both sides).

## Verification

- `python3 .claude/lib/pre_commit_ci_sync.py .` → exit 0 (OK: pre-commit mirrors all CI-enforced checks). Before Part 2 it correctly reported `cspell` drift, confirming the gate now enforces it.
- Unit tests green (9 passed).
- `pre-commit run cspell --all-files` → Passed (no real typos). ruff-format / ruff-lint green.

## Notes

This repo's `pre_commit_ci_sync.py` is the line-scanner classifier (pre-#748 structural parser), so the change keeps that style and merges only the `cspell` entry — no behavioral refactor. The new test file is invoked explicitly (`python3 -m pytest .claude/lib/tests/...`); this repo's main suite has `testpaths = ["tests"]` and no CI job runs `.claude/lib/tests/`, so the live CI enforcement of cspell parity is the docs.yml sync-drift gate itself (which this PR makes pass).

Closes #1121
Part of noorinalabs-main#684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
