### PR TITLE
fix(frontend): re-pin nginx runtime digest — libexpat CVE-2026-45186 (#1131)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,7 +30,7 @@ RUN npm run build
 # the starting layer; the upgrade step keeps OS packages current within the
 # alpine 3.23 patch lifecycle. Re-pin to a newer digest on each minor nginx
 # bump (or alpine 3.24+ when nginx publishes it).
-FROM nginx:stable-alpine3.23@sha256:5f979dcfed4ce6461873f087e8c980d6e29b084b9e8776d9704a7e989b5f4898
+FROM nginx:stable-alpine3.23@sha256:0d3b80406a13a767339fbe2f41406d6c7da727ab89cf8fae399e81f780f814d1
 # gettext provides `envsubst`, used by entrypoint.sh to render runtime-config.js
 # from its template at container start (isnad-graph#932).
 RUN apk upgrade --no-cache && apk add --no-cache gettext


### PR DESCRIPTION
## What

Re-pins the **frontend runtime base image** digest to clear `libexpat` **CVE-2026-45186** (HIGH, DoS via crafted XML), which turned the **Publish to GHCR** workflow red on `main` after #1130 merged.

```
- FROM nginx:stable-alpine3.23@sha256:5f979dcf…  # alpine 3.23.4 → libexpat 2.7.5-r0
+ FROM nginx:stable-alpine3.23@sha256:0d3b8040…  # alpine 3.23.5 → libexpat 2.8.1-r0 (fixed)
```

## Why a re-pin (not just apk upgrade)

The runtime stage already runs `apk upgrade --no-cache`, but the pinned 3.23.4 snapshot's apk index doesn't carry `2.8.1-r0`, so the upgrade is a no-op for this package. The current `stable-alpine3.23` digest (alpine 3.23.5) ships the fix. This is the Dockerfile's own documented maintenance path ("re-pin to a newer digest").

## Not a #1130 regression

#1130 was ontology-generator CI wiring — no Dockerfile/frontend-dep change. This is the recurring **base-image OS-package CVE** class (advisory + alpine point-release land after our last digest pin). The Trivy gate is **push-to-main-only**, so #1130's PR was green while the post-merge publish went red.

## Verification (deterministic)

Built the faithful runtime stage (new digest + `apk upgrade --no-cache` + `apk add gettext`) and ran Trivy with CI's exact params:

```
$ trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 fe-runtime-fixtest
fe-runtime-fixtest (alpine 3.23.5)  alpine  Vulnerabilities: 0
exit code: 0
```

Closes #1131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
