### PR TITLE
tech-debt(ci-parity): align pre-commit actionlint -ignore + gate .claude/lib/tests in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -214,6 +214,26 @@ jobs:
           actionlint -color \
             -ignore 'constant expression "false" in condition'
 
+  lib-tests:
+    name: Pytest — .claude/lib unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Mirrors how the parent repo gates its `.claude/lib/` (noorinalabs-main
+      # ci.yml `pytest` job). The repo's main suite is `testpaths = ["tests"]`,
+      # so the sync-gate classifier tests under `.claude/lib/tests/` were
+      # CI-unguarded — a regression in `pre_commit_ci_sync.py`'s kind
+      # classification (the live cspell-parity enforcement, main#684) would not
+      # fail CI, only local pre-commit (ig#1123). This repo's helper imports only
+      # the stdlib (no PyYAML — it is the line-scanner classifier, not the
+      # parent's structural parser), so `pytest` alone is the only dependency.
+      - run: pip install pytest
+      - name: Run .claude/lib tests
+        run: python3 -m pytest .claude/lib/tests/ -q
+
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,20 @@ repos:
         name: gitleaks
 
   # --- Workflow lint (commit stage) — mirrors docs.yml actionlint job (#327) ---
+  # `args` MUST match the docs.yml `Run actionlint on workflows` step exactly:
+  # ci.yml's `e2e` job is deliberately `if: false` (kill-switch pending the
+  # mock-auth-refresh, ig#812), which the pinned v1.7.12 flags as
+  # `constant expression "false" in condition`. CI carries this `-ignore`;
+  # without it here `pre-commit run actionlint --all-files` FAILS locally on the
+  # pre-existing `if: false` while CI stays green — a local⇄CI divergence of the
+  # same class as the cspell gap main#684 closed (ig#1123). Keep the `-ignore`
+  # string byte-identical to docs.yml so local and CI agree.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
       - id: actionlint
         name: actionlint
+        args: ['-ignore', 'constant expression "false" in condition']
         stages: [pre-commit]
 
   # --- Spellcheck (commit stage) — mirrors docs.yml Spellcheck (cspell) job ---
@@ -123,6 +132,21 @@ repos:
         entry: bash -c 'ENVIRONMENT=test uv run pytest tests/ -x --tb=short -q -m "not integration and not e2e and not ml"'
         language: system
         pass_filenames: false
+        stages: [pre-commit]
+
+      # `.claude/lib/` unit tests — mirrors the docs.yml `Pytest — .claude/lib`
+      # job (ig#1123). The main `pytest-unit` hook above runs `tests/` only
+      # (pyproject `testpaths = ["tests"]`), so the sync-gate classifier tests
+      # under `.claude/lib/tests/` are otherwise local-pre-push/CI-unguarded; a
+      # regression in `pre_commit_ci_sync.py`'s kind classification would not
+      # fail on commit. Scoped via `files:` so it only runs when `.claude/lib/`
+      # changes, keeping the common commit loop snappy.
+      - id: claude-lib-tests
+        name: claude-lib-tests
+        entry: bash -c 'ENVIRONMENT=test uv run pytest .claude/lib/tests/ -q'
+        language: system
+        pass_filenames: false
+        files: ^\.claude/lib/
         stages: [pre-commit]
 
       # Integration tests require Docker (Neo4j, PostgreSQL) — run in CI only.


### PR DESCRIPTION
## What

Closes two pre-existing local⇄CI parity gaps flagged in #1123 (follow-up from cspell-parity #1122, child of main#684 — local "clean" must match CI).

### 1. pre-commit `actionlint` now carries CI's `-ignore`
The `.pre-commit-config.yaml` actionlint hook (pinned `rev: v1.7.12`) lacked the `-ignore 'constant expression "false" in condition'` that `docs.yml`'s actionlint job already carries for ci.yml's intentional `if: false` e2e kill-switch (ig#812). Result: `pre-commit run actionlint --all-files` **failed locally** on the v1.7.12 finding while CI stayed green. The hook now passes the same `-ignore`, byte-identical to docs.yml. Validated: the actionlint pre-commit hook (provisioning v1.7.12) **Passed** on this commit.

### 2. `.claude/lib/tests/` now gated in CI (and on commit)
The repo's `testpaths = ["tests"]` excluded the sync-gate classifier suite under `.claude/lib/tests/`, so a regression in `pre_commit_ci_sync.py` (the live cspell-parity enforcement, main#684) failed only on local pre-commit — never in CI. Added:
- a `docs.yml` job `Pytest — .claude/lib unit tests` (mirrors how the parent repo gates its `.claude/lib/`; stdlib-only helper, so `pytest` is the sole dep);
- a scoped `claude-lib-tests` pre-commit hook (`files: ^\.claude/lib/`) so the suite also guards on commit.

## Sync-drift gate
Both additions are **already-classified kinds** (`actionlint`, `pytest`) on both sides, so the `pre_commit_ci_sync.py` gate stays green — verified locally `rc=0`, no classifier change needed.

## Validation
- sync gate `rc=0`; `.claude/lib/tests/` → 9 passed
- full `pre-commit` (commit stage) green incl. actionlint @ v1.7.12
- `pre-push` (frontend build) green
- both YAML files parse

Closes #1123

TechDebt: none — this is itself a tech-debt/hygiene paydown (CI-parity); no new debt introduced.
