### PR TITLE
schema-drift: allow-list grade_normalized (Hadith + Grading) — sibling of ip#119

### DIFF
--- a/scripts/ingest-extras.yaml
+++ b/scripts/ingest-extras.yaml
@@ -41,6 +41,10 @@ nodes:
       category: permanent
       issue: noorinalabs/noorinalabs-isnad-graph:docs/adr/005-cross-repo-ingest-schema-contract.md
       note: normalize-v1 emits a coarse grade alongside the model's grade_composite; intentionally ingest-only — the model exposes only the composite. Kept per ingest-platform#35 ruling.
+    - field: grade_normalized
+      category: permanent
+      issue: noorinalabs/noorinalabs-isnad-graph:docs/adr/005-cross-repo-ingest-schema-contract.md
+      note: normalized form of the ingest-only grade (canonical normalize_grade(); absent→"unknown"); intentionally ingest-only — the model exposes only grade_composite. Streaming ingest emits it on every Hadith. Mirrors ingest-platform#119.
     - field: sect
       category: permanent
       issue: noorinalabs/noorinalabs-isnad-graph:docs/adr/005-cross-repo-ingest-schema-contract.md
@@ -54,6 +58,11 @@ nodes:
       category: permanent
       issue: noorinalabs/noorinalabs-isnad-graph:docs/adr/005-cross-repo-ingest-schema-contract.md
       note: per-edge attribute on TRANSMITTED_TO, denormalized onto the Narrator node by ingest; the model exposes it only on the edge. Kept per ingest-platform#35 ruling.
+  Grading:
+    - field: grade_normalized
+      category: permanent
+      issue: noorinalabs/noorinalabs-isnad-graph:docs/adr/005-cross-repo-ingest-schema-contract.md
+      note: normalized form (canonical normalize_grade()) of the Grading node's grade; the model exposes only the raw HadithGrade `grade` enum, not its normalized string, so this is intentionally ingest-only. Streaming ingest emits it on the Grading node when a grade is present. Mirrors ingest-platform#119.
 
 # All Hadith per-appearance number fields and the four promoted fields were
 # reconciled out on 2026-05-31; the remaining entries are the four permanent


### PR DESCRIPTION
## Summary

Allow-list `grade_normalized` in `scripts/ingest-extras.yaml` on both **Hadith** and a new **Grading** section, so the `schema-drift` gate accepts it as a rationalized ingest-only property once ip#119 lands.

ip#119 (ingest-platform PR #121) adds `grade_normalized` to the streaming ingest path — emitted on Hadith (always; absent→`"unknown"`) and Grading (when a grade is present), mirroring the canonical `normalize_grade()`. It is ingest-only, exactly like the existing `grade` field: the isnad-graph Hadith model exposes only `grade_composite`, and the Grading model carries only the raw `HadithGrade` enum, not its normalized string form.

## Change

- `nodes.Hadith`: new `grade_normalized` entry — `category: permanent`, ADR-005 anchor, mirroring the existing `grade` precedent exactly.
- New `nodes.Grading` section with the same `grade_normalized` entry (streaming emits it on the Grading node too).

## Verification

`uv run python scripts/emit_ingest_schema.py check` against the ingest-platform sibling schema:

- Clean against the current wave-24 sibling schema (ip#119 not yet merged — the designed convergence window).
- Against the ip#119 head schema (which emits `grade_normalized` on Hadith + Grading): **fails with exactly 2 phantom-field errors WITHOUT** these entries, **clean WITH** them.

Green-before-push: full pre-commit + pre-push hook set passed (pip-audit, gitleaks, mypy, pytest, frontend-build, co-authored-by-trailers).

Part of #1168
Sibling of noorinalabs/noorinalabs-isnad-ingest-platform#119

TechDebt: none
