### PR TITLE
feat(ci): base-pin + fixture-realism gates rollout to isnad-graph (#744)

### DIFF
--- a/.claude/lib/check_dockerfile_base_pin.py
+++ b/.claude/lib/check_dockerfile_base_pin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Lint Dockerfile `FROM` statements for digest-pin + distro-upgrade compliance.
+
+Deterministic conversion of `.claude/team/charter/tech-decisions.md § Base Image
+Pinning` (noorinalabs-main#735, the charter-prose-inventory worklist item #4 /
+epic #726). The section requires every `FROM` to use a **digest-pinned tag**
+(`image:tag@sha256:<digest>`) **combined with an in-image package upgrade**, to
+close the two failure modes it names — floating-tag drift and within-tag package
+drift (the shape isnad-graph#853 hit).
+
+What this gate enforces (verbatim from the section's distro table)
+================================================================
+For every `FROM` that is not exempt:
+
+1. The image reference MUST carry an `@sha256:` digest pin.
+2. The stage MUST run the package-manager upgrade matching the base distro:
+
+   | Family      | Pin shape               | Upgrade command                                 |
+   |-------------|-------------------------|-------------------------------------------------|
+   | Alpine      | image:tag@sha256:digest | `RUN apk upgrade --no-cache`                    |
+   | Debian-slim | image:tag@sha256:digest | `apt-get update && apt-get -y upgrade && clean` |
+   | Distroless  | image:tag@sha256:digest | none — no package manager (pinned-only is fine) |
+
+   The distro family is inferred from the image name: `alpine` → Alpine,
+   `distroless` → Distroless (no upgrade required), otherwise the glibc/Debian
+   default (an apt upgrade is required). A genuinely-other base that has no
+   package manager should carry the `# RATIONALE:` exemption below.
+
+Exemptions honored (verbatim from the section)
+=============================================
+- **`scratch`** final/any layer — no package manager; the upstream stages that
+  produced its contents still follow the rule and are checked on their own
+  `FROM`.
+- **Distroless** — pinned-only is sufficient (no package manager); the digest
+  pin is still required.
+- **Multi-stage stage reference** — a `FROM <earlier-stage>` inherits the
+  upstream stage's pin, so it is not re-checked (the named stage was checked at
+  its defining `FROM`).
+- **Vendor images** documented with an inline `# RATIONALE:` comment on the
+  `FROM` line (or the comment line immediately above it).
+
+CLI
+===
+    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+
+Exit codes:
+    0 — every FROM in every file is compliant (or exempt)
+    1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
+    2 — usage / file-not-found error
+
+This is a reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
+pre-commit config and its CI. The parent repo `noorinalabs-main` ships no
+Dockerfiles itself; the cross-repo rollout that points this at each child's
+Dockerfiles is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
+# A leading `--platform=...` flag precedes the image and must be stripped.
+_PLATFORM_RE = re.compile(r"^--platform=\S+\s+", re.IGNORECASE)
+# A trailing `AS <stage>` names the build stage.
+_AS_RE = re.compile(r"\s+AS\s+(?P<stage>\S+)\s*$", re.IGNORECASE)
+
+# Upgrade-command signatures per distro family (searched over the stage body).
+_ALPINE_UPGRADE_RE = re.compile(r"\bapk\s+upgrade\b", re.IGNORECASE)
+# `apt-get update && apt-get -y upgrade` / `apt upgrade` — an apt invocation
+# followed (in the same command segment) by `upgrade`. `apt-get update` alone
+# does NOT match (that is "update", not "upgrade").
+_DEBIAN_UPGRADE_RE = re.compile(r"\bapt(?:-get)?\s+(?:-{1,2}\S+\s+)*upgrade\b", re.IGNORECASE)
+
+_RATIONALE_RE = re.compile(r"#\s*RATIONALE:", re.IGNORECASE)
+
+
+class FromStatement:
+    """One parsed `FROM` line: its image ref, optional stage name, exemptions."""
+
+    def __init__(self, lineno: int, image: str, stage: str | None, has_rationale: bool) -> None:
+        self.lineno = lineno
+        self.image = image
+        self.stage = stage
+        self.has_rationale = has_rationale
+
+
+def _preceding_comment_has_rationale(lines: list[str], from_idx: int) -> bool:
+    """True if the comment line(s) immediately above `from_idx` carry RATIONALE."""
+    j = from_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if stripped.startswith("#"):
+            return bool(_RATIONALE_RE.search(stripped))
+        return False
+    return False
+
+
+def parse_froms(text: str) -> list[FromStatement]:
+    """Parse every `FROM` statement in a Dockerfile, in source order."""
+    lines = text.splitlines()
+    froms: list[FromStatement] = []
+    for idx, raw in enumerate(lines):
+        m = _FROM_RE.match(raw)
+        if not m:
+            continue
+        rest = m.group("rest")
+        has_rationale = bool(_RATIONALE_RE.search(raw)) or _preceding_comment_has_rationale(
+            lines, idx
+        )
+        # Drop any trailing inline comment, then a leading --platform flag.
+        code = rest.split("#", 1)[0].strip()
+        code = _PLATFORM_RE.sub("", code).strip()
+        stage: str | None = None
+        as_m = _AS_RE.search(code)
+        if as_m is not None:
+            stage = as_m.group("stage")
+            code = code[: as_m.start()].strip()
+        image = code.split()[0] if code.split() else ""
+        froms.append(FromStatement(idx + 1, image, stage, has_rationale))
+    return froms
+
+
+def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
+    """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
+    lines = text.splitlines()
+    start = from_lineno  # from_lineno is 1-based; body starts on the next line
+    end = (next_from_lineno - 1) if next_from_lineno is not None else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def check_dockerfile_text(path: str, text: str) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile."""
+    violations: list[str] = []
+    froms = parse_froms(text)
+    defined_stages: set[str] = set()
+    for i, stmt in enumerate(froms):
+        next_lineno = froms[i + 1].lineno if i + 1 < len(froms) else None
+        image_l = stmt.image.lower()
+
+        # Exemptions, in order. `scratch` and stage-references have no package
+        # manager / inherit the upstream pin; a documented vendor RATIONALE opts
+        # out explicitly. Record this stage's own name for later references.
+        is_exempt = image_l == "scratch" or image_l in defined_stages or stmt.has_rationale
+        if stmt.stage:
+            defined_stages.add(stmt.stage.lower())
+        if is_exempt:
+            continue
+
+        if "@sha256:" not in stmt.image:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
+                f"(require image:tag@sha256:<digest>)"
+            )
+
+        body = _stage_body(text, stmt.lineno, next_lineno)
+        if "distroless" in image_l:
+            continue  # distroless has no package manager; pinned-only is sufficient
+        if "alpine" in image_l:
+            if not _ALPINE_UPGRADE_RE.search(body):
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Alpine upgrade "
+                    f"step (RUN apk upgrade --no-cache)"
+                )
+        elif not _DEBIAN_UPGRADE_RE.search(body):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Debian upgrade step "
+                f"(RUN apt-get update && apt-get -y upgrade && apt-get clean)"
+            )
+    return violations
+
+
+def check_file(path: Path) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
+            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
+            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
+            "an inline `# RATIONALE:` comment on the FROM line."
+        )
+        return 1
+
+    print("OK: all Dockerfile FROM statements are digest-pinned with the required upgrade.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/check_fixture_realism.py
+++ b/.claude/lib/check_fixture_realism.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Lint Arabic-text fixtures for production-realism (vocalization + عن particle).
+
+Deterministic conversion of `.claude/team/charter/pull-requests.md § Text-
+Processing / NER / Graph Fixtures Must Use Production-Realistic Input`
+(noorinalabs-main#735, charter-prose-inventory worklist item #1 / epic #726).
+This is the "lint / review-lens" the section's *Enforcement opportunity*
+sub-section names as the optional half of #671: a cheap static signal that an
+Arabic fixture is a toy rather than a real upstream sample.
+
+The fixture-masks-bug class recurred 5+ times — most damningly *inside its own
+fix* (da#146 / PR #151 replaced an un-voweled toy blob with a Bukhari-h1 fixture
+that contained no عن, masking the over-segmentation later surfaced as da#155; the
+P5W5 thaqalayn parser shipped a schema-assumed fixture that hid 0% extracted
+Arabic, da#175). A fixture that is *greener than real data* is masking a bug.
+
+What this gate flags
+====================
+For every file it is given, the codepoints are scanned. A file with NO Arabic
+letters is **not** an Arabic-text fixture and is skipped (passes — this lens only
+judges Arabic fixtures). A file that DOES contain Arabic letters is flagged when:
+
+  (a) it contains NO Arabic vocalization diacritic — none in the harakat range
+      U+064B–U+0652 (ً tanwīn-fatḥ … ْ sukūn). Real corpus text is voweled;
+      a fixture stripped of diacritics exercises a code path the production
+      corpus never takes.
+  (b) it lacks the high-frequency transmission particle عن (ʿan, U+0639 U+0646)
+      anywhere — the substring a naive segmenter over-splits; omitting it lets an
+      over-segmentation bug pass. (The section scopes this to isnad strings; the
+      `files:`/discovery wiring chooses which paths are fixtures, and the check
+      applies the floor to any Arabic-bearing fixture it is handed.)
+
+The عن search runs over a diacritic-stripped copy of the text, NOT the raw bytes.
+In real voweled corpus text the particle is written عَنْ — a fatḥa sits *between*
+the ʿayn and the nūn — so a naive bare-`عن` substring search would FAIL on the
+exact voweled fixtures criterion (a) demands. Stripping the harakat first
+(عَنْ → عن) is what lets a production-realistic voweled chain satisfy both checks
+at once (without it the two criteria would be mutually unsatisfiable).
+
+Either condition alone flags the file; the diagnostic names which one(s) failed.
+
+CLI
+===
+    python3 .claude/lib/check_fixture_realism.py <fixture> [<fixture> ...]
+
+Exit codes:
+    0 — every Arabic-text fixture carries vocalization AND the عن particle
+        (non-Arabic files are skipped)
+    1 — at least one Arabic-text fixture is un-voweled or lacks عن
+    2 — usage / file-not-found error
+
+Reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into pre-commit and
+CI. The parent repo `noorinalabs-main` ships no Arabic fixtures itself; pointing
+this at each child's text-processing/NER/graph fixtures is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The transmission particle عن (ʿan): U+0639 (ʿayn) U+0646 (nūn). Substring-
+# searched verbatim, exactly as the charter rule specifies.
+_AN_PARTICLE = "عن"  # عن
+
+# Arabic vocalization diacritics — the harakat the rule names as `ً–ْ`:
+# U+064B (tanwīn fatḥ) … U+0652 (sukūn), inclusive.
+_DIACRITIC_START = 0x064B
+_DIACRITIC_END = 0x0652
+
+# Arabic consonantal letters (hamza U+0621 … yāʾ U+064A). Presence of any of
+# these is what makes a file an "Arabic-text fixture" worth judging — distinct
+# from the diacritics (which sit just above this range) and from digits/marks.
+_LETTER_START = 0x0621
+_LETTER_END = 0x064A
+
+# Tatweel / kashida (U+0640) is an elongation glyph, not a letter or a vowel; it
+# is stripped alongside the harakat so it cannot split the عن particle either.
+_TATWEEL = 0x0640
+
+
+def has_arabic_letters(text: str) -> bool:
+    """True if the text contains at least one Arabic consonantal letter."""
+    return any(_LETTER_START <= ord(ch) <= _LETTER_END for ch in text)
+
+
+def has_vocalization(text: str) -> bool:
+    """True if the text contains at least one harakat diacritic (U+064B–U+0652)."""
+    return any(_DIACRITIC_START <= ord(ch) <= _DIACRITIC_END for ch in text)
+
+
+def strip_diacritics(text: str) -> str:
+    """Remove harakat (U+064B–U+0652) and tatweel so عَنْ collapses to عن."""
+    return "".join(
+        ch
+        for ch in text
+        if not (_DIACRITIC_START <= ord(ch) <= _DIACRITIC_END) and ord(ch) != _TATWEEL
+    )
+
+
+def has_an_particle(text: str) -> bool:
+    """True if عن appears once diacritics/tatweel are stripped (عَنْ → عن)."""
+    return _AN_PARTICLE in strip_diacritics(text)
+
+
+def check_fixture_text(path: str, text: str) -> list[str]:
+    """Return violation strings for one fixture (empty list = clean or skipped)."""
+    if not has_arabic_letters(text):
+        return []  # not an Arabic-text fixture — this lens does not judge it
+    reasons: list[str] = []
+    if not has_vocalization(text):
+        reasons.append("no vocalization diacritics (none in U+064B–U+0652 ً–ْ)")
+    if not has_an_particle(text):
+        reasons.append("missing transmission particle عن")
+    if not reasons:
+        return []
+    return [f"{path}: Arabic-text fixture is not production-realistic — {'; '.join(reasons)}"]
+
+
+def check_file(path: Path) -> list[str]:
+    return check_fixture_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_fixture_realism.py <fixture> [<fixture> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Fixture-realism violations (pull-requests.md § Production-Realistic Input, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nArabic-text fixtures must be lifted from a real upstream sample: voweled "
+            "(diacritics in U+064B–U+0652) and carrying the عن transmission particle. "
+            "A fixture greener than real data masks the next bug in that path."
+        )
+        return 1
+
+    print("OK: all Arabic-text fixtures carry vocalization and the عن particle.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -24,7 +24,7 @@ kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
     terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
-    cspell
+    cspell, dockerfile-base-pin, fixture-realism
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -90,6 +90,16 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # mirror — new domain vocabulary then failed only after push. Patterns cover
     # the action ref, the bundled-CLI step name, and the generic job/step word.
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+    # `dockerfile-base-pin` and `fixture-realism` are the two charter-prose→code
+    # gates built in noorinalabs-main#735 (worklist #4 + #1 of the #734
+    # inventory) and rolled into this repo by #744. Each is a
+    # `.claude/lib/check_*.py` invoked identically by a CI `run:` step and a
+    # pre-commit hook; classifying them here is what makes the sync-drift gate
+    # DEMAND the mirror (the #684 contract: an un-classified CI check is a silent
+    # blind spot). Patterns match the script basename (present on both sides'
+    # invoke line) and the hook id / job-kind token.
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
+    "fixture-realism": ("check_fixture_realism", "fixture-realism"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_check_dockerfile_base_pin.py
+++ b/.claude/lib/tests/test_check_dockerfile_base_pin.py
@@ -1,0 +1,195 @@
+"""Tests for check_dockerfile_base_pin — the Base Image Pinning gate (#735).
+
+Verifies the deterministic conversion of `tech-decisions.md § Base Image
+Pinning`: every FROM must be digest-pinned AND carry the matching distro
+upgrade, with the section's exact exemptions (scratch, distroless, stage
+references, vendor `# RATIONALE:`). Positive cases use the real required pattern
+the section documents; negative cases use the exact prohibited shapes it names
+(floating tag, pin-only, apk-only).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_dockerfile_base_pin import (  # noqa: E402
+    check_dockerfile_text,
+    main,
+    parse_froms,
+)
+
+# A real digest (truncated only for readability is NOT allowed by the checker —
+# it needs the literal `@sha256:` marker, which these carry in full shape).
+_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4"
+
+
+class CompliantFromsPass(unittest.TestCase):
+    def test_alpine_pinned_with_apk_upgrade(self) -> None:
+        df = f"""# Digest-pinned tag + apk upgrade for defense-in-depth
+FROM nginx:stable-alpine3.23{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_debian_slim_pinned_with_apt_upgrade(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST}
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_distroless_pin_only_is_sufficient(self) -> None:
+        # Distroless has no package manager — pinned-only passes, no upgrade.
+        df = f"FROM gcr.io/distroless/static-debian12{_DIGEST}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_scratch_final_layer_exempt(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM scratch
+COPY --from=builder /app /app
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_stage_reference_inherits_pin(self) -> None:
+        # `FROM builder` references an earlier stage; it inherits the pin and is
+        # not re-checked for a digest or an upgrade.
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get clean
+
+FROM builder
+RUN pip install .
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_inline_comment_exempts(self) -> None:
+        df = "FROM vendor/proprietary:1.4  # RATIONALE: not redistributable digest-pinned\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_preceding_comment_exempts(self) -> None:
+        df = """# RATIONALE: vendor image, not available as a digest-pinned ref
+FROM vendor/proprietary:1.4
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_platform_flag_is_stripped(self) -> None:
+        df = f"""FROM --platform=linux/amd64 node:20-alpine{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class ProhibitedShapesFlagged(unittest.TestCase):
+    def test_floating_tag_flagged(self) -> None:
+        # WRONG (floating tag): no digest, no upgrade — both defenses missing.
+        violations = check_dockerfile_text("Dockerfile", "FROM nginx:alpine\n")
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+        self.assertTrue(any("Alpine upgrade" in v for v in violations))
+
+    def test_pin_only_alpine_missing_upgrade(self) -> None:
+        # INSUFFICIENT (pin-only): tag frozen but Alpine packages drift — the
+        # exact shape isnad-graph#853 hit.
+        df = f"FROM nginx:stable-alpine3.23{_DIGEST}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Alpine upgrade", violations[0])
+
+    def test_apk_only_missing_digest(self) -> None:
+        # INSUFFICIENT (apk-only): upgrade present but base layer is unpinned.
+        df = "FROM nginx:alpine\nRUN apk upgrade --no-cache\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("not digest-pinned", violations[0])
+
+    def test_debian_pinned_missing_apt_upgrade(self) -> None:
+        df = f"FROM python:3.12-slim{_DIGEST}\nRUN pip install .\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_apt_update_only_is_not_an_upgrade(self) -> None:
+        # `apt-get update` is not `apt-get upgrade`; pin present, upgrade absent.
+        df = f"FROM debian:bookworm-slim{_DIGEST}\nRUN apt-get update\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_line_number_reported(self) -> None:
+        df = """# header comment
+FROM nginx:alpine
+RUN apk upgrade --no-cache
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("Dockerfile:2:", violations[0])
+
+
+class MultiStageMixed(unittest.TestCase):
+    def test_compliant_builder_but_bad_runtime_flags_only_runtime(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM nginx:alpine
+COPY --from=builder /app /app
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        # builder is clean; only the floating runtime FROM is flagged (pin+upgrade).
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(all("FROM nginx:alpine" in v for v in violations))
+
+
+class ParserBehavior(unittest.TestCase):
+    def test_parse_collects_stage_names_and_images(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+FROM scratch
+"""
+        froms = parse_froms(df)
+        self.assertEqual(len(froms), 2)
+        self.assertEqual(froms[0].stage, "builder")
+        self.assertTrue(froms[0].image.startswith("python:3.12-slim@sha256:"))
+        self.assertEqual(froms[1].image, "scratch")
+
+    def test_from_keyword_case_insensitive(self) -> None:
+        df = f"from nginx:alpine{_DIGEST} as web\nRUN apk upgrade --no-cache\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class CliBehavior(unittest.TestCase):
+    def test_clean_file_exits_zero(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write(f"FROM nginx:stable-alpine3.23{_DIGEST}\nRUN apk upgrade --no-cache\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_exits_one(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write("FROM nginx:alpine\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "/no/such/Dockerfile"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_check_fixture_realism.py
+++ b/.claude/lib/tests/test_check_fixture_realism.py
@@ -1,0 +1,146 @@
+"""Tests for check_fixture_realism — the Production-Realistic fixture lint (#735).
+
+Per the rule it enforces, this test's OWN fixtures are production-realistic:
+
+  - POSITIVE cases are real-shape voweled Arabic isnad chains carrying عَنْ (the
+    عن particle, voweled) — e.g. the Bukhari mu`allaq chain shape
+    `حَدَّثَنَا … عَنْ … عَنْ …`.
+  - NEGATIVE cases are the exact toy shapes the rule flags: an un-voweled blob,
+    and the da#146/da#155 worked example — a voweled Bukhari-h1-shape chain that
+    is missing عن (the gap that masked the over-segmentation bug).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_fixture_realism import (  # noqa: E402
+    check_fixture_text,
+    has_an_particle,
+    has_arabic_letters,
+    has_vocalization,
+    main,
+    strip_diacritics,
+)
+
+# Real-shape voweled isnad with the عَنْ particle (Bukhari-style mu`an`an chain).
+# Production-realistic: full harakat + repeated عَنْ, exactly what a naive
+# segmenter over-splits.
+REAL_VOWELED_WITH_AN = (
+    "حَدَّثَنَا مُسَدَّدٌ قَالَ حَدَّثَنَا يَحْيَى عَنْ شُعْبَةَ عَنْ قَتَادَةَ عَنْ أَنَسٍ عَنِ النَّبِيِّ صَلَّى اللَّهُ عَلَيْهِ وَسَلَّمَ"
+)
+
+# da#146/da#155 worked example: a voweled Bukhari-h1-shape chain that uses only
+# قَالَ / سَمِعَ and carries NO عن — the fixture that masked the over-segmentation.
+VOWELED_MISSING_AN = "حَدَّثَنَا الْحُمَيْدِيُّ قَالَ حَدَّثَنَا سُفْيَانُ قَالَ سَمِعْتُ يَحْيَى بْنَ سَعِيدٍ الْأَنْصَارِيَّ"
+
+# Un-voweled toy blob: no diacritics at all (and no عن).
+UNVOWELED_TOY = "حدثنا محمد قال حدثنا يحيى بن سعيد"
+
+# Un-voweled but DOES contain عن — isolates the "no vocalization" reason.
+UNVOWELED_WITH_AN = "حدثنا محمد عن يحيى عن انس عن النبي"
+
+
+class HelperPrimitives(unittest.TestCase):
+    def test_has_arabic_letters_true_on_arabic(self) -> None:
+        self.assertTrue(has_arabic_letters(REAL_VOWELED_WITH_AN))
+
+    def test_has_arabic_letters_false_on_ascii(self) -> None:
+        self.assertFalse(has_arabic_letters("hadithReference: 1\nnarrator: Anas"))
+
+    def test_has_vocalization_distinguishes_voweled(self) -> None:
+        self.assertTrue(has_vocalization(REAL_VOWELED_WITH_AN))
+        self.assertFalse(has_vocalization(UNVOWELED_TOY))
+
+    def test_strip_diacritics_collapses_voweled_an(self) -> None:
+        # عَنْ must collapse to bare عن so the particle search can see it.
+        self.assertIn("عن", strip_diacritics("عَنْ"))
+
+    def test_has_an_particle_sees_through_vowels(self) -> None:
+        # The load-bearing case: voweled عَنْ is detected as the particle.
+        self.assertTrue(has_an_particle(REAL_VOWELED_WITH_AN))
+        self.assertTrue(has_an_particle(UNVOWELED_WITH_AN))
+        self.assertFalse(has_an_particle(VOWELED_MISSING_AN))
+        self.assertFalse(has_an_particle(UNVOWELED_TOY))
+
+
+class CleanFixturesPass(unittest.TestCase):
+    def test_real_voweled_chain_with_an_passes(self) -> None:
+        self.assertEqual(check_fixture_text("fix.json", REAL_VOWELED_WITH_AN), [])
+
+    def test_non_arabic_file_is_skipped(self) -> None:
+        # English / schema-only files are not Arabic-text fixtures — not judged.
+        self.assertEqual(check_fixture_text("schema.json", '{"narrator": "Anas", "n": 1}'), [])
+
+    def test_real_chain_embedded_in_json_passes(self) -> None:
+        payload = f'{{"matn_ar": "...", "isnad_ar": "{REAL_VOWELED_WITH_AN}"}}'
+        self.assertEqual(check_fixture_text("hadith.json", payload), [])
+
+
+class ToyFixturesFlagged(unittest.TestCase):
+    def test_unvoweled_toy_flags_both_reasons(self) -> None:
+        violations = check_fixture_text("toy.json", UNVOWELED_TOY)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("no vocalization diacritics", violations[0])
+        self.assertIn("missing transmission particle", violations[0])
+
+    def test_voweled_missing_an_flags_only_particle(self) -> None:
+        # The da#146/da#155 shape: voweled (passes a) but no عن (fails b).
+        violations = check_fixture_text("bukhari_h1.json", VOWELED_MISSING_AN)
+        self.assertEqual(len(violations), 1)
+        self.assertNotIn("no vocalization diacritics", violations[0])
+        self.assertIn("missing transmission particle", violations[0])
+
+    def test_unvoweled_with_an_flags_only_vocalization(self) -> None:
+        violations = check_fixture_text("toy2.json", UNVOWELED_WITH_AN)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("no vocalization diacritics", violations[0])
+        self.assertNotIn("missing transmission particle", violations[0])
+
+    def test_path_reported_in_violation(self) -> None:
+        violations = check_fixture_text("fixtures/toy.json", UNVOWELED_TOY)
+        self.assertTrue(violations[0].startswith("fixtures/toy.json:"))
+
+
+class CliBehavior(unittest.TestCase):
+    def _write(self, text: str) -> str:
+        fh = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
+        fh.write(text)
+        fh.close()
+        return fh.name
+
+    def test_clean_fixture_exits_zero(self) -> None:
+        name = self._write(REAL_VOWELED_WITH_AN)
+        try:
+            self.assertEqual(main(["check_fixture_realism.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_toy_fixture_exits_one(self) -> None:
+        name = self._write(UNVOWELED_TOY)
+        try:
+            self.assertEqual(main(["check_fixture_realism.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_non_arabic_fixture_exits_zero(self) -> None:
+        name = self._write('{"narrator": "Anas"}')
+        try:
+            self.assertEqual(main(["check_fixture_realism.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_fixture_realism.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_fixture_realism.py", "/no/such/fixture.json"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -114,6 +114,94 @@ repos:
         self.assertNotIn("cspell", harmful)
 
 
+class BasePinAndFixtureRealismKindClassification(unittest.TestCase):
+    """#744: the two charter-prose→code gates rolled into this repo must each
+    classify on BOTH sides — a CI `run:` invoking the `.claude/lib/check_*.py`
+    script and a pre-commit hook running the same script — so a CI base-pin /
+    fixture-realism gate with no local mirror is harmful drift, not silence."""
+
+    def test_dockerfile_base_pin_ci_run_classified(self) -> None:
+        wf = """
+jobs:
+  base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile frontend/Dockerfile
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_ci(wf))
+
+    def test_fixture_realism_ci_run_classified(self) -> None:
+        wf = """
+jobs:
+  realism:
+    steps:
+      - run: python3 .claude/lib/check_fixture_realism.py data/curated/ner_name_audit.csv
+"""
+        self.assertIn("fixture-realism", kinds_from_ci(wf))
+
+    def test_precommit_hooks_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile frontend/Dockerfile
+      - id: fixture-realism
+        entry: bash -c 'python3 .claude/lib/check_fixture_realism.py data/curated/*'
+"""
+        kinds = kinds_from_precommit(cfg)
+        self.assertIn("dockerfile-base-pin", kinds)
+        self.assertIn("fixture-realism", kinds)
+
+    def test_ci_base_pin_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("dockerfile-base-pin", harmful)
+
+
+class RealRepoHasNoBasePinOrRealismDrift(unittest.TestCase):
+    """End-to-end against this repo: ci.yml enforces the base-pin + fixture-
+    realism gates and .pre-commit-config.yaml mirrors both, so the sync gate must
+    see no drift for either kind (the gate as the docs.yml job runs it)."""
+
+    def _ci_kinds(self) -> set[str]:
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        ci_kinds: set[str] = set()
+        for p in sorted(wf_dir.glob("*.y*ml")):
+            if p.is_file():
+                ci_kinds |= kinds_from_ci(p.read_text(encoding="utf-8"))
+        return ci_kinds
+
+    def test_repo_ci_enforces_both(self) -> None:
+        ci_kinds = self._ci_kinds()
+        self.assertIn("dockerfile-base-pin", ci_kinds)
+        self.assertIn("fixture-realism", ci_kinds)
+
+    def test_repo_precommit_mirrors_both(self) -> None:
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        kinds = kinds_from_precommit(precommit.read_text(encoding="utf-8"))
+        self.assertIn("dockerfile-base-pin", kinds)
+        self.assertIn("fixture-realism", kinds)
+
+    def test_repo_has_no_drift_for_either(self) -> None:
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        ci_paths = sorted(wf_dir.glob("*.y*ml"))
+        harmful, _ = check_repo(precommit, ci_paths)
+        self.assertNotIn("dockerfile-base-pin", harmful)
+        self.assertNotIn("fixture-realism", harmful)
+
+
 class RealRepoHasNoCspellDrift(unittest.TestCase):
     """End-to-end against this repo's own files: docs.yml enforces cspell and
     .pre-commit-config.yaml now mirrors it, so the gate must see no cspell drift.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,31 @@ jobs:
       - run: uvx ruff@${{ env.RUFF_VERSION }} check scripts/
       - run: uvx ruff@${{ env.RUFF_VERSION }} format --check scripts/
 
+  # Charter-prose→code gates rolled in by #744 (built in noorinalabs-main#735).
+  # Both invoke a stdlib-only `.claude/lib/check_*.py` — no uv/node needed — and
+  # are mirrored by the `dockerfile-base-pin` / `fixture-realism` pre-commit
+  # hooks. The docs.yml sync-drift gate classifies both kinds, so dropping either
+  # the CI step or the local hook is harmful drift. Kept as single-line `run:`
+  # invocations so the line-scanner sync classifier registers the script name.
+  base-pin-and-fixture-realism:
+    name: Base-image pin + fixture realism
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Every Dockerfile FROM must be digest-pinned + carry the matching distro
+      # upgrade (charter § Base Image Pinning).
+      - name: Dockerfile base-image pin + upgrade
+        run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile frontend/Dockerfile
+      # Arabic NER / graph-load fixtures under data/curated/ must be production-
+      # realistic (voweled + transmission particle). The check skips non-Arabic
+      # files; `find` keeps new curated fixtures covered. Frontend e2e display
+      # mocks are out of scope (UI response stubs, not parser inputs).
+      - name: Fixture realism (Arabic NER/graph-load fixtures)
+        run: find data/curated -type f \( -name '*.csv' -o -name '*.yaml' -o -name '*.yml' -o -name '*.json' -o -name '*.jsonl' -o -name '*.txt' \) -print0 | xargs -0 -r python3 .claude/lib/check_fixture_realism.py
+
   lockfile-validation:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,6 +165,39 @@ repos:
         files: ^(src/utils/grades\.py|scripts/emit_grade_vocab\.py|frontend/src/lib/grade-vocab\.generated\.json)$
         stages: [pre-commit]
 
+      # Base-image pinning gate (charter tech-decisions.md § Base Image Pinning,
+      # noorinalabs-main#735 / #744). Every Dockerfile FROM must be digest-pinned
+      # (image:tag@sha256:<digest>) AND carry the matching distro upgrade (apk /
+      # apt). Mirrors the `dockerfile-base-pin` job in ci.yml; the sync-drift gate
+      # classifies this kind so the local mirror is mandatory (#684 parity).
+      # Scoped to the two Dockerfiles so it only runs when one changes.
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile frontend/Dockerfile
+        language: system
+        pass_filenames: false
+        files: ^(Dockerfile|frontend/Dockerfile)$
+        stages: [pre-commit]
+
+      # Fixture-realism gate (charter pull-requests.md § Production-Realistic
+      # Input, noorinalabs-main#735 / #744). Arabic text-processing / NER / graph-
+      # load fixtures must be voweled and carry the transmission particle (the
+      # static toy-fixture lens). Scoped to the curated upstream-sample data under
+      # data/curated/ (the repo's NER/graph-load fixture location); the check
+      # skips any non-Arabic file it is handed. The frontend e2e display mocks
+      # under frontend/tests/e2e/fixtures/ are intentionally OUT of scope — they
+      # are UI API-response stubs, not parser/NER/graph-load inputs, so the
+      # particle/segmentation floor does not apply to them. Mirrors the
+      # `fixture-realism` job in ci.yml. `find` keeps new curated fixtures covered
+      # without editing this entry.
+      - id: fixture-realism
+        name: fixture-realism
+        entry: bash -c 'find data/curated -type f \( -name "*.csv" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.jsonl" -o -name "*.txt" \) -print0 | xargs -0 -r python3 .claude/lib/check_fixture_realism.py'
+        language: system
+        pass_filenames: false
+        files: ^data/curated/
+        stages: [pre-commit]
+
   # --- Lockfile validation ---
   - repo: local
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 # syntax=docker/dockerfile:1
 # Multi-arch build (amd64 + arm64) — see docs/devops/ghcr-publish-design.md
-FROM python:3.14-slim AS base
+#
+# Base pinned to python:3.14-slim by digest for supply-chain reproducibility
+# (charter tech-decisions.md § Base Image Pinning, noorinalabs-main#735). The
+# digest freezes the starting layer; the `apt-get -y upgrade` in the RUN below
+# then pulls the latest Debian patches at build time so we don't ship known-fixed
+# OS CVEs within the slim base (same two failure modes — floating-tag drift and
+# within-tag package drift — the nginx pin in frontend/Dockerfile closes). The
+# digest is the multi-arch OCI index (amd64 + arm64), so it resolves on both
+# build platforms. Re-pin to a newer digest on each python minor bump.
+FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061 AS base
 
-# Single RUN layer for OS deps + cleanup to minimize image size
+# Single RUN layer for OS deps + cleanup to minimize image size. `apt-get -y
+# upgrade` keeps the pinned base's packages current within the slim lifecycle
+# (the within-tag-drift half of § Base Image Pinning).
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,13 @@
-FROM node:24-alpine AS build
+# Build stage pinned to node:24-alpine by digest for supply-chain reproducibility
+# (charter tech-decisions.md § Base Image Pinning, isnad-graph#1142 / main#735).
+# The digest is the multi-arch OCI index (amd64 + arm64). `apk upgrade --no-cache`
+# pulls the latest alpine patches so the build toolchain isn't itself running
+# known-fixed CVEs; the compiled dist/ is copied into the (separately pinned +
+# upgraded) nginx runtime stage below. Re-pin to a newer digest on each node
+# minor bump.
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS build
 WORKDIR /app
+RUN apk upgrade --no-cache
 # package-lock.json resolves @noorinalabs/design-system from GitHub Packages
 # (npm.pkg.github.com) — see #940. .npmrc points the @noorinalabs scope at that
 # registry and reads the token from ${NODE_AUTH_TOKEN}; the token is supplied to


### PR DESCRIPTION
## Summary

Rolls the two charter-prose→code gates built in noorinalabs-main#735 into isnad-graph's pre-commit + CI, and **fix-forwards the real violations** the first run surfaced.

isnad-graph both **builds images** and ships **Arabic NER / graph-load fixture data**, so both checks apply here.

### `check_dockerfile_base_pin.py` — real violations fixed forward
Per charter `tech-decisions.md` § Base Image Pinning, every `FROM` must be digest-pinned **and** carry the matching distro upgrade.

- **`Dockerfile` (backend):** `python:3.14-slim` was unpinned **and** the base stage had no `apt-get upgrade`. Pinned to the multi-arch (amd64+arm64) OCI-index digest `sha256:44dd0449…` and added `apt-get -y upgrade` to the base `RUN`.
- **`frontend/Dockerfile`:** the `node:24-alpine` build base was unpinned. Pinned to the multi-arch digest `sha256:156b55f9…` and added a real `RUN apk upgrade --no-cache` to the builder (it previously passed the upgrade check only via an incidental comment match — fragile). The runtime `nginx:stable-alpine3.23` stage was already pinned + upgraded.

### `check_fixture_realism.py` — scoped to the genuine NER/graph-load fixtures
Per charter `pull-requests.md` § Text-Processing / NER / Graph Fixtures. Wired against `data/curated/` — this repo's production-realistic upstream-sample location (`ner_name_audit.csv`, `historical_events.yaml`). These **already pass** (voweled + the transmission particle present in real sanadset/thaqalayn rows), so no fixture edits were needed; the gate now guards against a future toy being added there.

**Deliberately out of scope:** the `frontend/tests/e2e/fixtures/*.json` display mocks. They are UI API-response stubs (`items`/`total`/`page` shapes) consumed by Playwright, **not** parser/NER/graph-load inputs — a matn body or a narrator name legitimately carries no transmission particle, so the segmentation floor does not apply. Forcing it there would be false rigor. Rationale is documented inline in `.pre-commit-config.yaml` and `ci.yml`.

### Wiring
- `.pre-commit-config.yaml`: `dockerfile-base-pin` + `fixture-realism` local hooks (scoped `files:`).
- `.github/workflows/ci.yml`: one `base-pin-and-fixture-realism` job, single-line `run:` steps so the line-scanner sync classifier registers the script names.
- `.claude/lib/pre_commit_ci_sync.py`: classifies the two new kinds (`dockerfile-base-pin`, `fixture-realism`) so the docs.yml sync-drift gate **demands** the local⇄CI mirror (#684 parity), with tests.

## Test plan (pre-merge)
- `check_dockerfile_base_pin.py Dockerfile frontend/Dockerfile` → OK.
- `find data/curated … | xargs … check_fixture_realism.py` → OK.
- `.claude/lib/tests/` → 54 passed (47 + 7 new sync-classification cases).
- `pre_commit_ci_sync.py .` → no harmful drift; both new kinds mirrored.
- Full pre-commit + pre-push (incl. vite build) green; ruff 0.15.11 + actionlint clean.

TechDebt: this repo's `pre_commit_ci_sync.py` is still the older stdlib-only line-scanner; the parent has since moved to a structural YAML parser (#748) with extra kinds (memory-budget, doc-freshness, office-drift, mermaid). Wholesale convergence is out of scope here (the `lib-tests` CI job installs only `pytest`, no PyYAML) and belongs to the #684 org-wide parity rollout.

Reviewers: Arjun Raghavan, Anya Kowalczyk

Part of #744
