### PR TITLE
fix(frontend): email/password login posts to /auth/login (was 404 /auth/login/email) (#1141)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -150,7 +150,7 @@ export default function LoginPage() {
 
     setFormLoading(true)
     try {
-      const res = await fetch(`${AUTH_BASE}/login/email`, {
+      const res = await fetch(`${AUTH_BASE}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: loginEmail, password: loginPassword }),

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -116,7 +116,7 @@ describe('LoginPage — non-JSON auth response guard (#977)', () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/auth/providers')) return Promise.resolve(providersResponse())
-      if (url.endsWith('/auth/login/email')) return Promise.resolve(htmlResponse())
+      if (url.endsWith('/auth/login')) return Promise.resolve(htmlResponse())
       return Promise.reject(new Error(`unexpected fetch: ${url}`))
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -145,7 +145,7 @@ describe('LoginPage — non-JSON auth response guard (#977)', () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/auth/providers')) return Promise.resolve(providersResponse())
-      if (url.endsWith('/auth/login/email'))
+      if (url.endsWith('/auth/login'))
         return Promise.resolve(jsonResponse({ access_token: 'real-token' }))
       return Promise.reject(new Error(`unexpected fetch: ${url}`))
     })


### PR DESCRIPTION
## What
One-line fix: `LoginPage.tsx` posted the email/password sign-in to `${AUTH_BASE}/login/email`, which 404s. The user-service auth API serves **`/auth/login`**. Changed the path to match (and the sibling `/register` call, which was already correct).

## Why it matters
**Email/password login was broken in the UI on stg and prod** (deployed `e4c0c54`) — every sign-in showed "Not Found". OAuth (Google/GitHub) was unaffected (different paths), which is why it went unnoticed.

Evidence: `POST https://users.stg.noorinalabs.com/auth/login/email` → 404 (captured from the live stg UI); live OpenAPI lists only `/auth/login`.

## Tests
`LoginPage.test.tsx` had two fetch mocks keyed on `/auth/login/email` — they **codified the bug** (the test mocked the same wrong path the code called, so it passed). Updated both to `/auth/login`. 5/5 pass. eslint + tsc + vite build all green.

## How found
Surfaced while driving the stg UI with a newly-seeded QA test user — the API login at `/auth/login` works, but the UI's path did not.

Closes #1141. Part of parent main#723 QA-enablement follow-on.

## Reviewer notes
TechDebt: none

---
