### PR TITLE
test(integration)(P6W2): mark test_cross_service_auth as integration — #1120

### DIFF
--- a/tests/integration/test_cross_service_auth.py
+++ b/tests/integration/test_cross_service_auth.py
@@ -39,6 +39,8 @@ from src.config import (
     get_settings,
 )
 
+pytestmark = pytest.mark.integration
+
 # ---------------------------------------------------------------------------
 # RSA key material (generated once per module)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`tests/integration/test_cross_service_auth.py` lives in `tests/integration/` but lacked the integration marker, so `test_malformed_bearer_token_returns_401` leaked into the offline unit selection (~10s). Adds module-level `pytestmark = pytest.mark.integration` — the same form sibling integration modules use (`test_historical_overlay.py`, `test_api_endpoints.py`). The `integration` marker is registered in `pyproject.toml`.

Closes #1120

TechDebt: none — test-marker hygiene fix; no new debt.

## Reviewers
- Requestor: Marisol Vega-Cruz (implementer)
- Reviewer: Anya Kowalczyk
- Reviewer: Linh Pham

🧵 Implementer committed the fix but went idle (API 529 overload) before pushing; orchestrator ran `npm ci` to clear the frontend pre-push build gate and pushed/opened the PR (throttle-takeover). Authored commit is Marisol Vega-Cruz's.
