### PR TITLE
ci(embed): add Trivy CVE-scan gate to build-and-push-embed (#1174)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -219,6 +219,21 @@ jobs:
           cache-from: type=gha,scope=embed
           cache-to: type=gha,mode=max,scope=embed
 
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          # Scan by digest — guaranteed to exist immediately after push and
+          # immune to tag-resolution races. metadata-action emits :latest,
+          # :sha-*, and (on main) :stg-* + :stg-latest — never :main.
+          # Digest is the one stable handle across all of them. Mirrors the
+          # api/frontend matrix scan; the embed image now backs the live api
+          # service (deploy#523) so a CRITICAL/HIGH CVE must gate publish.
+          image-ref: ${{ env.REGISTRY }}/noorinalabs/noorinalabs-isnad-graph-embed@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: "1"
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
       - name: Summary
         if: always()
         run: |


### PR DESCRIPTION
## What

Adds a Trivy CVE-scan gate to the `build-and-push-embed` job in `.github/workflows/ghcr-publish.yml`, mirroring the scan already present in the `build-and-push` (api/frontend) matrix job.

## Why

`build-and-push-embed` published `ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed` with **no Trivy scan**, unlike the api/frontend matrix job which scans by digest and hard-fails on CRITICAL/HIGH before the images are usable. The `-embed` image (torch + sentence-transformers + baked MiniLM weights) now backs the **live, internet-facing `api` service** on stg and (imminently) prod via noorinalabs-deploy PR #525 (deploy#523). Without this gate, a new CRITICAL/HIGH CVE in the torch/transformers dep set could reach production traffic ungated.

## Change

Inserted a single step between "Build and push" and "Summary" in `build-and-push-embed`:

- Scans by pushed digest (`steps.build.outputs.digest`) — stable handle immune to tag races.
- `severity: CRITICAL,HIGH`, `exit-code: "1"` (hard-fail), `ignore-unfixed: true`.
- Same pinned action SHA (`aquasecurity/trivy-action@57a97c…` v0.35.0) as the matrix job — parity is the point, no repin.

`actionlint` clean; local pre-commit + pre-push hooks green.

## Reviewers

- Idris Yusuf (security)
- Jelani Mwangi (DevOps architect)

Closes #1174
